### PR TITLE
thfEnimityRelance

### DIFF
--- a/modules/zenith-public/lua/4-additive/jobAbilities/thfEnimityRebalance.lua
+++ b/modules/zenith-public/lua/4-additive/jobAbilities/thfEnimityRebalance.lua
@@ -1,0 +1,131 @@
+-----------------------------------
+-- Thief Enmity Rebalance
+-- Custom modifications for ZenithXI
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('a-j_thf_enmity_rebal')
+
+-----------------------------------
+-- Sneak Attack & Trick Attack Recast Reduction
+-----------------------------------
+-- Reduces the recast time of Sneak Attack and Trick Attack
+-- based on the number of merit points spent in Ambush
+-- Each merit point reduces recast by 1 second
+local adjustRecast = function(player, ability)
+    local merits = player:getMerit(xi.merit.AMBUSH)
+
+    if merits > 0 then
+        -- Reduce recast timer by 1 second per merit point
+        -- Minimum recast is 0 seconds (instant)
+        ability:setRecast(math.max(0, ability:getRecast() - merits))
+    end
+end
+
+-----------------------------------
+-- Apply Recast Reduction to Sneak Attack
+-----------------------------------
+m:addOverride('xi.actions.abilities.sneak_attack.onAbilityCheck', function(player, target, ability)
+    adjustRecast(player, ability)
+
+    return super(player, target, ability)
+end)
+
+-----------------------------------
+-- Apply Recast Reduction to Trick Attack
+-----------------------------------
+m:addOverride('xi.actions.abilities.trick_attack.onAbilityCheck', function(player, target, ability)
+    adjustRecast(player, ability)
+
+    return super(player, target, ability)
+end)
+
+-----------------------------------
+-- Enhanced Trick Attack Enmity Transfer
+-----------------------------------
+-- When Trick Attack effect ends, transfers a portion of the Thief's
+-- enmity (hate) to the designated trick attack partner (tank/trust)
+-- The amount transferred scales with Thief level:
+-- - At level 75 THF: 50% of enmity is transferred
+-- - Lower levels transfer proportionally less (e.g., level 37 = 25%)
+--
+-- Flag usage:
+-- - TA_PROCESSING: Prevents recursive re-entry when we temporarily re-add TA
+--   (delStatusEffectSilent still triggers onEffectLose callbacks)
+-- - TA_TRANSFERRED: Prevents double transfer from game's double-application of TA
+--
+-- Limitation: Enmity transfer requires player to still be targeting the mob
+-- when the effect wears off. If target changes, transfer will not occur.
+m:addOverride('xi.effects.trick_attack.onEffectLose', function(player, effect)
+    -- Always call super first for proper effect cleanup (removes TRICK_ATK_AGI mod)
+    super(player, effect)
+
+    -- Prevent recursive re-entry during our temp effect manipulation
+    -- delStatusEffectSilent still triggers onEffectLose, so we must guard against it
+    if player:getLocalVar('TA_PROCESSING') == 1 then
+        return
+    end
+
+    -- Check if we already transferred enmity for this TA usage
+    -- The game applies TA twice, so onEffectLose fires twice per usage
+    if player:getLocalVar('TA_TRANSFERRED') == 1 then
+        player:setLocalVar('TA_TRANSFERRED', 0)
+        return
+    end
+
+    -- Calculate enmity transfer percentage based on Thief level
+    -- Main job THF uses main level, subjob THF uses sub level
+    -- Formula: 50% * (THF Level / 75)
+    -- Example: Level 75 THF = 50% transfer, Level 37 THF = 25% transfer
+    local thfLevel = 0
+    if player:getMainJob() == xi.job.THF then
+        thfLevel = player:getMainLvl()
+    elseif player:getSubJob() == xi.job.THF then
+        thfLevel = player:getSubLvl()
+    end
+
+    -- Exit if THF level is 0 (shouldn't happen, but guard against it)
+    if thfLevel == 0 then
+        return
+    end
+
+    local taEnmityPerc = 0.5 * thfLevel / 75
+    local pTarget = player:getTarget()
+
+    if pTarget then
+        -- Set processing flag to prevent recursive calls from delStatusEffectSilent
+        player:setLocalVar('TA_PROCESSING', 1)
+
+        -- Temporarily re-apply Trick Attack effect to identify the TA partner
+        -- This is needed because getTrickAttackChar requires the effect to be active
+        player:addStatusEffect(xi.effect.TRICK_ATTACK, 0, 0, 10)
+        local taTarget = player:getTrickAttackChar(pTarget)
+        player:delStatusEffectSilent(xi.effect.TRICK_ATTACK)
+
+        -- Clear processing flag
+        player:setLocalVar('TA_PROCESSING', 0)
+
+        if taTarget then
+            -- Get current enmity values
+            -- CE = Cumulative Enmity (permanent hate)
+            -- VE = Volatile Enmity (decaying hate)
+            local ce = pTarget:getCE(player)
+            local ve = pTarget:getVE(player)
+
+            -- Transfer calculated percentage of enmity from Thief to TA partner
+            -- The partner gains the transferred enmity
+            pTarget:setCE(taTarget, pTarget:getCE(taTarget) + ce * taEnmityPerc)
+            pTarget:setVE(taTarget, pTarget:getVE(taTarget) + ve * taEnmityPerc)
+
+            -- Reduce Thief's enmity by the transferred amount
+            -- Thief keeps the remaining percentage
+            pTarget:setCE(player, ce * (1 - taEnmityPerc))
+            pTarget:setVE(player, ve * (1 - taEnmityPerc))
+
+            -- Mark transfer complete to prevent double-transfer from game's double-application
+            player:setLocalVar('TA_TRANSFERRED', 1)
+        end
+    end
+end)
+
+return m


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

-- Reduces the recast time of Sneak Attack and Trick Attack
-- based on the number of merit points spent in Ambush
-- Each merit point reduces recast by 1 second

## Steps to test these changes

1. SA/TA Recast Reduction - Each Ambush merit reduces recast by 1 second
  2. TA Enmity Transfer - Transfers 50% of enmity to TA partner at level 75 THF (scales with level)


  Setup Commands

  !changejob THF 75         -- Set to THF level 75
  !addalltrusts             -- Unlock trusts (for TA partner)
  !reset                    -- Reset ability recasts


  Test 1: Recast Reduction (SA/TA)

  Baseline (0 merits):
  1. Use Sneak Attack, note default recast (60 seconds)
  2. !reset
  3. Use Trick Attack, note default recast (60 seconds)

  With Merits:
  1. Spend merit points on Ambush (via normal merit menu)
    - 1 merit = 1 second reduction
    - 5 merits = 5 second reduction (54 second recast)
  2. !reset
  3. Use Sneak Attack - verify recast is reduced
  4. !reset
  5. Use Trick Attack - verify recast is reduced

  Expected: Recast = 60 - (Ambush merits) seconds


  Test 2: TA Enmity Transfer

  Setup:
  1. !changejob THF 75
  2. Summon a tank trust (e.g., Valaineral, Trion)
  3. Find/engage a mob

  Test Procedure:
  1. Build enmity on mob (attack it, generate hate)
  2. !getenmity - Note your CE/VE values
  3. Position behind trust, facing mob
  4. Use Trick Attack
  5. Attack mob (weaponskill works best)
  6. !getenmity - Check new CE/VE values

  Expected Result at THF 75:
  - Your enmity reduced by ~50%
  - Trust gained that 50%

  Level Scaling Test:
  1. !changejob THF 37
  2. Repeat above steps
  3. Expected: ~25% transfer (37/75 * 50%)
