### PR TITLE
Update Avatar's Favor recast and ability content tags

### DIFF
--- a/modules/zenith-public/sql/TraitsAndJAs.sql
+++ b/modules/zenith-public/sql/TraitsAndJAs.sql
@@ -74,6 +74,7 @@ UPDATE `abilities` SET `level` = 71, `recastTime`= 90, `content_tag`= NULL WHERE
 UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'dragon_breaker'; -- TODO: Duration changed from 180 to 120
 
 -- SMN
+UPDATE `abilities` SET `level` = 75, `recastTime`= 300, `content_tag`= NULL WHERE `name` = 'avatars_favor'; -- Recast changed from 30 to 300
 UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'mana_cede';
 
 -- BLU
@@ -86,6 +87,7 @@ UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'triple_
 -- PUP
 UPDATE `abilities` SET `level` = 60, `content_tag`= NULL WHERE `name` = 'cooldown';
 -- UPDATE `abilities` SET `level` = 71, `content_tag`= NULL WHERE `name` = 'tactical_switch'; -- TODO: Not yet implemented
+UPDATE `abilities` SET `recastTime`= 90, `content_tag`= NULL WHERE `name` = 'deus_ex_automata'; -- Recast changed from 60 to 90
 
 -- DNC
 UPDATE `abilities` SET `level` = 71, `recastTime`= 30, `content_tag`= NULL WHERE `name` = 'presto'; -- TODO: Potency changed from 5 steps to original 3. Daze increase from 5 to original 2. Step Accuracy from +50 to +20.
@@ -110,6 +112,29 @@ UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'one_for
 -- GEO
 UPDATE `abilities` SET `level` = 65, `content_tag`= NULL WHERE `name` = 'concentric_pulse';
 UPDATE `abilities` SET `level` = 71, `content_tag`= NULL WHERE `name` = 'theurgic_focus'; -- TODO: Not yet implemented. TODO: Potency changed from +50MAB to +25MAB
+
+-------------------------
+-- Content Tag Updates --
+-------------------------
+UPDATE `abilities` SET `content_tag`= NULL WHERE `name` IN (
+    'footwork',
+    'afflatus_solace',
+    'afflatus_misery',
+    'composure',
+    'snarl',
+    'bestial_loyalty',
+    'pianissimo',
+    'yonin',
+    'innin',
+    'hasso',
+    'seigan',
+    'sekkanoki',
+    'spirit_surge',
+    'elemental_siphon',
+    'maintenance',
+    'chocobo_jig_ii',
+    'contradance'
+);
 
 ------------------------
 -- Disabled Abilities --


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

In conjunction with #30 the recast of Avatar's Favor increases to five minutes.

I also noticed that abilities without level changes within TraitsAndJAs.sql were passively disabled due to not updating their content_tag to NULL. This PR enables the following without requiring the corresponding expansion:
    'footwork',
    'afflatus_solace',
    'afflatus_misery',
    'composure',
    'snarl',
    'bestial_loyalty',
    'pianissimo',
    'yonin',
    'innin',
    'hasso',
    'seigan',
    'sekkanoki',
    'spirit_surge',
    'elemental_siphon',
    'maintenance',
    'chocobo_jig_ii',
    'contradance'

## Steps to test these changes

- Make changes
- dbtool
- Test. Working.
