### PR TITLE
SQL Module to disable WOTG Aptant NMs

### DIFF
--- a/modules/zenith-public/sql/AptantNMsDisable.sql
+++ b/modules/zenith-public/sql/AptantNMsDisable.sql
@@ -1,0 +1,68 @@
+-- ------------------------------
+-- Disable Aptant NMs
+-- Public Module for ZenithXI
+-- ------------------------------
+-- Notorious Monsters that are part of the Ebon / Ebur / Furia synergy equipment sets.
+-- November 2009 Version Update. (Post WotG / A Shantotto Ascension)
+-- ------------------------------
+-- Related MobIDs:
+-- Abatwa 17477675
+-- Aqrabuamelu 17584416
+-- Atkorkamuy 17293485
+-- Becut 17334356
+-- Big Bang 17117349
+-- Came-cruse 17334523
+-- Canal Moocher 17469578
+-- Chary Apkallu 17027228
+-- Chelicerata 16986188
+-- Citadel Pipistrelles 17448990
+-- Croque-mitaine 17145965
+-- Demoiselle Desolee 17170569
+-- Drumskull Zogdregg 17113381
+-- Frost Flambeau 16797738
+-- Harvestman 16990252
+-- Jenglot 17612840
+-- Konjac 17469632
+-- Laelaps 17494135
+-- Martinet 17277011
+-- Muq Shabeel 17174561
+-- Nargun 17277103
+-- Sabotender Corrido 17244350
+-- Sargas 16806117
+-- Skvader 16797770
+-- Tegmine 17240232
+-- Venomfang 17043466
+-- Warabouc 17117295
+-- Zmey Gorynych 17240315
+
+UPDATE `mob_spawn_points`
+SET pos_x = 0, pos_y = 0, pos_z = 0
+WHERE `mobname` in
+(
+'Abatwa',
+'Aqrabuamelu',
+'Atkorkamuy',
+'Big_Bang',
+'Canal_Moocher',
+'Chary_Apkallu',
+'Chelicerata',
+'Citadel_Pipistrelles',
+'Croque-Mitaine',
+'Demoiselle_Desolee',
+'Drumskull_Zogdregg',
+'Frost_Flambeau',
+'Harvestman',
+'Jenglot',
+'Konjac',
+'Laelaps',
+'Martinet',
+'Muq_Shabeel',
+'Nargun',
+'Sabotender_Corrido',
+'Sargas',
+'Skvader',
+'Tegmine',
+'Venomfang',
+'Warabouc',
+'Zmey_Gorynych'
+);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This SQL Module disables the Aptant Notorious Monsters from the November 2009 Version Update. (Post WotG / A Shantotto Ascension) by setting their spawn position to 0,0,0.

Implementes: ZEN-100

## Steps to test these changes

The following NMs should not be available on server start, and !gotoid will not visit these MobIDs.

- Abatwa !gotoid 17477675
- Aqrabuamelu !gotoid 17584416
- Atkorkamuy !gotoid 17293485
- Becut !gotoid 17334356
- Big Bang !gotoid 17117349
- Came-cruse !gotoid 17334523
- Canal Moocher !gotoid 17469578 (lottery NM)
- Chary Apkallu !gotoid 17027228
- Chelicerata !gotoid 16986188
- Citadel Pipistrelles !gotoid 17448990
- Croque-mitaine !gotoid 17145965
- Demoiselle Desolee !gotoid 17170569 (lottery NM)
- Drumskull Zogdregg !gotoid 17113381 (lottery NM)
- Frost Flambeau !gotoid 16797738
- Harvestman !gotoid 16990252
- Jenglot !gotoid 17612840
- Konjac !gotoid 17469632
- Laelaps !gotoid 17494135
- Martinet !gotoid 17277011
- Muq Shabeel !gotoid 17174561
- Nargun !gotoid 17277103
- Sabotender Corrido !gotoid 17244350
- Sargas !gotoid 16806117
- Skvader !gotoid 16797770 (lottery NM)
- Tegmine !gotoid 17240232
- Venomfang !gotoid 17043466
- Warabouc !gotoid 17117295
- Zmey Gorynych !gotoid 17240315
