### PR TITLE
Berserk change to static 25% increase

### DIFF
--- a/modules/zenith-public/lua/2-base/abilities.lua
+++ b/modules/zenith-public/lua/2-base/abilities.lua
@@ -13,6 +13,22 @@ local effectAdjustments =
             power = -10, -- Changed from 20% to 10%
         },
     },
+    berserk =
+    {
+        effectId = xi.effect.BERSERK,
+        set =
+        {
+            power = 25, -- Force static 25% modifiers (ignoring BERSERK_POTENCY)
+        },
+    },
+    defender =
+    {
+        effectId = xi.effect.DEFENDER,
+        set =
+        {
+            power = 25, -- Force static 25% defense modifier
+        },
+    },
     -- Monk
     impetus =
     {
@@ -122,6 +138,21 @@ for effectName, config in pairs(effectAdjustments) do
 
         -- Only apply adjustments for fresh effects, not restored ones
         if not isRestoring then
+            -- Handle set operations (force specific values)
+            if effectConfig.set then
+                if effectConfig.set.power then
+                    effect:setPower(effectConfig.set.power)
+                end
+
+                if effectConfig.set.subpower then
+                    effect:setSubPower(effectConfig.set.subpower)
+                end
+
+                if effectConfig.set.duration then
+                    effect:setDuration(effectConfig.set.duration)
+                end
+            end
+
             -- Handle add operations
             if effectConfig.add then
                 if effectConfig.add.power then


### PR DESCRIPTION
Jira identified the Berserk and Defender changed in LSB so this script is to revert the changes to static 25% modifiers.  After checking the Defender.lua file it was determined that it was already set to 25% static increase so this is just changing the Berserk Job Ability.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes Berserk to static 25% increase modifier as per Jira and ERA standards.

## Steps to test these changes

1. Use Berserk and check 
   - ATTP% increased by 25
   - RATTP% increased by 25
   - DEFP% decreased by 25