### PR TITLE
Utsusemi changes for ninja sub

### DIFF
--- a/modules/zenith-public/lua/2-base/utsusemi_ninja_sub.lua
+++ b/modules/zenith-public/lua/2-base/utsusemi_ninja_sub.lua
@@ -1,0 +1,41 @@
+require('modules/module_utils')
+
+local m = Module:new('utsusemi_ninja_sub')
+
+m:addOverride('xi.actions.spells.ninjutsu.utsusemi_ichi.onMagicCastingCheck', function(caster, target, spell)
+    -- +1 s cast time when NIN is subjob
+    if caster:getMainJob() ~= xi.job.NIN then
+        spell:setCastTime(spell:getCastTime() + 1000)
+    end
+
+    return super(caster, target, spell)
+end)
+
+m:addOverride('xi.actions.spells.ninjutsu.utsusemi_ni.onMagicCastingCheck', function(caster, target, spell)
+    -- +1 s cast time when NIN is subjob
+    if caster:getMainJob() ~= xi.job.NIN then
+        spell:setCastTime(spell:getCastTime() + 1000)
+    end
+
+    return super(caster, target, spell)
+end)
+
+m:addOverride('xi.spells.enhancing.calculateNinjutsuPower', function(caster, target, spell, spellId, tier, spellEffect)
+    local power, subPower = super(caster, target, spell, spellId, tier, spellEffect)
+    if spellEffect == xi.effect.COPY_IMAGE then
+        -- Utsusemi Ichi gives one less shadow when Ninja is subjob
+        if
+            spellId == xi.magic.spell.UTSUSEMI_ICHI and
+            caster:getMainJob() ~= xi.job.NIN
+        then
+            power = power - 1
+            if power == 2 then
+                subPower = xi.effect.COPY_IMAGE_2
+            end
+        end
+    end
+
+    return power, subPower
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Increases Utsusemi casting time by 1 second and reduces number of shadows given by Ichi by one when ninja is a subjob

Closes: ZEN-95

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

- !changejob 75 nin
- Cast both Ichi/Ni
- !changejob 75 thf
- !changesjob 37 nin
- Cast both Ichi/Ni
