### PR TITLE
Increase the default fishing pool sizes by 50%

### DIFF
--- a/modules/zenith-public/sql/FishingPoolSizeIncrease.sql
+++ b/modules/zenith-public/sql/FishingPoolSizeIncrease.sql
@@ -1,0 +1,3 @@
+-- Blanket increase of all fishing pool sizes by 50% for ZenithXI server
+UPDATE fishing_group
+SET pool_size = FLOOR(pool_size * 1.5)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This SQL module increases the fishing pool sizes in the fishing_group table by a blanket 50%.

## Steps to test these changes

SELECT * FROM fishing_group LIMIT 1
Note that the first pool_size is 300

Navigate to your server/tools folder
py -3 dbtool.py
Select the (1.) Update DB option
Verify the FishingPoolSizeIncrease.sql is present in the list of imported files
Proceed with the update

SELECT * FROM fishing_group LIMIT 1
Note that the first pool_size is 450

Note that during every DB Update, fishing_group.sql will drop the original table, reimports the default values, and at the end the regular imports will be adjusted by the module again.