### PR TITLE
[sql] Enable and update the values of Tandem Strike

### DIFF
--- a/modules/zenith-public/sql/TraitsAndJAs.sql
+++ b/modules/zenith-public/sql/TraitsAndJAs.sql
@@ -189,6 +189,11 @@ UPDATE `traits` SET `value` = 5 WHERE `name` = 'shield def. bonus' AND `rank` = 
 -- UPDATE `traits` SET `value` = 7 WHERE `name` = 'dead aim' AND `rank` = 2; -- Dead Aim II, +7% critical hit damage -- TODO: Not yet implemented
 -- UPDATE `traits` SET `value` = 9 WHERE `name` = 'dead aim' AND `rank` = 3; -- Dead Aim II, +9% critical hit damage -- TODO: Not yet implemented
 
+UPDATE `traits` SET `value` = 5 WHERE `name` = 'tandem strike' AND `rank` = 1;    -- Tandem Strike I, +5 Acc/Macc
+UPDATE `traits` SET `value` = 10 WHERE `name` = 'tandem strike' AND `rank` = 2;   -- Tandem Strike II, +10 Acc/Macc
+UPDATE `traits` SET `value` = 15 WHERE `name` = 'tandem strike' AND `rank` = 3;   -- Tandem Strike III, +15 Acc/Macc
+UPDATE `traits` SET `value` = 20 WHERE `name` = 'tandem strike' AND `rank` = 4;   -- Tandem Strike IV, +20 Acc/Macc
+
 UPDATE `traits` SET `value` = 10 WHERE `name` = 'daken' AND `rank` = 1; -- Daken I, 10%
 UPDATE `traits` SET `value` = 12 WHERE `name` = 'daken' AND `rank` = 2; -- Daken II, 12%
 UPDATE `traits` SET `value` = 14 WHERE `name` = 'daken' AND `rank` = 3; -- Daken III, 14%
@@ -379,6 +384,8 @@ UPDATE `traits` SET `content_tag`= NULL WHERE `name` IN (
     'lizard killer',
     'plantoid killer',
     'vermin killer',
+    'tandem strike',
+    'tandem blow',
     'crit. def. bonus',
     'dead aim',
     'daken',


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Enables Tandem Strike and Tandem Blow for BST.
- Updates the values of Tandem Strike. Cuts the bonus in half.
- Level 30 +5 Acc
- Level 45 +10 Acc
- Level 60 +15 Acc
- Level 75 +20 Acc

## Steps to test these changes

- Run dbtool
- Observe tags and values are updated.