### PR TITLE
Add all Geodes/Avatarites to Abyssea content restriction

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -804,7 +804,7 @@ auto CMobEntity::GetEligibleGeodes() -> std::vector<uint16>
         element = battleutils::GetDayElement();
     }
 
-    if (GetMLevel() >= 80 && luautils::IsContentEnabled("ABYSSEA"))
+    if (GetMLevel() >= 80)
     {
         return { geodeMap[element], avatariteMap[element] };
     }
@@ -958,7 +958,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
 
         // Check for geode/avatarites drops
         // Only one type of geode can drop per mob
-        if (xirand::GetRandomNumber(100) < 20 && CanAddSpecial(RECAST_GEODE))
+        if (xirand::GetRandomNumber(100) < 20 && CanAddSpecial(RECAST_GEODE) && luautils::IsContentEnabled("ABYSSEA"))
         {
             if (const auto geodes = GetEligibleGeodes(); !geodes.empty())
             {

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -804,7 +804,7 @@ auto CMobEntity::GetEligibleGeodes() -> std::vector<uint16>
         element = battleutils::GetDayElement();
     }
 
-    if (GetMLevel() >= 80)
+    if (GetMLevel() >= 80 && luautils::IsContentEnabled("ABYSSEA"))
     {
         return { geodeMap[element], avatariteMap[element] };
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds the Geodes and Avatarites (Flame Geode, Snow Geode, Breeze Geode, Soil Geode, Thunder Geode, Aqua Geode, Light Geode, Shadow Geode, Ifritite, Shivite, Garudite, Titanite, Ramuite, Leviatite, Carbite, Fenrite) to the Content Restriction option for Abyssea. 

Elemental Geodes were added in the December 2010 Version Update:
https://www.bg-wiki.com/ffxi/December_2010_Version_Update_Changes#General_Items

Avatarites were added in the December 2011 Version Update:
https://www.bg-wiki.com/ffxi/December_2011_Version_Update_Changes#General_Items

Implements ticket ZEN-97

## Steps to test these changes

In settings > main.lua set the following:
RESTRICT_CONTENT = 1
ENABLE_ABYSSEA   = 0

!godmode
!zone Lufaise Meadows
!pos 450 -8 131
Kill enemies using !hp 1
Geodes and Avatarites should never drop

In settings > main.lua set the following:
RESTRICT_CONTENT = 0
Keep killing enemies until a Geode or an Avatarite drops