### PR TITLE
Require Avatar's favor to skillchain with smn BP

### DIFF
--- a/modules/zenith-public/git-patches/102-SummonerSkillchains.patch
+++ b/modules/zenith-public/git-patches/102-SummonerSkillchains.patch
@@ -1,0 +1,26 @@
+Adds logic to the petskill "first" variable within OnPetSkillFinished
+This variable is used to determine if a mob has been interacted with for skillchaining, as even AoE skills can only SC a single mob
+
+This patch abuses that variable and sets it to false if the pet has a player owner and that owner does not have avatar's favor active
+---
+diff --git a/src/map/entities/petentity.cpp b/src/map/entities/petentity.cpp
+index fb85d967f6..f079c266d8 100644
+--- a/src/map/entities/petentity.cpp
++++ b/src/map/entities/petentity.cpp
+@@ -490,7 +490,14 @@ void CPetEntity::OnPetSkillFinished(CPetSkillState& state, action_t& action)
+     uint16 msg            = 0;
+     uint16 defaultMessage = PSkill->getMsg();
+ 
+-    bool first{ true };
++    bool canSkillchain = true;
++    if (this->getPetType() == PET_TYPE::AVATAR && this->PMaster; auto* PChar = dynamic_cast<CCharEntity*>(this->PMaster))
++    {
++        // If pet is an avatar and pet's owner is a PC, lock skillchaing behind avatar's favor
++        canSkillchain = PChar->StatusEffectContainer->HasStatusEffect(EFFECT_AVATARS_FAVOR);
++    }
++    // this bool is only ever used for skillchain. If in the future it gets used for something else this logic will need to be adjusted.
++    bool first{ canSkillchain };
+     for (auto&& PTargetFound : PAI->TargetFind->m_targets)
+     {
+         actionList_t& list = action.getNewActionList();
+ 


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Saw ZEN-108 and couldn't help myself

The patch file is pretty straightforward. Compiled and tested locally

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Build with patch file applied
set a mob to `!immortal`
use `!reset` between BP triggers
do it multiple times with fenrir to see that moonlit doesn't skillchain with crescent
use avatar's favor and see that it does