### PR TITLE
FoV/GoV exp once daily and disable prowesses

### DIFF
--- a/modules/zenith-public/git-patches/101-RegimeBlockProwess.patch
+++ b/modules/zenith-public/git-patches/101-RegimeBlockProwess.patch
@@ -1,0 +1,15 @@
+disables the section of xi.regime.checkRegime that adds prowess buffs
+---
+diff --git a/scripts/globals/regimes.lua b/scripts/globals/regimes.lua
+index 5a4fee556e..4499129545 100644
+--- a/scripts/globals/regimes.lua
++++ b/scripts/globals/regimes.lua
+@@ -1450,7 +1450,7 @@ xi.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
+     end
+ 
+     -- prowess buffs from completing Grounds regimes
+-    if regimeType == xi.regime.type.GROUNDS then
++    if regimeType == xi.regime.type.GROUNDS and false then
+         addGovProwessBonusEffect(player)
+ 
+         -- repeat clears bonus

--- a/modules/zenith-public/lua/2-base/regimes.lua
+++ b/modules/zenith-public/lua/2-base/regimes.lua
@@ -1,0 +1,24 @@
+require('modules/module_utils')
+
+local m = Module:new('regimes')
+
+m:addOverride('xi.regime.checkRegime', function(player, mob, regimeId, index, regimeType)
+    local vanadielEpoch = VanadielUniqueDay()
+    local localVarName = 'regimeReminder'
+    if player:getCharVar('[regime]lastReward') < vanadielEpoch then
+        player:setLocalVar(localVarName, 0)
+        player:setLocalVar('[regime]repeat', 0)
+        super(player, mob, regimeId, index, regimeType)
+    else
+        -- cannot receive credit for regime today, maybe give a system message once per zone?
+        if
+            player:getLocalVar(localVarName) == 0 and
+            player:getCharVar('[regime]id') == regimeId
+        then
+            player:sys('You must wait until the next game day to complete another Page of Valor')
+            player:setLocalVar(localVarName, 1)
+        end
+    end
+end)
+
+return m

--- a/modules/zenith-public/lua/2-base/regimes.lua
+++ b/modules/zenith-public/lua/2-base/regimes.lua
@@ -7,7 +7,6 @@ m:addOverride('xi.regime.checkRegime', function(player, mob, regimeId, index, re
     local localVarName = 'regimeReminder'
     if player:getCharVar('[regime]lastReward') < vanadielEpoch then
         player:setLocalVar(localVarName, 0)
-        player:setLocalVar('[regime]repeat', 0)
         super(player, mob, regimeId, index, regimeType)
     else
         -- cannot receive credit for regime today, maybe give a system message once per zone?


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

- Removes the block that gives the player prowesses
- Removes the block that repeats the regime
- Adds exp to the daily reward conditioned on REGIME_WAIT

Closes: ZEN-80

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

- Completing more than one page in a game day gives no rewards after the first
- The repeat option will do nothing