### PR TITLE
Block usage of explorer moogles behind rank 3

### DIFF
--- a/modules/zenith-public/lua/3-complete/explorer_moogle.lua
+++ b/modules/zenith-public/lua/3-complete/explorer_moogle.lua
@@ -1,0 +1,51 @@
+-- -----------------------------------
+-- Explorer Moogle Module
+--
+-- This module overrides the conditions to use explorer moogle teleports.
+-- -----------------------------------
+
+require('modules/module_utils')
+
+local m = Module:new('explorer_moogle')
+
+local canNotTeleport = function(player)
+    -- Check if player is at least rank 3 in any nation
+    local noRank3Nation =
+            player:getRank(player:getNation(xi.nation.BASTOK)) < 3 and
+            player:getRank(player:getNation(xi.nation.SANDORIA)) < 3 and
+            player:getRank(player:getNation(xi.nation.WINDURST)) < 3
+
+    -- Returns true if player is not rank 3 in any nation and meets the minimum level requirement
+    -- The handling of not meeting the level requirement is done in the original explorerMoogleOnTrigger
+    return noRank3Nation and player:getMainLvl() >= xi.settings.main.EXPLORER_MOOGLE_LV
+end
+
+-- Override the teleport conditions for explorer moogle
+m:addOverride('xi.teleport.explorerMoogleOnTrigger', function(player, event)
+    if canNotTeleport(player) then
+        event = event + 1
+    end
+
+    -- Call the original function with the modified event or
+    -- startEvent gets called before we change the event id
+    super(player, event)
+end)
+
+m:addOverride('xi.teleport.explorerMoogleOnEventFinish', function(player, csid, option, event)
+    -- Check if the player is eligible for the teleport
+    -- If they are not, we skip the event finish and do nothing
+    if
+        canNotTeleport(player) and
+        option > 0
+    then
+        -- If player is not eligible but managed to reach the event finish,
+        -- we log this because they have possibility cheated.
+        print(fmt('[JAILUTILS] player {} with id {} has teleported with the explorer moogle while ineligible', player:getName(), player:getID()))
+        return
+    else
+        -- Call the original function
+        super(player, csid, option, event)
+    end
+end)
+
+return m

--- a/modules/zenith-public/lua/3-complete/explorer_moogle.lua
+++ b/modules/zenith-public/lua/3-complete/explorer_moogle.lua
@@ -11,9 +11,9 @@ local m = Module:new('explorer_moogle')
 local canNotTeleport = function(player)
     -- Check if player is at least rank 3 in any nation
     local noRank3Nation =
-            player:getRank(player:getNation(xi.nation.BASTOK)) < 3 and
-            player:getRank(player:getNation(xi.nation.SANDORIA)) < 3 and
-            player:getRank(player:getNation(xi.nation.WINDURST)) < 3
+            player:getRank(xi.nation.BASTOK) < 3 and
+            player:getRank(xi.nation.SANDORIA) < 3 and
+            player:getRank(xi.nation.WINDURST) < 3
 
     -- Returns true if player is not rank 3 in any nation and meets the minimum level requirement
     -- The handling of not meeting the level requirement is done in the original explorerMoogleOnTrigger
@@ -35,7 +35,8 @@ m:addOverride('xi.teleport.explorerMoogleOnEventFinish', function(player, csid, 
     -- Check if the player is eligible for the teleport
     -- If they are not, we skip the event finish and do nothing
     if
-        canNotTeleport(player) and
+        (canNotTeleport(player) or
+        player:getMainLvl() < xi.settings.main.EXPLORER_MOOGLE_LV) and
         option > 0
     then
         -- If player is not eligible but managed to reach the event finish,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds an extra check when players attempt to teleport via the explorer moogles. If players are under rank 3 they will not be allowed to select a destination to be teleported to.

JIRA-issue: ZEN-73

## Steps to test these changes

Numerous calls to `!setrank` to ensure moogles only allowed destination selection once the player has the appropriate rank. Also, `!changejob` and `!setgil` to make sure everything else works as intended.
