### PR TITLE
Persist ph nm cooldowns

### DIFF
--- a/modules/zenith-public/lua/1-enum/zxi/mobHelpers.lua
+++ b/modules/zenith-public/lua/1-enum/zxi/mobHelpers.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Various helpers to manipulate mobs
+-----------------------------------
+zxi = zxi or {}
+zxi.mobHelpers = zxi.mobHelpers or {}
+
+local m = Module:new('mobHelpers')
+
+zxi.mobHelpers.getRespawnVarName = function(mob, mobId)
+    if not mob then
+        print('zxi.mobHelpers.getRespawnVarName got nil mob')
+
+        return nil
+    end
+
+    local template = '[Respawn]{}_{}'
+    if mobId then
+        -- passing direct name and ids as params
+        return fmt(template, mob, mobId)
+    end
+
+    return fmt(template, mob:getName(), mob:getID())
+end
+
+return m

--- a/modules/zenith-public/lua/2-base/phOnMobDespawn.lua
+++ b/modules/zenith-public/lua/2-base/phOnMobDespawn.lua
@@ -45,7 +45,12 @@ m:addOverride('xi.mob.phOnDespawn', function(ph, phList, chance, cooldown, param
             if nm:getLocalVar('pop') == 0 then
                 local serverPopTime = GetServerVariable(respawnVarName)
                 -- so we don't query the server vars every ph kill
-                nm:setLocalVar('pop', serverPopTime > 0 and serverPopTime or 1)
+                nm:setLocalVar('pop', serverPopTime > 0 and serverPopTime or 2)
+
+                -- when nm is chosen to spawn, we will set the server variable to 1, which implies it is primed to spawn on first PH kill after server startup
+                if nm:getLocalVar('pop') == 1 then
+                    chance = 100
+                end
             end
 
             phKills = nm:getLocalVar('phKills')
@@ -103,6 +108,11 @@ m:addOverride('xi.mob.phOnDespawn', function(ph, phList, chance, cooldown, param
     -- reset counter if NM gets spawned
     if nm then
         if superResults then
+            -- if the server restarts between now and the NM dying, the first PH kill after restart will have 100% chance
+            SetServerVariable(respawnVarName, 1)
+            -- we set the local var just to be consistent and avoid confusion. As far as this xi.mob function is concerned, 'pop' is irrelevant now that the nm is primed
+            nm:setLocalVar('pop', 1)
+
             -- NM was set to spawn, add listener to save pop time after NM dies
             nm:addListener('DESPAWN', 'PH_SAVE_COOLDOWN', function(mobArg)
                 -- super adds a despawn listener, too. The stack should resolve the same order as it was added

--- a/modules/zenith-public/lua/2-base/phOnMobDespawn.lua
+++ b/modules/zenith-public/lua/2-base/phOnMobDespawn.lua
@@ -28,6 +28,7 @@ m:addOverride('xi.mob.phOnDespawn', function(ph, phList, chance, cooldown, param
     --print(phList)
     local phId = ph:getID()
     local nmId = phList[phId]
+    local respawnVarName = ''
 
     -- so these stay in scope for second half after call of super()
     -- All guaranteed to be non-nil if nm is not nil
@@ -38,6 +39,15 @@ m:addOverride('xi.mob.phOnDespawn', function(ph, phList, chance, cooldown, param
         nm = GetMobByID(nmId)
 
         if nm then
+            -- set server var so we can use it if we need it here and in DESPAWN listener below
+            respawnVarName = zxi.mobHelpers.getRespawnVarName(nm)
+            -- restore pop localvar if server rebooted
+            if nm:getLocalVar('pop') == 0 then
+                local serverPopTime = GetServerVariable(respawnVarName)
+                -- so we don't query the server vars every ph kill
+                nm:setLocalVar('pop', serverPopTime > 0 and serverPopTime or 1)
+            end
+
             phKills = nm:getLocalVar('phKills')
             popTime = nm:getLocalVar('pop')
             -- adjust values based on table above
@@ -92,6 +102,17 @@ m:addOverride('xi.mob.phOnDespawn', function(ph, phList, chance, cooldown, param
 
     -- reset counter if NM gets spawned
     if nm then
+        if superResults then
+            -- NM was set to spawn, add listener to save pop time after NM dies
+            nm:addListener('DESPAWN', 'PH_SAVE_COOLDOWN', function(mobArg)
+                -- super adds a despawn listener, too. The stack should resolve the same order as it was added
+                -- but if cooldowns aren't persisting properly we'll need to add a timer inside this listener
+                SetServerVariable(respawnVarName, mobArg:getLocalVar('pop'))
+
+                mobArg:removeListener('PH_SAVE_COOLDOWN')
+            end)
+        end
+
         if
             GetSystemTime() < popTime or -- NM is on cooldown, don't stack kill count until out of window
             nm:isAlive() or

--- a/modules/zenith-public/lua/3-complete/hnm_respawn_windows.lua
+++ b/modules/zenith-public/lua/3-complete/hnm_respawn_windows.lua
@@ -100,9 +100,7 @@ local beastmenNMs = {
 -- Helper function to set respawn time and persist it
 local function setAndPersistRespawnTime(mob, respawnTimeCalc)
     if mob then
-        local mobName = mob:getName()
-        local id = mob:getID()
-        local varName = '[Respawn]'..mobName..'_'..id
+        local varName = zxi.mobHelpers.getRespawnVarName(mob)
 
         mob:setRespawnTime(respawnTimeCalc)
         SetServerVariable(varName, os.time() + respawnTimeCalc)
@@ -115,7 +113,7 @@ local function restoreOrSetRespawnTime(mobId, respawnTimeCalc)
 
     if mob then
         local mobName = mob:getName()
-        local varName = '[Respawn]'..mobName..'_'..mobId
+        local varName = zxi.mobHelpers.getRespawnVarName(mob)
         local savedRespawnTime = GetServerVariable(varName)
         local currentTime = os.time()
 
@@ -201,7 +199,7 @@ createStandardNMOverrides(nmsToModify)
 --decide wether to spawn NQ or HQ version of beastmen NMs
 --returns true if the mob was spawned or respawn time was set, false otherwise
 local function processNqHqSpawn(primaryId, secondaryId, name, currentTime)
-    local varName = '[Respawn]'..name..'_'..primaryId
+    local varName = zxi.mobHelpers.getRespawnVarName(name, primaryId)
     local respawn   = GetServerVariable(varName)
     if respawn and respawn > 0 then
         if respawn > currentTime then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

addresses ZEN-123

on death of a PH, nm localvar `pop` is pulled from the db or otherwise set to non-zero

on despawn of the PH-style NM, the new localvar `pop` is saved to the db

Edit: additionally, added the priming of an NM to persist reboot. So when the PH chooses the nm to spawn, save pop value as `1`, then on first PH kill after restart (localvar `pop` is zero), if the value from db is 1, set `chance` to 100%

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- go to a ph-style NM
- record its mob id
- `!exec print(GetMobByID(<mobid>):getLocalVar('pop'))`
- kill one of its PHs
- see that the var is set to 1 (normally it's only set in the despawn flow of the NM)
- go to PH's lua file, set chance to 100 and immediate to true: `xi.mob.phOnDespawn(mob, vasiliceratopsPHTable, 100, 5400, {immediate=true})`
- kill PH again
- see NM spawns immediately after PH despawn
- check its `pop` var again, it should not have changed
- kill it
- after despawn, check its pop var
- log out and restart map server
- log back in and kill PH
- see pop var is back to what it was and that NM didn't spawn even with the 100% chance still set

Additional testing
- I guess you could go and test the HNM module, but the changes there were minimal just so we could have a standardized server var generation