### PR TITLE
Set water trade cooldown to 20 minutes for Yara Ma Yha Who

### DIFF
--- a/modules/zenith-public/lua/2-base/qm2_water_trade.lua
+++ b/modules/zenith-public/lua/2-base/qm2_water_trade.lua
@@ -1,0 +1,26 @@
+-- -----------------------------------
+-- QM2 Water Trade Module
+--
+-- This module overrides the cooldown for trading water to the ???
+-- to pop the NM Yara Ma Yha Who.
+-- -----------------------------------
+
+require('modules/module_utils')
+
+local m = Module:new('qm2_water_trade')
+
+m:addOverride('xi.zones.Tahrongi_Canyon.npcs.qm2.onTrade', function(player, npc, trade)
+    local trades = npc:getLocalVar('trades')
+    local ID = zones[xi.zone.TAHRONGI_CANYON]
+    super(player, npc, trade)
+
+    if
+        npc:getLocalVar('trades') == trades + 1 or
+        GetMobByID(ID.mob.YARA_MA_YHA_WHO):isSpawned()
+    then
+        -- 20 minutes until next trade
+        npc:setLocalVar('tradeCooldown', GetSystemTime() + (20 * 60))
+    end
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Reduces the cooldown for trading `FLASK_OF_DISTILLED_WATER` to the ???, used to pop the NM Yara Ma Yha Who, in Tahrongi Canyon to from 50 to 20 minutes.

JIRA-issue: ZEN-145

## Steps to test these changes

`!additem 4509 12` to get 12 waters,
set ` npc:setLocalVar('tradeCooldown', GetSystemTime() + 10)` to reduce trade cooldown to 10 secs,
trade waters until NM pops making sure after 10 secs you can trade again. 
