### PR TITLE
Adjustment To Crab Resistance to Blunt dmg

### DIFF
--- a/modules/zenith-public/sql/crab_blunt_weakness.sql
+++ b/modules/zenith-public/sql/crab_blunt_weakness.sql
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Crab Blunt/H2H Weakness
+-- Public Module for ZenithXI
+-----------------------------------
+-- Adds 25% weakness to blunt (impact) damage
+-- Adds 12.5% weakness to H2H damage
+-- Affects ALL crab variants (resist_ids: 75, 76, 77, 372, 400)
+-----------------------------------
+
+UPDATE `mob_resistances` SET `impact_sdt` = `impact_sdt` + 2500, `h2h_sdt` = `h2h_sdt` + 1250 WHERE `resist_id` IN (75, 76, 77, 372, 400);

--- a/modules/zenith-public/sql/crab_blunt_weakness.sql
+++ b/modules/zenith-public/sql/crab_blunt_weakness.sql
@@ -7,4 +7,4 @@
 -- Affects ALL crab variants (resist_ids: 75, 76, 77, 372, 400)
 -----------------------------------
 
-UPDATE `mob_resistances` SET `impact_sdt` = `impact_sdt` + 2500, `h2h_sdt` = `h2h_sdt` + 1250 WHERE `resist_id` IN (75, 76, 77, 372, 400);
+UPDATE `mob_resistances` SET `impact_sdt` = `impact_sdt` + 2500, `h2h_sdt` = `h2h_sdt` + 1250 WHERE `name` LIKE "Crab%";


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

-- Adds 25% weakness to blunt (impact) damage
-- Adds 12.5% weakness to H2H damage
-- Affects ALL crab variants (resist_ids: 75, 76, 77, 372, 400)

## Steps to test these changes

## Test Crab Mob IDs

Use these mob IDs with `!spawnmob`:

| Zone | Mob Name | Mob ID |
|------|----------|--------|
| Zeruhn Mines | Snipper | 17109023 |
| East Sarutabaruta | River Crab | 17109023-17109026 |
| Valkurm Dunes | Snipper | 16781313 |

---

## Test Cases

### Test 1: Verify Modifiers Applied
**Purpose:** Confirm the SDT modifiers are correctly set on crabs.

**Steps:**
1. Spawn a crab: `!spawnmob 17109023`
2. Target the crab
3. Check blunt modifier: `!getmod IMPACT_SDT`
   - **Expected:** 2500 (for standard crabs)
4. Check H2H modifier: `!getmod HTH_SDT`
   - **Expected:** 1250 (for standard crabs)

---

### Test 2: Blunt Damage Comparison
**Purpose:** Verify blunt weapons deal ~25% more damage than baseline.

**Setup:**
```
!changejob WAR 75
!godmode 1
!additem 17024
!additem 16535
```

**Steps:**
1. Spawn a crab: `!spawnmob 17109023`
2. Equip Bronze Sword (slashing) - record damage over 10 hits
3. Despawn and respawn crab
4. Equip Ash Club (blunt) - record damage over 10 hits
5. Compare average damage

**Expected Result:** Blunt damage should be ~25% higher than slashing damage.

---

### Test 3: H2H Damage Comparison
**Purpose:** Verify H2H deals ~12.5% more damage than baseline.

**Setup:**
```
!changejob MNK 75
!godmode 1
```

**Steps:**
1. Spawn a crab: `!spawnmob 17109023`
2. Attack with H2H - record damage over 10 hits
3. Compare to baseline (or slashing weapon damage from Test 2)

**Expected Result:** H2H damage should be ~12.5% higher than baseline slashing.

---

### Test 4: Non-Crab Mob Comparison
**Purpose:** Confirm other mobs are NOT affected.

**Steps:**
1. Find a non-crab mob (e.g., a beetle or bird)
2. Check modifiers: `!getmod IMPACT_SDT` and `!getmod HTH_SDT`
3. Attack with blunt weapon

**Expected Result:** Non-crab mobs should have 0 for these modifiers (unless they have their own resistances).

---

## Damage Calculation Reference

The damage formula applies SDT as:
```
finalDamage = baseDamage * (1 + SDT_VALUE / 10000)
```

| SDT Value | Effect |
|-----------|--------|
| 0 | No change (100% damage) |
| 2500 | +25% damage (125% total) |
| 1250 | +12.5% damage (112.5% total) |
| -5000 | -50% damage (50% total) |

---
