### PR TITLE
fix ph on mob despawn module

### DIFF
--- a/modules/zenith-public/lua/2-base/phOnMobDespawn.lua
+++ b/modules/zenith-public/lua/2-base/phOnMobDespawn.lua
@@ -9,7 +9,7 @@
 --   - If the NM has spawned
 -----------------------------------
 
-local m = Module:new('phOnDespawn')
+local m = Module:new('b_phOnDespawn')
 
 local nmParamChanges =
 {
@@ -115,7 +115,7 @@ m:addOverride('xi.mob.phOnDespawn', function(ph, phNmId, chance, cooldown, param
     end
 
     -- call the original function with adjusted values
-    local superResults = super(ph, phList, chance, cooldown, params)
+    local superResults = super(ph, phNmId, chance, cooldown, params)
 
     -- reset counter if NM gets spawned
     if nm then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When `phList` is `nil`, the original function's `GetMobByID(phNmId)` at `mobs.lua:107` fails because it receives `nil` instead of a number. 

## Steps to test these changes

NA
