### PR TITLE
Update CI to detect PRs coming from the same repo

### DIFF
--- a/.github/workflows/block_restricted_edits.yml
+++ b/.github/workflows/block_restricted_edits.yml
@@ -11,13 +11,38 @@ jobs:
         shell: bash
         id: check
         run: |
-          if [[ "${{ github.head_ref }}" != "base" ]]; then
-            echo "Not a PR from 'base' branch, checking which files are modified"
-            echo "should_continue=true" >> $GITHUB_OUTPUT
-          else
+          # technically zenith _is_ a fork of LSB, so we have to detect based on repo
+          HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+          BASE_REPO="${{ github.repository }}"
+          FORK=true
+          BRANCH=""
+
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            FORK=false
+          fi
+
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            BRANCH="$GITHUB_REF_NAME"
+          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            BRANCH=$(jq -r '.pull_request.head.ref' "$GITHUB_EVENT_PATH")
+          fi
+
+          echo "Fork: $FORK"
+          echo "Branch: $BRANCH"
+
+          if [ "$FORK" = "false" ] && [ "$BRANCH" = "base" ]; then
             echo "'base' branch is allowed to modify anything in the codebase"
             echo "should_continue=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
+
+          if [ "$FORK" = "false" ]; then
+            echo "All PRs should come from forks."
+            echo "Please fork this repository and inform someone about deleting this branch."
+            exit 1
+          fi
+
+          echo "should_continue=true" >> $GITHUB_OUTPUT
 
       - name: Check out the code
         if: steps.check.outputs.should_continue == 'true'


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

See #50 and https://github.com/Zenith-XI/ZenithXI/actions/runs/16939167497/job/48003276883

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
First PR tested that it blocks with a message if your PR is from the same repo

[this one](https://github.com/Zenith-XI/ZenithXI/actions/runs/16939268499/job/48003639391?pr=51) shows that it continues (and fails because i'm modifying the ci file)

Final test would be that base->testing PR to sync from LSB still works