### PR TITLE
Reward Nation Rings at creation regardless of race

### DIFF
--- a/modules/zenith-public/lua/2-base/nation_rings_all_races.lua
+++ b/modules/zenith-public/lua/2-base/nation_rings_all_races.lua
@@ -1,0 +1,32 @@
+-----------------------------------
+-- Module: Nation Rings for All Races
+-- Ensures all new characters receive the nation ring for their
+-- chosen starting nation, regardless of race selection.
+--
+-- Base behavior only gives the ring if the race's "home nation"
+-- matches the chosen nation. This module removes that restriction.
+-----------------------------------
+local m = Module:new('b_nation_rings_all_races')
+
+-- Map nations to their corresponding rings
+local nationRings =
+{
+    [xi.nation.SANDORIA] = xi.item.SAN_DORIAN_RING,
+    [xi.nation.BASTOK]   = xi.item.BASTOKAN_RING,
+    [xi.nation.WINDURST] = xi.item.WINDURSTIAN_RING,
+}
+
+m:addOverride('xi.player.charCreate', function(player)
+    -- Call the original charCreate function
+    super(player)
+
+    -- Ensure player has their nation's ring regardless of race
+    local nation = player:getNation()
+    local ringId = nationRings[nation]
+
+    if ringId and not player:hasItem(ringId) then
+        player:addItem(ringId)
+    end
+end)
+
+return m


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Allow the Nation Ring to be issued to new players regardless of their race and nation combination.  For example, a Mithra can start in Sandoria and will still get a Sandoria nation ring at start.

## Steps to test these changes

Create a new Character.
New Character should have a nation ring based on their starting nation.
