### PR TITLE
Nerf mobs with h2h skill since battleutils makes them attack twice

### DIFF
--- a/modules/zenith-public/git-patches/000-PR4866-monkWeapDmg.patch
+++ b/modules/zenith-public/git-patches/000-PR4866-monkWeapDmg.patch
@@ -1,0 +1,40 @@
+From 51348427e294a9d6d09b001c915c7a14f4f9e416 Mon Sep 17 00:00:00 2001
+From: MowFord <131182600+MowFord@users.noreply.github.com>
+Date: Fri, 15 Dec 2023 16:30:25 -0600
+Subject: [PATCH] Monk mob weapon damage adjustments to match PC
+
+---
+ src/map/utils/mobutils.cpp | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/src/map/utils/mobutils.cpp b/src/map/utils/mobutils.cpp
+index 1b0397426e9..75384619e87 100644
+--- a/src/map/utils/mobutils.cpp
++++ b/src/map/utils/mobutils.cpp
+@@ -56,6 +56,7 @@ namespace mobutils
+     uint16 GetWeaponDamage(CMobEntity* PMob, uint16 slot)
+     {
+         uint16 lvl    = PMob->GetMLevel();
++        auto*  weapon = dynamic_cast<CItemWeapon*>(PMob->m_Weapons[SLOT_MAIN]);
+         int8   bonus  = 2;
+         uint16 damage = 0;
+ 
+@@ -69,7 +70,17 @@ namespace mobutils
+             bonus = 0;
+         }
+ 
+-        damage = lvl + bonus;
++        if (slot == SLOT_MAIN && (weapon == nullptr || weapon->getSkillType() == SKILL_HAND_TO_HAND))
++        {
++            // https://ffxiclopedia.fandom.com/wiki/Category:Hand-to-Hand
++            // base h2h weapon dmg for a given h2h skill: (0.11 * h2h skill) + 3
++            uint16 h2hskill = battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_MNK, lvl);
++            damage          = 0.11f * h2hskill + 3;
++        }
++        else
++        {
++            damage = lvl + bonus;
++        }
+ 
+         damage = (uint16)(damage * PMob->m_dmgMult / 100.0f);
+ 


### PR DESCRIPTION
…wice

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

See https://github.com/LandSandBoat/server/pull/4866
and https://github.com/LandSandBoat/server/pull/4674

It's such a monumental effort to pull data to verify this, and unlikely that other layers of combat are correct enough to see things. I think as long as mobs have "weapons" in core, we should have this workaround to not have players getting womped by monk-type mobs (or specifically, mobs with h2h skill set, since some monks aren't set to h2h)

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
go to lvl 1-10 mandragoras outside windy as lvl 1 player, see they don't melt you into the ground. Same for other monk-type mobs. You can use `!getstats` to confirm weapon dmg is being updated properly (most mobs just use main lvl +2 as their weapon dmg)