### PR TITLE
Garrison grants op warp on win

### DIFF
--- a/modules/zenith-public/lua/1-enum/garrison_improvements.lua
+++ b/modules/zenith-public/lua/1-enum/garrison_improvements.lua
@@ -5,11 +5,10 @@ local m = Module:new('garrison_improvements')
 -- Override the gil payout function to also grant outpost warps
 m:addOverride('xi.garrison.handleGilPayout', function(levelCap, players)
     super(levelCap, players)
-    
     -- Then add our custom outpost warp logic
     if #players > 0 then
+        local zone = players[1]:getZone()
         local region = zone:getRegionID()
-        
         -- User-friendly region names mapping (matching outpost teleporter display)
         local regionNames = {
             [xi.region.RONFAURE]         = 'The Ronfaure Region',
@@ -32,14 +31,12 @@ m:addOverride('xi.garrison.handleGilPayout', function(levelCap, players)
             [xi.region.MOVALPOLOS]       = 'The Movalpolos Region',
             [xi.region.TAVNAZIANARCH]    = 'The Tavnazian Archipelago Region',
         }
-        
+
         local regionName = regionNames[region] or 'Unknown Region'
-        
         -- Grant outpost warp to each player
         for _, player in ipairs(players) do
             if player ~= nil then
                 local nation = player:getNation()
-                
                 -- Check if player already has the outpost teleport for this region
                 if not player:hasTeleport(nation, region + 5) then
                     player:addTeleport(nation, region + 5)

--- a/modules/zenith-public/lua/1-enum/garrison_improvements.lua
+++ b/modules/zenith-public/lua/1-enum/garrison_improvements.lua
@@ -12,28 +12,28 @@ m:addOverride('xi.garrison.handleGilPayout', function(levelCap, players)
         
         -- User-friendly region names mapping (matching outpost teleporter display)
         local regionNames = {
-            [xi.region.RONFAURE]         = "The Ronfaure Region",
-            [xi.region.ZULKHEIM]         = "The Zulkheim Region", 
-            [xi.region.NORVALLEN]        = "The Norvallen Region",
-            [xi.region.GUSTABERG]        = "The Gustaberg Region",
-            [xi.region.DERFLAND]         = "The Derfland Region",
-            [xi.region.SARUTABARUTA]     = "The Sarutabaruta Region",
-            [xi.region.KOLSHUSHU]        = "The Kolshushu Region",
-            [xi.region.ARAGONEU]         = "The Aragoneu Region",
-            [xi.region.FAUREGANDI]       = "The Fauregandi Region",
-            [xi.region.VALDEAUNIA]       = "The Valdeaunia Region",
-            [xi.region.QUFIMISLAND]      = "The Qufim Island Region",
-            [xi.region.LITELOR]          = "The Li'Telor Region",
-            [xi.region.KUZOTZ]           = "The Kuzotz Region",
-            [xi.region.VOLLBOW]          = "The Vollbow Region",
-            [xi.region.ELSHIMO_LOWLANDS] = "The Elshimo Lowlands Region",
-            [xi.region.ELSHIMO_UPLANDS]  = "The Elshimo Uplands Region",
-            [xi.region.TULIA]            = "The Tu'Lia Region",
-            [xi.region.MOVALPOLOS]       = "The Movalpolos Region",
-            [xi.region.TAVNAZIANARCH]    = "The Tavnazian Archipelago Region",
+            [xi.region.RONFAURE]         = 'The Ronfaure Region',
+            [xi.region.ZULKHEIM]         = 'The Zulkheim Region', 
+            [xi.region.NORVALLEN]        = 'The Norvallen Region',
+            [xi.region.GUSTABERG]        = 'The Gustaberg Region',
+            [xi.region.DERFLAND]         = 'The Derfland Region',
+            [xi.region.SARUTABARUTA]     = 'The Sarutabaruta Region',
+            [xi.region.KOLSHUSHU]        = 'The Kolshushu Region',
+            [xi.region.ARAGONEU]         = 'The Aragoneu Region',
+            [xi.region.FAUREGANDI]       = 'The Fauregandi Region',
+            [xi.region.VALDEAUNIA]       = 'The Valdeaunia Region',
+            [xi.region.QUFIMISLAND]      = 'The Qufim Island Region',
+            [xi.region.LITELOR]          = 'The Li\'Telor Region',
+            [xi.region.KUZOTZ]           = 'The Kuzotz Region',
+            [xi.region.VOLLBOW]          = 'The Vollbow Region',
+            [xi.region.ELSHIMO_LOWLANDS] = 'The Elshimo Lowlands Region',
+            [xi.region.ELSHIMO_UPLANDS]  = 'The Elshimo Uplands Region',
+            [xi.region.TULIA]            = 'The Tu\'Lia Region',
+            [xi.region.MOVALPOLOS]       = 'The Movalpolos Region',
+            [xi.region.TAVNAZIANARCH]    = 'The Tavnazian Archipelago Region',
         }
         
-        local regionName = regionNames[region] or "Unknown Region"
+        local regionName = regionNames[region] or 'Unknown Region'
         
         -- Grant outpost warp to each player
         for _, player in ipairs(players) do
@@ -43,7 +43,7 @@ m:addOverride('xi.garrison.handleGilPayout', function(levelCap, players)
                 -- Check if player already has the outpost teleport for this region
                 if not player:hasTeleport(nation, region + 5) then
                     player:addTeleport(nation, region + 5)
-                    player:printToPlayer(string.format("You have unlocked the outpost warp for %s!", regionName), xi.msg.channel.SYSTEM_3)
+                    player:printToPlayer(string.format('You have unlocked the outpost warp for %s!', regionName), xi.msg.channel.SYSTEM_3)
                 end
             end
         end

--- a/modules/zenith-public/lua/1-enum/garrison_improvements.lua
+++ b/modules/zenith-public/lua/1-enum/garrison_improvements.lua
@@ -12,7 +12,7 @@ m:addOverride('xi.garrison.handleGilPayout', function(levelCap, players)
         -- User-friendly region names mapping (matching outpost teleporter display)
         local regionNames = {
             [xi.region.RONFAURE]         = 'The Ronfaure Region',
-            [xi.region.ZULKHEIM]         = 'The Zulkheim Region', 
+            [xi.region.ZULKHEIM]         = 'The Zulkheim Region',
             [xi.region.NORVALLEN]        = 'The Norvallen Region',
             [xi.region.GUSTABERG]        = 'The Gustaberg Region',
             [xi.region.DERFLAND]         = 'The Derfland Region',

--- a/modules/zenith-public/lua/1-enum/garrison_improvements.lua
+++ b/modules/zenith-public/lua/1-enum/garrison_improvements.lua
@@ -32,15 +32,16 @@ m:addOverride('xi.garrison.handleGilPayout', function(levelCap, players)
             [xi.region.TAVNAZIANARCH]    = 'The Tavnazian Archipelago Region',
         }
 
-        local regionName = regionNames[region] or 'Unknown Region'
+        local regionName = regionNames[region] or 'This zone\'s region'
+        local teleportBit = region + 5
         -- Grant outpost warp to each player
         for _, player in ipairs(players) do
             if player ~= nil then
                 local nation = player:getNation()
                 -- Check if player already has the outpost teleport for this region
-                if not player:hasTeleport(nation, region + 5) then
-                    player:addTeleport(nation, region + 5)
-                    player:printToPlayer(string.format('You have unlocked the outpost warp for %s!', regionName), xi.msg.channel.SYSTEM_3)
+                if not player:hasTeleport(nation, teleportBit) then
+                    player:addTeleport(nation, teleportBit)
+                    player:printToPlayer(fmt('You have unlocked the outpost warp for {}!', regionName), xi.msg.channel.SYSTEM_3)
                 end
             end
         end

--- a/modules/zenith-public/lua/1-enum/garrison_improvements.lua
+++ b/modules/zenith-public/lua/1-enum/garrison_improvements.lua
@@ -1,0 +1,53 @@
+-- Garrison improvements: grants outpost warps on victory
+
+local m = Module:new('garrison_improvements')
+
+-- Override the gil payout function to also grant outpost warps
+m:addOverride('xi.garrison.handleGilPayout', function(levelCap, players)
+    super(levelCap, players)
+    
+    -- Then add our custom outpost warp logic
+    if #players > 0 then
+        local region = zone:getRegionID()
+        
+        -- User-friendly region names mapping (matching outpost teleporter display)
+        local regionNames = {
+            [xi.region.RONFAURE]         = "The Ronfaure Region",
+            [xi.region.ZULKHEIM]         = "The Zulkheim Region", 
+            [xi.region.NORVALLEN]        = "The Norvallen Region",
+            [xi.region.GUSTABERG]        = "The Gustaberg Region",
+            [xi.region.DERFLAND]         = "The Derfland Region",
+            [xi.region.SARUTABARUTA]     = "The Sarutabaruta Region",
+            [xi.region.KOLSHUSHU]        = "The Kolshushu Region",
+            [xi.region.ARAGONEU]         = "The Aragoneu Region",
+            [xi.region.FAUREGANDI]       = "The Fauregandi Region",
+            [xi.region.VALDEAUNIA]       = "The Valdeaunia Region",
+            [xi.region.QUFIMISLAND]      = "The Qufim Island Region",
+            [xi.region.LITELOR]          = "The Li'Telor Region",
+            [xi.region.KUZOTZ]           = "The Kuzotz Region",
+            [xi.region.VOLLBOW]          = "The Vollbow Region",
+            [xi.region.ELSHIMO_LOWLANDS] = "The Elshimo Lowlands Region",
+            [xi.region.ELSHIMO_UPLANDS]  = "The Elshimo Uplands Region",
+            [xi.region.TULIA]            = "The Tu'Lia Region",
+            [xi.region.MOVALPOLOS]       = "The Movalpolos Region",
+            [xi.region.TAVNAZIANARCH]    = "The Tavnazian Archipelago Region",
+        }
+        
+        local regionName = regionNames[region] or "Unknown Region"
+        
+        -- Grant outpost warp to each player
+        for _, player in ipairs(players) do
+            if player ~= nil then
+                local nation = player:getNation()
+                
+                -- Check if player already has the outpost teleport for this region
+                if not player:hasTeleport(nation, region + 5) then
+                    player:addTeleport(nation, region + 5)
+                    player:printToPlayer(string.format("You have unlocked the outpost warp for %s!", regionName), xi.msg.channel.SYSTEM_3)
+                end
+            end
+        end
+    end
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds the region outpost warp on Garrison victory

## Steps to test these changes

1. Participate in Garrison and win
2. Verify server message was display and correct
3. Verify the outpost warp NPC now provides the region as an option

## Jira Ticket

https://zenithxi.atlassian.net/browse/ZEN-79
