### PR TITLE
Small fix for checking changed file paths are only in module

### DIFF
--- a/.github/workflows/block_restricted_edits.yml
+++ b/.github/workflows/block_restricted_edits.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Check for restricted path changes
         run: |
-          if echo "$CHANGED_FILES" | sed 's/\([^,]*\)/\n\1/g' | grep -qv "^modules/zenith-public"; then
+          if echo "$CHANGED_FILES" | sed 's/,/\n/g' | grep -qv "^modules/zenith-public"; then
             echo "🚫 Changes to restricted paths detected! Please do not modify files outside of the public modules directory."
             exit 1
           else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Found that the `sed` was bad for splitting changed files by comma to check for basepath. This should work properly

![image](https://github.com/user-attachments/assets/23d34ad6-7918-4fe5-876c-066ab839ee8a)


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
