### PR TITLE
Xolotl pet summoning and aggro logic

### DIFF
--- a/modules/zenith-public/lua/3-complete/xolotl_pet_logic.lua
+++ b/modules/zenith-public/lua/3-complete/xolotl_pet_logic.lua
@@ -1,0 +1,113 @@
+local m = Module:new('xolotl_pet_logic')
+
+local isSummoning = false
+local petResummonTime = 180
+
+local spawnPet = function(mob, pet, spawnPos)
+    if pet == nil or mob == nil then return end
+
+    isSummoning = true
+    -- Fake a Summoning animation
+    mob:entityAnimationPacket(xi.animationString.CAST_SUMMONER_START)
+    mob:timer(5000, function(mob)
+        mob:entityAnimationPacket(xi.animationString.CAST_SUMMONER_STOP)
+        pet:setSpawn(spawnPos.x + 2, spawnPos.y, spawnPos.z, spawnPos.rot)
+        pet:spawn()
+        if mob:isEngaged() then pet:updateEnmity(mob:getTarget()) end
+        pet:follow(mob, xi.followType.ROAM);
+        isSummoning = false
+    end)
+end
+
+local handlePetResummonTimer = function(mob)
+    local xolotlID = mob:getID()
+
+    if GetSystemTime() >=
+        (GetServerVariable('[XOLOTL]HoundTOD') + petResummonTime) then
+        if not GetMobByID(xolotlID + 1):isSpawned() and not isSummoning then
+            spawnPet(mob, GetMobByID(xolotlID + 1), mob:getPos())
+        end
+    end
+
+    if GetSystemTime() >=
+        (GetServerVariable('[XOLOTL]SacrificeTOD') + petResummonTime) then
+        if not GetMobByID(xolotlID + 2):isSpawned() and not isSummoning then
+            spawnPet(mob, GetMobByID(xolotlID + 2), mob:getPos())
+        end
+    end
+end
+
+-- Placeholder for Superlink logic
+local handleGroupAggro = function(xolotlID, target)
+    -- This function needs the Xolotl ID as mobid to loop through the group
+    for i = xolotlID, xolotlID + 2 do
+        local m = GetMobByID(i)
+
+        if m and m:getCurrentAction() == xi.act.ROAMING then
+            m:updateEnmity(target)
+        end
+    end
+end
+
+m:addOverride('xi.zones.Attohwa_Chasm.mobs.Xolotl.onMobFight',
+              function(mob, target)
+    super(mob)
+    handlePetResummonTimer(mob)
+    handleGroupAggro(mob:getID(), target)
+end)
+
+m:addOverride('xi.zones.Attohwa_Chasm.mobs.Xolotl.onMobRoam', function(mob)
+    super(mob)
+    handlePetResummonTimer(mob)
+end)
+
+m:addOverride('xi.zones.Attohwa_Chasm.mobs.Xolotls_Hound_Warrior.onMobDespawn',
+              function(mob)
+    super(mob)
+    SetServerVariable('[XOLOTL]HoundTOD', GetSystemTime())
+end)
+
+m:addOverride('xi.zones.Attohwa_Chasm.mobs.Xolotls_Sacrifice.onMobDespawn',
+              function(mob)
+    super(mob)
+    SetServerVariable('[XOLOTL]SacrificeTOD', GetSystemTime())
+end)
+
+m:addOverride('xi.zones.Attohwa_Chasm.mobs.Xolotls_Hound_Warrior.onMobRoam',
+              function(mob)
+    super(mob)
+    local xolotl = GetMobByID(mob:getID() - 1)
+    mob:follow(xolotl, xi.followType.ROAM)
+
+    if mob and mob:getCurrentAction() == xi.act.ROAMING and
+        not xolotl:isSpawned() then DespawnMob(mob:getID())
+    end
+end)
+
+m:addOverride('xi.zones.Attohwa_Chasm.mobs.Xolotls_Sacrifice.onMobRoam',
+              function(mob)
+    super(mob)
+    local xolotl = GetMobByID(mob:getID() - 2)
+    mob:follow(xolotl, xi.followType.ROAM)
+
+    if mob and mob:getCurrentAction() == xi.act.ROAMING and
+        not xolotl:isSpawned() then DespawnMob(mob:getID())
+    end
+
+end)
+
+m:addOverride('xi.zones.Attohwa_Chasm.mobs.Xolotls_Hound_Warrior.onMobFight',
+              function(mob, target)
+    super(mob)
+    local xolotlID = mob:getID() - 1
+    handleGroupAggro(xolotlID, target)
+end)
+
+m:addOverride('xi.zones.Attohwa_Chasm.mobs.Xolotls_Sacrifice.onMobFight',
+              function(mob, target)
+    super(mob)
+    local xolotlID = mob:getID() - 2
+    handleGroupAggro(xolotlID, target)
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Handles Xolotl's "pet" summon, aggro and despawn logic. 

- Based on https://www.youtube.com/watch?v=O9gFQ4C_4Cw pets are resummoned 120 seconds after death.
- Stores pets TODs in ServerVarChars and tries to resummon them 120s after despawn, faking a Summoning animation
- Sets the pets to follow Xolotl around
- Despawns pets if they are roaming and Xolotl is not up
- If Xolotl or a Pet if aggrod while they are roaming, all three enemies will engage on the same target
- If a pet is resummoned, will engage on the target currently tanking Xolotl

TODO: Investigate why Superlink 32 does not work out of the box.

## Steps to test these changes

!zone <Attohwa Chasm>
!gotoname Xolotl
if not up: !spawnmob 16806215

While roaming, Xolotl should summon his pets, 120s cooldown after a pet dies.
While engaged, Xolotl should summon his pets, 120s cooldown after a pet dies.
While Xolotl is roaming, pets should follow around Xolotl.
Engage on Xolotl, !hp 0 to kill it, the pets should still be engaging on you.
!goto <me> which should deaggro. Pets should despawn if roaming and Xolotl is not up.

!spawnmob 16806215
Wait for daybreak (0400). Xolotl should despawn as normal, and pets should despawn as well.