### PR TITLE
Create quest to allow players to open waterfall path in Uleguerand Range

### DIFF
--- a/modules/zenith-public/lua/3-complete/ice_wall_quest.lua
+++ b/modules/zenith-public/lua/3-complete/ice_wall_quest.lua
@@ -1,0 +1,115 @@
+-- -----------------------------------
+-- Ice Wall Quest Module
+--
+-- This module creates a quest to interact with
+-- The Ice Wall in Uleguerand Range.
+-- Players can trade a Fire Cluster to open the wall.
+-- -----------------------------------
+
+local m = Module:new('ice_wall_quest')
+
+local ID = zones[xi.zone.ULEGUERAND_RANGE]
+local npcName = 'Ice Wall'
+local checkWaterfall = function(player)
+    local waterfall = GetNPCByID(ID.npc.WATERFALL)
+
+    local waterfallOpen = waterfall:getAnimation() ~= xi.anim.OPEN_DOOR
+
+    if not waterfallOpen then
+        player:fmt('{} : The path is currently clear!', npcName)
+    end
+
+    return waterfallOpen
+end
+
+local openWaterfall = function(player)
+    -- can't just use :openDoor(30) because we need to check the weather before closing it
+    local waterfall = GetNPCByID(ID.npc.WATERFALL)
+    waterfall:setAnimation(xi.anim.OPEN_DOOR)
+
+    -- close door after 30s, unless weather changed in that time
+    waterfall:timer(30000, function(npcArg)
+        local weather = npcArg:getZone():getWeather()
+
+        if
+        npcArg:actionQueueEmpty() and -- don't close the door if someone else traded while it was open
+        (weather == xi.weather.SNOW or
+        weather == xi.weather.BLIZZARDS)
+        then
+            npcArg:setAnimation(xi.anim.CLOSE_DOOR)
+        end
+    end)
+
+    return true
+end
+
+local info =
+{
+    name     = 'Breaking the Ice Wall',
+    author   = 'ZenithXI',
+    var      = '[LQS]ICE_WALL_QUEST',
+    required = { { xi.item.FIRE_CLUSTER, 1 } },
+    reward   =
+    {
+        after = openWaterfall,
+    },
+}
+
+LQS.add(m, {
+    info = info,
+    entities =
+    {
+        ['Uleguerand_Range'] =
+        {
+            {
+                name = npcName,
+                type = xi.objType.NPC,
+                marker = LQS.MAIN_QUEST,
+                pos = { 3.84123, -177.199, 67.45, 106 }, -- !pos -3.276 -0.000 25.295 244
+                default = -- onTrigger functions aren't registered if entity doesn't have this default event table
+                {
+                    { delay   = 500 },
+                },
+            },
+        },
+    },
+    steps =
+    {
+        {
+            [npcName] =
+            {
+                LQS.dialog({
+                    quest = info.name,
+                    event =
+                    {
+                        'This area looks charred.',
+                    },
+                }),
+                check = LQS.checks({ eval = checkWaterfall }), -- executed when onTrigger for this step is called
+                onTrigger = LQS.dialog({
+                    step  = false,
+                    event =
+                    {
+                        'If only there was some way to melt the ice...', -- don't say anything, messages will come from check function
+                    },
+                }),
+                onTrade = LQS.trade({
+                    quest    = info.name,
+                    required = info.required,
+                    reward   = info.reward,
+                    step     = false,
+                    declined =
+                    {
+                        'You won\'t be able to melt the ice with that.',
+                    },
+                    accepted =
+                    {
+                        'You trade a Fire Cluster to the Ice Wall, revealing a hidden path.',
+                    },
+                }),
+            },
+        },
+    },
+})
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Creates a custom quest that allows players to trade a Fire Cluster to the waterfall in Uleguerand Range when it freezes and blocks the path.

Jira Issue: ZEN - 103

## Steps to test these changes

Changing weather to clear and snow/blizzards, when the waterfall is frozen the path is blocked. Trading a fire cluster to the custom npc changes the animation to open the path. Trading any other item besides a fire cluster does nothing.
