### PR TITLE
Reduce Wyvern Exp buffs granted to wyvern and player

### DIFF
--- a/modules/zenith-public/lua/2-base/dragoon_adjustments.lua
+++ b/modules/zenith-public/lua/2-base/dragoon_adjustments.lua
@@ -1,0 +1,56 @@
+-- -- -----------------------------------
+-- -- Dragoon Adjustments Module
+-- --
+-- -- This module overrides the base behaviour of Dragoon job abilities.
+-- -- -----------------------------------
+
+require('modules/module_utils')
+
+local m = Module:new('dragoon_adjustments')
+
+local wyvernMods = {
+    { xi.mod.ACC, 1 },
+    { xi.mod.HPP, 3 },
+    { xi.mod.ATTP, 1 },
+}
+
+local playerMods = {
+    { xi.mod.ATTP, 2 },
+    { xi.mod.DEFP, 2 },
+    { xi.mod.HASTE_ABILITY, 100 },
+    { xi.mod.ALL_WSDMG_ALL_HITS, 2 },
+}
+
+m:addOverride('xi.job_utils.dragoon.addWyvernExp', function(player, ability)
+    local numLevelUps = super(player, ability)
+
+    if numLevelUps > 0 then
+        local wyvern = player:getPet()
+
+        -- Trim the pet buffs down to ACC+5, HPP+3, ATTP+4 per lvl
+        for _, mod in ipairs(wyvernMods) do
+            wyvern:delMod(mod[1], mod[2] * numLevelUps)
+        end
+
+        -- Cut all the player buffs in half
+        for _, mod in ipairs(playerMods) do
+            player:delMod(mod[1], mod[2] * numLevelUps)
+        end
+    end
+
+    return numLevelUps
+end)
+
+m:addOverride('xi.pets.wyvern.onMobDeath', function(mob, player)
+    local numLevelUps = mob:getLocalVar('level_Ups')
+
+    -- Add player buffs back before call to super
+    -- Call to super will remove the original mod calculations
+    for _, mod in ipairs(playerMods) do
+        player:addMod(mod[1], mod[2] * numLevelUps)
+    end
+
+    super(mob, player)
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Reduces wyvern modifiers granted to both the pet and the player. For the player reduces all modifiers by half excluding `xi.mod.ALL_WSDMG_ALL_HITS` which is completely removed. For the wyvern modifiers are reduced to ACC+5, HPP+3, ATTP+4 per level.

JIRA-issue: ZEN-116

## Steps to test these changes

Insert various `print` statements to see values of the original modifiers compared to the reduced modifiers to ensure that when they are applied the correct values are being used.
