### PR TITLE
Shield Barrier and Protect Spells Rebalance

### DIFF
--- a/modules/zenith-public/lua/4-additive/traits/pld/protectRebalance.lua
+++ b/modules/zenith-public/lua/4-additive/traits/pld/protectRebalance.lua
@@ -1,0 +1,64 @@
+-----------------------------------
+-- Protect/Protectra Enhancement Module
+-- Combines defense rebalancing and Shield Barrier trait modifications
+-- - Adjusts defense amounts for Protect and Protectra spells
+-- - Modifies Shield Barrier to grant Protect Defense + (Shield Defense / 2)
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+
+local m = Module:new('protectEnhancements')
+
+-- Define the new defense values for Protect and Protectra spells
+-- Both spell lines will use the same defense values
+local protectDefenseValues = {
+    -- Protect spells
+    [xi.magic.spell.PROTECT]       = 10,  -- Protect
+    [xi.magic.spell.PROTECT_II]    = 25,  -- Protect II
+    [xi.magic.spell.PROTECT_III]   = 40,  -- Protect III
+    [xi.magic.spell.PROTECT_IV]    = 55,  -- Protect IV
+    [xi.magic.spell.PROTECT_V]     = 65,  -- Protect V
+
+    -- Protectra spells
+    [xi.magic.spell.PROTECTRA]     = 10,  -- Protectra
+    [xi.magic.spell.PROTECTRA_II]  = 25,  -- Protectra II
+    [xi.magic.spell.PROTECTRA_III] = 40,  -- Protectra III
+    [xi.magic.spell.PROTECTRA_IV]  = 55,  -- Protectra IV
+    [xi.magic.spell.PROTECTRA_V]   = 65,  -- Protectra V
+}
+
+-- Override the base power calculation for Protect/Protectra spells
+m:addOverride('xi.spells.enhancing.calculateEnhancingBasePower', function(caster, target, spell, spellId, skillLevel, spellParams, dayWeatherBonus)
+    local basePower = super(caster, target, spell, spellId, skillLevel, spellParams, dayWeatherBonus)
+
+    -- Check if this is a Protect or Protectra spell and override its base power
+    local newDefense = protectDefenseValues[spellId]
+    if newDefense then
+        basePower = newDefense
+    end
+
+    return basePower
+end)
+
+-- Override the final power calculation to modify Shield Barrier trait behavior
+m:addOverride('xi.spells.enhancing.calculateEnhancingFinalPower', function(caster, target, spell, basePower, spellGroup, tier, spellEffect)
+    local finalPower = super(caster, target, spell, basePower, spellGroup, tier, spellEffect)
+
+    -- Check if this is a Protect spell and caster has Shield Barrier trait
+    if
+        spellEffect == xi.effect.PROTECT and
+        caster:isPC() and
+        caster:getMod(xi.mod.SHIELD_BARRIER) > 0
+    then
+        -- Remove the original Shield Barrier bonus (which was added in the original function)
+        finalPower = finalPower - caster:getShieldDefense()
+
+        -- Add the modified Shield Barrier bonus (Shield Defense / 2)
+        local shieldDefense = caster:getShieldDefense()
+        finalPower = finalPower + math.floor(shieldDefense / 2)
+    end
+
+    return finalPower
+end)
+
+return m


### PR DESCRIPTION
module to adjust how defense is added when a paladin holds a shield and protect is casted upon him at level 70+

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

module to adjust how defense is added when a paladin holds a shield and protect is casted upon him at level 70+.  It also changes the DEF values gained when under the effect of protect to match ERA values.

## Steps to test these changes
Shield Barrier
1. equip a shield and cast protect on yourself as a paladin, note defense.
2. remove shield and cast protect on yourself as a paladin, note defense.
3. defense should go up with shield equipped by half of the shields DEF value.

Protect
1. Cast various protect spells on your character and check out the DEF increases received match the values in the script.
