### PR TITLE
Updated EXP for Pages of DC and MM

### DIFF
--- a/scripts/items/page_from_miratetes_memoirs.lua
+++ b/scripts/items/page_from_miratetes_memoirs.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- ID: 4247
 -- Item: Page From Miratete's Memo
--- Grants 750 - 1, 500 EXP
+-- Grants 1,250 - 2,000 EXP
 -- Does not grant Limit Points.
 -----------------------------------
 ---@type TItem
@@ -17,7 +17,7 @@ itemObject.onItemCheck = function(target, item, param, caster)
 end
 
 itemObject.onItemUse = function(target)
-    target:addExp(xi.settings.main.EXP_RATE * math.random(750, 1500))
+    target:addExp(xi.settings.main.EXP_RATE * math.random(1250, 2000))
 end
 
 return itemObject

--- a/scripts/items/page_from_the_dragon_chronicles.lua
+++ b/scripts/items/page_from_the_dragon_chronicles.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- ID: 4198
 -- Item: Page from the Dragon Chronicles
--- Grants 500 - 1, 000 EXP
+-- Grants 1,000 - 1,500 EXP
 -- Does not grant Limit Points.
 -----------------------------------
 ---@type TItem
@@ -17,7 +17,7 @@ itemObject.onItemCheck = function(target, item, param, caster)
 end
 
 itemObject.onItemUse = function(target)
-    target:addExp(xi.settings.main.EXP_RATE * math.random(500, 1000))
+    target:addExp(xi.settings.main.EXP_RATE * math.random(1000, 1500))
 end
 
 return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request updates the EXP gained from the two items:

- Page from the Dragon Chronicles (4198) to the range of 1000 to 1500
- Page From Miratete's Memo (4247) to the range of 1250 to 2000

## Steps to test these changes

1. Enter the game with GMLevel 4
2. If your level is less than 20, run the command !setlevel 20 - this will cover the check for both items
3. Run the command !additem 4198
4. Run the command !additem 4247
5. Use both items, and confirm that the exp gained is within the ranges provided above, and for which this pull request has updated
