### PR TITLE
Adds LFP functionality while trusts are out

### DIFF
--- a/modules/zenith-public/cpp/lfp_with_trusts.cpp
+++ b/modules/zenith-public/cpp/lfp_with_trusts.cpp
@@ -1,0 +1,60 @@
+﻿/************************************************************************
+ * LFP With Trusts Module
+ *
+ * This module allows players to toggle LFP status while trusts are
+ * deployed, bypassing client-side restrictions.
+ *
+ * Exposes player:setSeekingParty(value) method binding to Lua.
+ ************************************************************************/
+#include "map/utils/moduleutils.h"
+
+#include "common/lua.h"
+#include "map/entities/charentity.h"
+#include "map/lua/lua_baseentity.h"
+#include "map/packets/char_status.h"
+#include "map/packets/char_sync.h"
+#include "map/packets/s2c/0x0b4_config.h"
+#include "map/utils/charutils.h"
+
+class LfpWithTrustsModule : public CPPModule
+{
+    void OnInit() override
+    {
+        TracyZoneScoped;
+
+        // Bind setSeekingParty as a method on CBaseEntity
+        // Usage: player:setSeekingParty(true/false)
+        lua["CBaseEntity"]["setSeekingParty"] = [](CLuaBaseEntity* PLuaEntity, bool value) -> bool
+        {
+            TracyZoneScoped;
+
+            if (PLuaEntity == nullptr)
+            {
+                return false;
+            }
+
+            CBaseEntity* PEntity = PLuaEntity->GetBaseEntity();
+            if (PEntity == nullptr || PEntity->objtype != TYPE_PC)
+            {
+                return false;
+            }
+
+            auto* PChar = static_cast<CCharEntity*>(PEntity);
+
+            if (PChar->playerConfig.InviteFlg != value)
+            {
+                PChar->playerConfig.InviteFlg = value;
+                PChar->updatemask |= UPDATE_HP;
+                charutils::SaveCharStats(PChar);
+                charutils::SavePlayerSettings(PChar);
+                PChar->pushPacket<GP_SERV_COMMAND_CONFIG>(PChar);
+                PChar->pushPacket<CCharStatusPacket>(PChar);
+                PChar->pushPacket<CCharSyncPacket>(PChar);
+            }
+
+            return true;
+        };
+    }
+};
+
+REGISTER_CPP_MODULE(LfpWithTrustsModule);

--- a/modules/zenith-public/lua/2-base/trusts.lua
+++ b/modules/zenith-public/lua/2-base/trusts.lua
@@ -3,11 +3,14 @@
 --
 -- This module overrides the max number of trusts a player can summon
 -- and implements a cooldown system for summoning trusts.
+--
+-- [ZENITH MOD] Also removes the LFP restriction to allow trusts while
+-- seeking a party, and allows setting LFP while trusts are deployed.
 -- -----------------------------------
 
 require('modules/module_utils')
 
-local m = Module:new('trusts')
+local m = Module:new('b_trusts')
 
 local trustLimitVar = '[TRUST]Additional'
 local trust1CooldownVar = '[TRUST]Cooldown1'
@@ -17,7 +20,7 @@ local trustCooldownTime = (60 * 15) -- 15 minutes
 -- Gets the cooldown time remaining for the next available trust.
 -- If both trusts are on cooldown, it returns the shorter of the two.
 local function getNextAvailableTrustTime(caster)
-    local now = os.time()
+    local now = GetSystemTime()
     local cooldown = 0
     local t1Cooldown = caster:getCharVar(trust1CooldownVar)
     local t2Cooldown = caster:getCharVar(trust2CooldownVar)
@@ -42,49 +45,46 @@ local function getNextAvailableTrustTime(caster)
     return fmt('{}:{} remaining until you can summon another trust.', mins, secsStr)
 end
 
+-- [ZENITH MOD] Temporarily disable LFP during trust casting, then re-enable
+-- This avoids duplicating all base casting restrictions and reduces maintenance burden
+local lfpRestoreDelay = 10 -- seconds
+
 m:addOverride('xi.trust.canCast', function(caster, spell, notAllowedTrustIds)
+    -- Check if both trust cooldowns are active
+    local cooldownMsg = getNextAvailableTrustTime(caster)
+    if cooldownMsg then
+        caster:printToPlayer(cooldownMsg, xi.msg.channel.SYSTEM_3)
+        return xi.msg.basic.TRUST_NO_CAST_TRUST
+    end
+
+    local wasSeekingParty = caster:isSeekingParty()
+
+    -- Temporarily disable LFP so base check passes
+    if wasSeekingParty then
+        caster:setSeekingParty(false)
+    end
+
+    -- Call the original canCast with all its checks
     local result = super(caster, spell, notAllowedTrustIds)
 
-    if result ~= 0 then
-        return result
+    -- If casting will succeed and player was LFP, schedule re-enable
+    if result == 0 and wasSeekingParty then
+        caster:timer(lfpRestoreDelay * 1000, function(player)
+            if player and player:isAlive() then
+                player:setSeekingParty(true)
+            end
+        end)
+    elseif wasSeekingParty then
+        -- Casting failed, immediately restore LFP
+        caster:setSeekingParty(true)
     end
 
-    local limit = 1
-    local trustAvailable = getNextAvailableTrustTime(caster)
-
-    -- Check if player has the trust limit variable set.
-    if
-        caster:getCharVar(trustLimitVar) ~= 0 and
-        caster:getMainLvl() >= 50
-    then
-        limit = 2
-    end
-
-    -- Check if player has summoned 2 trusts already.
-    local trusts = 0
-    for _, member in pairs(caster:getPartyWithTrusts()) do
-        if member:getObjType() == xi.objType.TRUST then
-            trusts = trusts + 1
-        end
-    end
-
-    if trusts >= limit then
-        caster:messageSystem(xi.msg.system.TRUST_MAXIMUM_NUMBER)
-        return -1
-    end
-
-    -- Check if player has both trusts variables on cooldown.
-    if trustAvailable ~= nil then
-        caster:printToPlayer(trustAvailable, xi.msg.channel.SYSTEM_3)
-        return -1
-    end
-
-    return 0
+    return result
 end)
 
 m:addOverride('xi.trust.spawn', function(caster, spell)
     super(caster, spell)
-    local now = os.time()
+    local now = GetSystemTime()
     local trustCdTimeStamp = now + trustCooldownTime
 
     -- When a player summons a trust, check if it's the first one they have summoned.

--- a/modules/zenith-public/lua/4-additive/commands/lfp.lua
+++ b/modules/zenith-public/lua/4-additive/commands/lfp.lua
@@ -1,0 +1,35 @@
+-----------------------------------
+-- func: lfp
+-- desc: Toggles Looking for Party flag, bypassing client restrictions with trusts
+--
+-- [ZENITH MOD] This command allows players to toggle their LFP status even
+-- when trusts are deployed, working around the client-side restriction.
+-----------------------------------
+---@type TCommand
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 0,  -- Available to all players
+    parameters = ''
+}
+
+commandObj.onTrigger = function(player)
+    local currentLfp = player:isSeekingParty()
+    local newLfp = not currentLfp
+
+    -- Use the entity method binding (from lfp_with_trusts.cpp)
+    local success = player:setSeekingParty(newLfp)
+
+    if success then
+        if newLfp then
+            player:printToPlayer('You are now seeking a party.', xi.msg.channel.SYSTEM_3)
+        else
+            player:printToPlayer('You are no longer seeking a party.', xi.msg.channel.SYSTEM_3)
+        end
+    else
+        player:printToPlayer('Failed to change party status.', xi.msg.channel.SYSTEM_3)
+    end
+end
+
+return commandObj


### PR DESCRIPTION
Adds LFP functionality while trusts are out, bypassing client restrictions.


**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds LFP functionality while trusts are out, bypassing client restrictions.

## Steps to test these changes

1. Summon a trust
2. run command !lfp
3. use other character to /sea all and you will see the character which had a trust deployed in LFP status.
4. !lfp can be run before you deploy trusts as well and the player will remain in lfp.
