### PR TITLE
jeuno Outpost Teleporter Npc

### DIFF
--- a/modules/zenith-public/lua/4-additive/npc/jeuno/[LQS]jeunoTeleportNpc.lua
+++ b/modules/zenith-public/lua/4-additive/npc/jeuno/[LQS]jeunoTeleportNpc.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- NPC: Jeuno Outpost Warper
+-----------------------------------
+-- Outpost teleporter NPC for Lower Jeuno using LQS framework.
+-- Provides paginated outpost warp menu with Gil/CP payment options.
+-- Features:
+--   - Signet application before teleport (optional)
+--   - Level and outpost unlock requirements
+--   - Standard retail outpost costs
+-----------------------------------
+
+return LQS.outpostTeleporter({
+    name = 'Outpost Warper',
+    zone = 'Lower_Jeuno',
+    pos  = { 24.1552, -1.0, 45.9046, 149 },
+    look = 1415, -- Hume Uncle model
+
+    -- Apply Signet before teleport (uses rank-based duration)
+    preTeleportEffects = { LQS.signetEffect() },
+
+    -- Other defaults:
+    -- greeting       = "Welcome to the Outpost Warp Service!"
+    -- itemsPerPage   = 5
+    -- teleportDelay  = 1250
+    -- animation      = { actionID = 6, animID = 600 }
+})


### PR DESCRIPTION
Added Npc that teleports players for gil or cp to outposts they have unlocked.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Creates an NPC that teleports players that have unlocked outposts to those outpost for gil or cp.

## Steps to test these changes

1. Go to  Lower Jeuno near the mog house.
2. talk to Outpost Warper NPC
3. select an outpost that you have unlocked and pay the fee in gil or cp
4. get teleported to that location.
