### PR TITLE
Increase reward from certain EXP scrolls.

### DIFF
--- a/modules/zenith-public/lua/3-complete/items/exp_scroll_adjustements.lua
+++ b/modules/zenith-public/lua/3-complete/items/exp_scroll_adjustements.lua
@@ -1,0 +1,15 @@
+-- Garrison improvements: grants outpost warps on victory
+
+local m = Module:new('exp_scroll_adjustements')
+
+-- Override the experience gained from Page from the Dragon Chronicles to 1000-1500
+m:addOverride('xi.items.page_from_the_dragon_chronicles.onItemUse', function(target)
+    target:addExp(xi.settings.main.EXP_RATE * math.random(1000, 1500))
+end)
+
+-- Override the experience gained from Page from Miratetes Memoirs to 1250-2000
+m:addOverride('xi.items.page_from_miratetes_memoirs.onItemUse', function(target)
+    target:addExp(xi.settings.main.EXP_RATE * math.random(1250, 2000))
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
**[ZEN-104] EXP Scroll Adjustment**
Updated the exp gained from:

1. page_from_the_dragon_chronicles - from it's previous range of (500, 1000) by an increase of 500 to the range of (1000, 1500)
2. page_from_miratetes_memoirs - from it's previous range of (750, 1500) by an increase of 500 to the range of (1250, 2000)

## Steps to test these changes

Assuming you have gmlevel == 4

1. Run the command !additem 4198
2. Run the command !additem 4247
3. Use the items and confirm the exp gained is within the new ranges, do this more than once for page_from_miratetes_memoirs , in case the exp gained is less than 1500
