### PR TITLE
Changes to Protect Def Values to Era Period

### DIFF
--- a/modules/zenith-public/lua/4-additive/spells/protectEraRebalance.lua
+++ b/modules/zenith-public/lua/4-additive/spells/protectEraRebalance.lua
@@ -1,0 +1,41 @@
+-----------------------------------
+-- Protect/Protectra Spell Defense Rebalance
+-- Adjusts the defense amounts for Protect and Protectra spells
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+
+local m = Module:new('protectRebalance')
+
+-- Define the new defense values for Protect and Protectra spells
+-- Both spell lines will use the same defense values
+local protectDefenseValues = {
+    -- Protect spells
+    [xi.magic.spell.PROTECT]       = 10,  -- Protect
+    [xi.magic.spell.PROTECT_II]    = 25,  -- Protect II
+    [xi.magic.spell.PROTECT_III]   = 40,  -- Protect III
+    [xi.magic.spell.PROTECT_IV]    = 55,  -- Protect IV
+    [xi.magic.spell.PROTECT_V]     = 65,  -- Protect V
+
+    -- Protectra spells
+    [xi.magic.spell.PROTECTRA]     = 10,  -- Protectra
+    [xi.magic.spell.PROTECTRA_II]  = 25,  -- Protectra II
+    [xi.magic.spell.PROTECTRA_III] = 40,  -- Protectra III
+    [xi.magic.spell.PROTECTRA_IV]  = 55,  -- Protectra IV
+    [xi.magic.spell.PROTECTRA_V]   = 65,  -- Protectra V
+}
+
+-- Override the base power calculation for Protect/Protectra spells
+m:addOverride('xi.spells.enhancing.calculateEnhancingBasePower', function(caster, target, spell, spellId, skillLevel, spellParams, dayWeatherBonus)
+    local basePower = super(caster, target, spell, spellId, skillLevel, spellParams, dayWeatherBonus)
+
+    -- Check if this is a Protect or Protectra spell and override its base power
+    local newDefense = protectDefenseValues[spellId]
+    if newDefense then
+        basePower = newDefense
+    end
+
+    return basePower
+end)
+
+return m


### PR DESCRIPTION
This PR changes Protect and Protectra to ERA DEF values.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR changes Protect and Protectra to ERA DEF values.

## Steps to test these changes

1. Cast various protect levels on your character and check the def value.
