### PR TITLE
Implement trust restrictions

### DIFF
--- a/modules/zenith-public/lua/2-base/trusts.lua
+++ b/modules/zenith-public/lua/2-base/trusts.lua
@@ -1,0 +1,119 @@
+-- -----------------------------------
+-- Trusts Module
+--
+-- This module overrides the max number of trusts a player can summon
+-- and implements a cooldown system for summoning trusts.
+-- -----------------------------------
+
+require('modules/module_utils')
+
+local m = Module:new('trusts')
+
+local trustLimitVar = '[TRUST]Additional'
+local trust1CooldownVar = '[TRUST]Cooldown1'
+local trust2CooldownVar = '[TRUST]Cooldown2'
+local trustCooldownTime = (60 * 15) -- 15 minutes
+
+-- Gets the cooldown time remaining for the next available trust.
+-- If both trusts are on cooldown, it returns the shorter of the two.
+local function getNextAvailableTrustTime(caster)
+    local now = os.time()
+    local cooldown = 0
+    local t1Cooldown = caster:getCharVar(trust1CooldownVar)
+    local t2Cooldown = caster:getCharVar(trust2CooldownVar)
+
+    if
+        t1Cooldown > now and
+        t2Cooldown > now
+    then
+        cooldown = math.min(t1Cooldown, t2Cooldown) - now
+    end
+
+    if cooldown <= 0 then
+        return nil
+    end
+
+    local mins = math.floor(cooldown / 60)
+    local secs = cooldown % 60
+
+    -- always show seconds as two digits to avoid 1:9 and instead display 1:09
+    local secsStr = string.format('%02d', secs)
+
+    return fmt('{}:{} remaining until you can summon another trust.', mins, secsStr)
+end
+
+m:addOverride('xi.trust.canCast', function(caster, spell, notAllowedTrustIds)
+    local result = super(caster, spell, notAllowedTrustIds)
+
+    if result ~= 0 then
+        return result
+    end
+
+    local limit = 1
+    local trustAvailable = getNextAvailableTrustTime(caster)
+
+    -- Check if player has the trust limit variable set.
+    if
+        caster:getCharVar(trustLimitVar) ~= 0 and
+        caster:getMainLvl() >= 50
+    then
+        limit = 2
+    end
+
+    -- Check if player has summoned 2 trusts already.
+    local trusts = 0
+    for _, member in pairs(caster:getPartyWithTrusts()) do
+        if member:getObjType() == xi.objType.TRUST then
+            trusts = trusts + 1
+        end
+    end
+
+    if trusts >= limit then
+        caster:messageSystem(xi.msg.system.TRUST_MAXIMUM_NUMBER)
+        return -1
+    end
+
+    -- Check if player has both trusts variables on cooldown.
+    if trustAvailable ~= nil then
+        caster:printToPlayer(trustAvailable, xi.msg.channel.SYSTEM_3)
+        return -1
+    end
+
+    return 0
+end)
+
+m:addOverride('xi.trust.spawn', function(caster, spell)
+    super(caster, spell)
+    local now = os.time()
+    local trustCdTimeStamp = now + trustCooldownTime
+
+    -- When a player summons a trust, check if it's the first one they have summoned.
+    -- If it is, create a variable to set a 15 minute cooldown for the first trust.
+    if
+        caster:getCharVar(trust1CooldownVar) <= now
+    then
+        caster:setCharVar(trust1CooldownVar, trustCdTimeStamp, trustCdTimeStamp)
+    -- If it's not the first trust, set a 15 minute cooldown for the second trust.
+    else
+        caster:setCharVar(trust2CooldownVar, trustCdTimeStamp, trustCdTimeStamp)
+    end
+end)
+
+m:addOverride('npcUtil.completeQuest', function(player, area, quest, params)
+    local result = super(player, area, quest, params)
+
+    if
+        result and
+        area == xi.questLog.JEUNO and
+        quest == xi.quest.id.jeuno.IN_DEFIANT_CHALLENGE
+    then
+        -- When a player completes LB1, set the additional variable to 1
+        -- to allow them to summon two trusts at once.
+        player:setCharVar(trustLimitVar, 1)
+        player:printToPlayer('You may now call forth an additional alter ego at level 50.', xi.msg.channel.SYSTEM_3)
+    end
+
+    return result
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Limits the number of trusts you can summon at the same time to 2 max. Also, introduces 2 `charvars` to set trust summoning cooldowns to 15 minutes to prevent summon/dismiss/resummon and avoid trusts gaining full hp/mp and cooldown resets on abilities. Finally, awards the ability to summon a second trust upon the completion of LB1.

JIRA issue: ZEN-119 & ZEN-10

## Steps to test these changes

Summon two trusts. Try to summon a third and you will receive the max summon message. Dismiss one trust and try to summon another and you will receive the cooldown message with the time remaining until next available summon. Try to summon two trusts before completing LB1 or below lvl 50 (once LB1 is complete) you will receive the max summon message.
