### PR TITLE
hassoZanshinProcChanges

### DIFF
--- a/modules/zenith-public/git-patches/107-HassoZanshinNerf.patch
+++ b/modules/zenith-public/git-patches/107-HassoZanshinNerf.patch
@@ -1,0 +1,26 @@
+diff --git a/src/map/entities/battleentity.cpp b/src/map/entities/battleentity.cpp
+index a7b06338cb..5cd21215e8 100644
+--- a/src/map/entities/battleentity.cpp
++++ b/src/map/entities/battleentity.cpp
+@@ -2983,7 +2983,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
+             const bool normalZanshinProc = missedOrCountered && xirand::GetRandomNumber(100) < zanshinChance;
+ 
+             const bool isSamWithHasso   = GetMJob() == JOB_SAM && this->StatusEffectContainer->HasStatusEffect(EFFECT_HASSO);
+-            const bool hassoZanshinProc = isSamWithHasso && xirand::GetRandomNumber(100) < zanshinChance / 4;
++            const bool hassoZanshinProc = isSamWithHasso && xirand::GetRandomNumber(100) < zanshinChance / 8;
+ 
+             if (normalZanshinProc || hassoZanshinProc)
+             {
+diff --git a/src/map/utils/battleutils.cpp b/src/map/utils/battleutils.cpp
+index 9f7632fb6a..eaf06d8c13 100644
+--- a/src/map/utils/battleutils.cpp
++++ b/src/map/utils/battleutils.cpp
+@@ -3344,7 +3344,7 @@ uint8 CheckMultiHits(CBattleEntity* PEntity, CItemWeapon* PWeapon)
+                 zanshin += ((CCharEntity*)PEntity)->PMeritPoints->GetMeritValue(MERIT_ZASHIN_ATTACK_RATE, (CCharEntity*)PEntity);
+             }
+ 
+-            if (xirand::GetRandomNumber(100) < (zanshin / 4))
++            if (xirand::GetRandomNumber(100) < (zanshin / 8))
+             {
+                 num++;
+             }


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Zanshin received a bonus after the 75 Era ended that added a pseudo double attack effect to Hasso (separate from missing an attack). This by itself grants an 11% outside of equipment or traits. All of which combines to make something that needs to be nerfed.
Changes the Chance of the Proc by 1/2 of its default amount.

## Steps to test these changes

### 1. Prepare Test Character
```
!job SAM 75
!addspell all
```

### 2. Maximize Zanshin Rate (for clearer results)
Base Zanshin at 75 SAM = 35%
With merits (5/5) = +10% = 45%

```
!setmerits 65535  (or manually set Zanshin merits)
```

### 3. Find a Test Target
Use a low-evasion mob that won't die quickly:
```
!spawnmob <mob_id>
```
## Test Procedure

### Method A: Combat Log Analysis (Recommended)

1. **Enable Hasso**:
   ```
   /ja "Hasso" <me>
   ```

2. **Engage target and auto-attack for 100+ swings**
   - Count total successful melee hits (not misses)
   - Count Zanshin procs that occur AFTER successful hits

3. **Expected Results**:
   | Patch State | Zanshin Rate | Expected Procs per 100 Hits |
   |-------------|--------------|----------------------------|
   | Before      | ~11%         | 10-12 procs                |
   | After       | ~5.5%        | 4-7 procs                  |