### PR TITLE
Add recast timer to zone in before seals drop

### DIFF
--- a/modules/zenith-public/lua/1-enum/recast_tables.lua
+++ b/modules/zenith-public/lua/1-enum/recast_tables.lua
@@ -1,0 +1,20 @@
+-- -----------------------------------
+-- Recast Tables Module
+--
+-- This module overrides the recast table for players and mobs.
+-- -----------------------------------
+
+require('modules/module_utils')
+
+local m = Module:new('recast_tables')
+
+-- Override the recast Tables
+
+xi = xi or {}
+
+xi.recast.LOOT     = 3
+
+xi.recastID.SEAL           =   1
+xi.recastID.GEODE          =   2
+
+return m

--- a/modules/zenith-public/lua/2-base/seal_zone_timer.lua
+++ b/modules/zenith-public/lua/2-base/seal_zone_timer.lua
@@ -1,0 +1,16 @@
+-- -----------------------------------
+-- Seals Zone Timer Module
+--
+-- This module overrides the player being able to reset the seal timer by log out or zone.
+-- -----------------------------------
+
+require('modules/module_utils')
+
+local m = Module:new('seal_zone_timer')
+
+m:addOverride('xi.player.onGameIn', function(player, firstLogin, zoning)
+    super(player, firstLogin, zoning)
+    player:addRecast(xi.recast.LOOT, xi.recastID.SEAL, 150)
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add a recast timer when a player zones in, this includes logging in to the game, to prevent abusing the seals mechanics that resets the 5 min cooldown period.

JIRA issue: ZEN-98

## Steps to test these changes

In the `mobentity.cpp` set `xirand::GetRandomNumber(100) < 20` to <= 100 and change `constexpr timer::duration SPECIAL_DROP_COOLDOWN = 5min;` to 0sec. This will ensure each mob drops a beastman seal 100% of the time with no cooldown. Change zones and kill mobs to see the within the first 150 seconds no seals drop and after that each kill gives a seal.
