### PR TITLE
fixRegimes edge case

### DIFF
--- a/modules/zenith-public/lua/2-base/regimes.lua
+++ b/modules/zenith-public/lua/2-base/regimes.lua
@@ -1,6 +1,10 @@
 local m = Module:new('b_regimes')
 
 m:addOverride('xi.regime.checkRegime', function(player, mob, regimeId, index, regimeType)
+    if not player then
+        return
+    end
+
     local vanadielEpoch = VanadielUniqueDay()
     local localVarName = 'regimeReminder'
     if player:getCharVar('[regime]lastReward') < vanadielEpoch then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When a mob dies without a player killer (DoT, environmental, trusts, etc.), player is nil in the onMobDeath callback. The original xi.regime.checkRegime handles this with a not player check at line 1371, but the module override was calling player methods before delegating to super().

## Steps to test these changes

NA
