### PR TITLE
Berserk-ComposureAbilityUpdate

### DIFF
--- a/modules/zenith-public/lua/2-base/abilities.lua
+++ b/modules/zenith-public/lua/2-base/abilities.lua
@@ -1,6 +1,6 @@
 require('modules/module_utils')
 
-local m = Module:new('abilities')
+local m = Module:new('b_abilities')
 
 local effectAdjustments =
 {
@@ -11,14 +11,6 @@ local effectAdjustments =
         add =
         {
             power = -10, -- Changed from 20% to 10%
-        },
-    },
-    berserk =
-    {
-        effectId = xi.effect.BERSERK,
-        set =
-        {
-            power = 25, -- Force static 25% modifiers (ignoring BERSERK_POTENCY)
         },
     },
     defender =

--- a/modules/zenith-public/lua/3-complete/jobAbilities/berserk.lua
+++ b/modules/zenith-public/lua/3-complete/jobAbilities/berserk.lua
@@ -1,0 +1,21 @@
+local m = Module:new('c-j_berserk')
+
+-----------------------------------
+-- Berserk Effect Override
+-- 25 + BERSERK_POTENCY (no level scaling)
+-----------------------------------
+
+m:addOverride('xi.effects.berserk.onEffectGain', function(target, effect)
+    local power    = 25 + target:getMod(xi.mod.BERSERK_POTENCY)
+    local jpEffect = target:getJobPointLevel(xi.jp.BERSERK_EFFECT) * 2
+
+    effect:addMod(xi.mod.ATTP, power)
+    effect:addMod(xi.mod.RATTP, power)
+    effect:addMod(xi.mod.DEFP, -25)
+
+    -- Job Point Bonuses
+    effect:addMod(xi.mod.ATT, jpEffect)
+    effect:addMod(xi.mod.RATT, jpEffect)
+end)
+
+return m

--- a/modules/zenith-public/lua/3-complete/jobAbilities/composure.lua
+++ b/modules/zenith-public/lua/3-complete/jobAbilities/composure.lua
@@ -1,0 +1,15 @@
+local m = Module:new('c-j_composure')
+
+-----------------------------------
+-- Composure Effect Override
+-- Era accuracy bonus: floor(level/5)
+-- Pre 8 Feb 2019 behavior
+-----------------------------------
+
+m:addOverride('xi.effects.composure.onEffectGain', function(target, effect)
+    local power = math.floor(target:getMainLvl() / 5)
+
+    effect:addMod(xi.mod.ACC, power)
+end)
+
+return m


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

berserkl now respects equipment mods, Composure now at era values

## Steps to test these changes

# Abilities Module Test Plan

## Berserk Tests

**Formula**: `25 + BERSERK_POTENCY` (no level scaling)

### Test 1: Base Berserk (No Conqueror)

```
!changejob WAR 75
!reset
!getstats offensive
```
Note the **Total Attack** value, then:
```
/ja "Berserk" <me>
!getstats offensive
```

**Expected**: Attack increased by exactly **25%**

---

### Test 2: Berserk with Conqueror +3

```
!changejob WAR 75
!additem 18991
```
Equip Conqueror in main hand, then:
```
!getmod BERSERK_POTENCY
```
**Expected**: Shows `BERSERK_POTENCY is 5`

```
!reset
!getstats offensive
```
Note the **Total Attack** value, then:
```
/ja "Berserk" <me>
!getstats offensive
```

**Expected**: Total Attack increased by **30%** (25 base + 5 from Conqueror)

---

### Test 3: Verify No Level Scaling

```
!changejob WAR 50
!deleffect BERSERK
!reset
!getstats offensive
```
Note the **Total Attack** value, then:
```
/ja "Berserk" <me>
!getstats offensive
```

**Expected**: Attack increased by exactly **25%**

## Composure Tests

**Formula**: `floor(level / 5)` ACC bonus (Era behavior, replaces retail formula)

### Test 1: Composure at Level 75

```
!changejob RDM 75
!deleffect COMPOSURE
!reset
!getstats offensive
```
Note the **Accuracy Base** value, then:
```
/ja "Composure" <me>
!getstats offensive
```

**Expected**: Accuracy Base increased by **+15** (floor(75/5) = 15)

---

### Test 2: Composure at Level 99

```
!setplayerlevel 99
!deleffect COMPOSURE
!reset
!getstats offensive
```
Note the **Accuracy Base** value, then:
```
/ja "Composure" <me>
!getstats offensive
```

**Expected**: Accuracy Base increased by **+19** (floor(99/5) = 19)

---

### Test 3: Composure at Level 50

```
!setplayerlevel 50
!deleffect COMPOSURE
!reset
!getstats offensive
```
Note the **Accuracy Base** value, then:
```
/ja "Composure" <me>
!getstats offensive
```

**Expected**: Accuracy Base increased by **+10** (floor(50/5) = 10)


