### PR TITLE
Flume Toads Cast No Spells

### DIFF
--- a/modules/zenith-public/sql/flumeToadNoSpells.sql
+++ b/modules/zenith-public/sql/flumeToadNoSpells.sql
@@ -1,0 +1,5 @@
+-- Fix Flume Toad spell list
+-- Toads (family 111) should not cast magic
+-- The base mob_pools has spellList=2 (Beastmen_BLM) which is incorrect
+
+UPDATE mob_pools SET spellList = 0 WHERE poolid = 6378; -- Flume_Toad


### PR DESCRIPTION
Updated Flume Toads so they do not cast any spells.


**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates Flume Toads so they do no cast any spells

## Steps to test these changes

1. !gotoid 17469710
2. engage a flume toad
3. notice they no longer cast spells.
