### PR TITLE
reverts A+ combat skill increases from 2014 update

### DIFF
--- a/modules/zenith-public/sql/revert_combat_skill_increases.sql
+++ b/modules/zenith-public/sql/revert_combat_skill_increases.sql
@@ -1,0 +1,21 @@
+--------------------------------
+-- Revert 2014 combat skill increases
+-- Public Module for ZenithXI
+--------------------------------
+
+-- 2014 update notes https://forum.square-enix.com/ffxi/threads/44539-dev1235-Job-Adjustments?p=526824#post526824
+
+-- THF Dagger skill from A+ to an A
+UPDATE `skill_ranks` SET `thf` = 2 WHERE `name` = 'dagger'; 
+
+-- NIN Katana skill from A+ to an A
+UPDATE `skill_ranks` SET `nin` = 2 WHERE `name` = 'katana';
+
+-- BLU Sword skill from A+ to an A
+UPDATE `skill_ranks` SET `blu` = 2 WHERE `name` = 'sword';
+
+-- PUP H2H skill from A+ to a B+
+UPDATE `skill_ranks` SET `pup` = 3 WHERE `name` = 'hand2hand';
+
+-- DNC Dagger skill from A+ to B+
+UPDATE `skill_ranks` SET `dnc` = 3 WHERE `name` = 'dagger';


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Reverts A+ combat skills that were added in a 2014 update that can referenced here: https://forum.square-enix.com/ffxi/threads/44539-dev1235-Job-Adjustments?p=526824#post526824

## Steps to test these changes

make sure all skills are capped !capallskills
change job to 75 and check for each of the following:

THF - Dagger Skill 269
NIN - Katana Skill 269
BLU - Sword Skill 269
PUP - H2H Skill 256
DNC - Dagger Skill 256

example: !changejob thf 75

for reference:

THF Dagger skill from A+ to an A
NIN Katana skill from A+ to an A
BLU Sword skill from A+ to an A
PUP H2H skill from A+ to a B+
DNC Dagger skill from A+ to B+

         A+    A     B+   B      B-    C+   C     C-    D      E      F      G
[75] = { 276, 269, 256, 250, 240, 230, 225, 220, 210, 200, 189, 171 },


