### PR TITLE
GM characters link to personal characters - Zoning Prevention

### DIFF
--- a/modules/zenith-public/cpp/gm_account_bindings.cpp
+++ b/modules/zenith-public/cpp/gm_account_bindings.cpp
@@ -1,0 +1,135 @@
+/*
+===========================================================================
+
+  Copyright (c) 2024 ZenithXI Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+/************************************************************************
+ * GM Account Bindings Module
+ *
+ * This module provides Lua bindings for account-based zone restriction
+ * enforcement. It allows the Lua zone restriction module to query
+ * account IDs and linked accounts from the gm_account_bindings table.
+ *
+ * Exposes:
+ *   - GetAccountIdFromCharId(charId) - Global function
+ *   - GetLinkedAccountIds(accountId) - Global function
+ *   - player:getAccountId() - Entity method
+ ************************************************************************/
+#include "map/utils/moduleutils.h"
+
+#include "common/database.h"
+#include "common/lua.h"
+#include "map/entities/charentity.h"
+#include "map/lua/lua_baseentity.h"
+
+class GMAccountBindingsModule : public CPPModule
+{
+    void OnInit() override
+    {
+        TracyZoneScoped;
+
+        // Global function: GetAccountIdFromCharId(charId)
+        // Returns the account ID for a given character ID
+        // Usage: local accountId = GetAccountIdFromCharId(charId)
+        lua["GetAccountIdFromCharId"] = [](uint32 charId) -> uint32
+        {
+            TracyZoneScoped;
+
+            if (charId == 0)
+            {
+                return 0;
+            }
+
+            const auto rset = db::preparedStmt(
+                "SELECT accid FROM chars WHERE charid = ? LIMIT 1",
+                charId);
+
+            if (rset && rset->rowsCount() && rset->next())
+            {
+                return rset->get<uint32>("accid");
+            }
+
+            return 0;
+        };
+
+        // Global function: GetLinkedAccountIds(accountId)
+        // Returns a table of linked account IDs from gm_account_bindings
+        // Queries both directions: where this account is the GM or the personal account
+        // Usage: local linkedAccounts = GetLinkedAccountIds(accountId)
+        lua["GetLinkedAccountIds"] = [](sol::this_state s, uint32 accountId) -> sol::table
+        {
+            TracyZoneScoped;
+
+            sol::state_view luaState(s);
+            auto            table = luaState.create_table();
+
+            if (accountId == 0)
+            {
+                return table;
+            }
+
+            // Query for linked accounts in both directions
+            // If accountId is the GM, return the personal accounts
+            // If accountId is the personal account, return the GM accounts
+            const auto rset = db::preparedStmt(
+                "SELECT "
+                "  CASE WHEN gm_account_id = ? THEN personal_account_id "
+                "  ELSE gm_account_id END AS linked_id "
+                "FROM gm_account_bindings "
+                "WHERE gm_account_id = ? OR personal_account_id = ?",
+                accountId,
+                accountId,
+                accountId);
+
+            if (rset && rset->rowsCount())
+            {
+                while (rset->next())
+                {
+                    table.add(rset->get<uint32>("linked_id"));
+                }
+            }
+
+            return table;
+        };
+
+        // Entity method: player:getAccountId()
+        // Returns the account ID for a player entity
+        // Usage: local accountId = player:getAccountId()
+        lua["CBaseEntity"]["getAccountId"] = [](CLuaBaseEntity* PLuaEntity) -> uint32
+        {
+            TracyZoneScoped;
+
+            if (PLuaEntity == nullptr)
+            {
+                return 0;
+            }
+
+            CBaseEntity* PEntity = PLuaEntity->GetBaseEntity();
+            if (PEntity == nullptr || PEntity->objtype != TYPE_PC)
+            {
+                return 0;
+            }
+
+            auto* PChar = static_cast<CCharEntity*>(PEntity);
+            return PChar->accid;
+        };
+    }
+};
+
+REGISTER_CPP_MODULE(GMAccountBindingsModule);

--- a/modules/zenith-public/lua/3-complete/gm_dualbox_zone_restriction.lua
+++ b/modules/zenith-public/lua/3-complete/gm_dualbox_zone_restriction.lua
@@ -1,0 +1,147 @@
+-----------------------------------
+-- GM Dual-Box Zone Restriction (Account-Based)
+-- Prevents characters from linked accounts from being in the same zone
+-- Bindings are managed via the web admin panel (gm_account_bindings table)
+-- This is a security measure to prevent GMs from abusing powers to benefit personal characters
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+-- luacheck: globals GetLinkedAccountIds
+-- GetLinkedAccountIds is registered by modules/zenith-public/cpp/gm_account_bindings.cpp
+-----------------------------------
+local m = Module:new('c_gm_dualbox_zone_restriction')
+
+-- Configuration
+local config =
+{
+    -- Safe zone to teleport conflicting players to (Ru'Lude Gardens)
+    safeZone = xi.zone.RULUDE_GARDENS,
+    safePos =
+    {
+        x = 48.930,
+        y = 10.002,
+        z = -71.032,
+        rot = 195,
+    },
+
+    -- Delay before teleport (milliseconds)
+    teleportDelay = 500,
+
+    -- Enable console logging
+    enableLogging = true,
+}
+
+-----------------------------------
+-- Helper Functions
+-----------------------------------
+
+-- Check if any player from a linked account is in the specified zone
+-- @param linkedAccountIds table: Array of linked account IDs
+-- @param targetZoneId number: The zone to check
+-- @param excludePlayerId number: Player ID to exclude from the check (the zoning player)
+-- @return CBaseEntity|nil: The first conflicting player found in zone, nil otherwise
+local function getLinkedAccountPlayerInZone(linkedAccountIds, targetZoneId, excludePlayerId)
+    if #linkedAccountIds == 0 then
+        return nil
+    end
+
+    -- Get all players in the target zone
+    local zone = GetZone(targetZoneId)
+    if zone == nil then
+        return nil
+    end
+
+    -- Iterate through zone players to find any from linked accounts
+    local zonePlayers = zone:getPlayers()
+    for _, zonePlayer in ipairs(zonePlayers) do
+        if zonePlayer ~= nil and zonePlayer:getID() ~= excludePlayerId then
+            local zonePlayerAccountId = zonePlayer:getAccountId()
+            if zonePlayerAccountId ~= 0 then
+                for _, linkedAccountId in ipairs(linkedAccountIds) do
+                    if zonePlayerAccountId == linkedAccountId then
+                        return zonePlayer
+                    end
+                end
+            end
+        end
+    end
+
+    return nil
+end
+
+-- Handle zone conflict by teleporting player to safe zone
+-- @param zoningPlayer CBaseEntity: The player to redirect (the one zoning in)
+-- @param conflictPlayer CBaseEntity: The player already in the zone (receives the notification)
+local function handleZoneConflict(zoningPlayer, conflictPlayer)
+    local zoningPlayerName = zoningPlayer:getName()
+    local conflictPlayerName = conflictPlayer:getName()
+    local zoneId = conflictPlayer:getZoneID()
+
+    -- Send message to the player already in the zone (they're fully loaded)
+    conflictPlayer:printToPlayer(
+        string.format(
+            '[GM Zone Restriction] A character from your linked account (%s) attempted to enter this zone and was redirected.',
+            zoningPlayerName
+        ),
+        xi.msg.channel.SYSTEM_3
+    )
+
+    -- Teleport the zoning player to safe zone after a brief delay
+    zoningPlayer:timer(config.teleportDelay, function(playerArg)
+        playerArg:setPos(
+            config.safePos.x,
+            config.safePos.y,
+            config.safePos.z,
+            config.safePos.rot,
+            config.safeZone
+        )
+    end)
+
+    if config.enableLogging then
+        printf('[GM Zone Restriction] %s (account-based) blocked from zone %d - linked account char %s present',
+            zoningPlayerName,
+            zoneId,
+            conflictPlayerName
+        )
+    end
+end
+
+-----------------------------------
+-- Zone Entry Override
+-----------------------------------
+
+m:addOverride('xi.player.onGameIn', function(player, firstLogin, zoning)
+    super(player, firstLogin, zoning)
+
+    -- Only check for conflicts during zone transitions (not initial login)
+    if not zoning then
+        return
+    end
+
+    -- Don't check if player is in the safe zone (they just got redirected here)
+    local targetZoneId = player:getZoneID()
+    if targetZoneId == config.safeZone then
+        return
+    end
+
+    -- Get the player's account ID using the C++ binding
+    local accountId = player:getAccountId()
+    if accountId == 0 then
+        return
+    end
+
+    -- Get linked accounts from the database via C++ binding
+    -- This returns accounts linked in either direction (GM->Personal or Personal->GM)
+    local linkedAccountIds = GetLinkedAccountIds(accountId)
+    if linkedAccountIds == nil or #linkedAccountIds == 0 then
+        return
+    end
+
+    -- Check if any player from a linked account is in the target zone
+    local conflictPlayer = getLinkedAccountPlayerInZone(linkedAccountIds, targetZoneId, player:getID())
+    if conflictPlayer ~= nil then
+        handleZoneConflict(player, conflictPlayer)
+    end
+end)
+
+return m

--- a/modules/zenith-public/sql/gm_account_bindings.sql
+++ b/modules/zenith-public/sql/gm_account_bindings.sql
@@ -1,0 +1,21 @@
+-- GM Account Bindings Table
+-- Links GM accounts to their personal accounts for zone restriction enforcement
+-- Database: xidb
+
+-- ============================================================================
+-- GM ACCOUNT BINDINGS TABLE
+-- Used to link GM accounts to personal (non-GM) accounts
+-- Zone restrictions prevent characters from linked accounts being in the same zone
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS gm_account_bindings (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    gm_account_id INT NOT NULL COMMENT 'The GM account ID',
+    personal_account_id INT NOT NULL COMMENT 'The linked personal account ID',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'When the binding was created',
+    created_by_char_id INT NOT NULL COMMENT 'Character ID of GM who created the binding',
+    created_by_name VARCHAR(50) NOT NULL COMMENT 'Name of GM who created the binding',
+    notes VARCHAR(255) DEFAULT NULL COMMENT 'Optional notes about this binding',
+    UNIQUE KEY uk_gm_personal (gm_account_id, personal_account_id),
+    INDEX idx_gm_account (gm_account_id),
+    INDEX idx_personal_account (personal_account_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
Adds new !gmlink commands to link gm characters to personal characters so they cannot be in the same zone as each other.


**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds new !gmlink commands to link gm characters to personal characters so they cannot be in the same zone as each other.

## Steps to test these changes

1. login with personal character and gm character
2. on gm character run !gmlink add <gmCharacterName> which links the characters
3. using gm char zone into the zone the personal char is in.  It will redirect them to Ru'Lude Gardens
4. using personal char zone into a zone that has the gm char. it will redirect them to Ru'Lude Gardens
5. the char that isnt loading into the zone will get a notification message on what has happened.
6. use the command !gmlink to see available arguments such as add, remove, list, clear etc.  try them out.
7. gmlevel 4 will have admin access to alter other gm's gm char / personal char links.
