### PR TITLE
Exclusive Equipment Module

### DIFF
--- a/modules/zenith-public/lua/4-additive/items/exclusive_equipment.lua
+++ b/modules/zenith-public/lua/4-additive/items/exclusive_equipment.lua
@@ -1,0 +1,66 @@
+-----------------------------------
+-- Exclusive Equipment Groups
+-- Prevents dual wielding of items within the same exclusion group
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+
+local m = Module:new('exclusive_equipment')
+
+-- Define exclusive groups - items in the same group cannot be equipped together
+-- To add new groups, create a new entry with the group name as key and a table
+-- of item IDs mapped to their internal names as the value
+local exclusiveGroups =
+{
+    -- Multi-attack clubs that cannot be dual wielded
+    multiAttackClubs =
+    {
+        [xi.item.KRAKEN_CLUB] = 'kraken_club',
+        [xi.item.OCTAVE_CLUB] = 'octave_club',
+    },
+    -- Add more groups here as needed
+    -- Example:
+    -- specialSwords =
+    -- {
+    --     [xi.item.SOME_SWORD] = 'some_sword',
+    --     [xi.item.OTHER_SWORD] = 'other_sword',
+    -- },
+}
+
+-- Helper function to handle equipment conflicts
+-- @param target object: The player object
+local function handleEquipmentConflict(target)
+    target:timer(50, function(targetArg)
+        -- Unequip both MAIN and SUB weapons when conflict detected
+        targetArg:unequipItem(xi.slot.MAIN)
+        targetArg:unequipItem(xi.slot.SUB)
+        targetArg:messageBasic(xi.msg.basic.ITEM_UNABLE_TO_USE)
+    end)
+end
+
+-- Apply overrides for all exclusive items
+for groupName, groupItems in pairs(exclusiveGroups) do
+    for itemId, itemName in pairs(groupItems) do
+        local itemPath = fmt('xi.items.{}', itemName)
+        xi.module.ensureTable(itemPath)
+
+        m:addOverride(itemPath .. '.onItemEquip', function(player, item)
+            super(player, item)
+
+            -- Get currently equipped items
+            local mainWeapon = player:getEquipID(xi.slot.MAIN)
+            local subWeapon = player:getEquipID(xi.slot.SUB)
+
+            -- Check for exclusive group conflicts between main and sub weapons
+            if
+                mainWeapon ~= subWeapon and
+                groupItems[mainWeapon] and
+                groupItems[subWeapon]
+            then
+                handleEquipmentConflict(player)
+            end
+        end)
+    end
+end
+
+return m


### PR DESCRIPTION
This module is used to restrict a character from equipping certain combinations of weapons.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This module restricts the use of certain combinations of weapons.  It can be easily edited to allow for additional combinations.

## Steps to test these changes

1. Equip a kraken club or Octave in Main hand. 
2. Equip a kraken club or Octave in the other hand.
3. Both weapons will be unequipped. 
