### PR TITLE
Fix for Ice Wall Quest

### DIFF
--- a/modules/zenith-public/lua/3-complete/ice_wall_quest.lua
+++ b/modules/zenith-public/lua/3-complete/ice_wall_quest.lua
@@ -6,36 +6,46 @@
 -- Players can trade a Fire Cluster to open the wall.
 -- -----------------------------------
 
-local m = Module:new('ice_wall_quest')
+local m = Module:new('c_ice_wall_quest')
 
 local ID = zones[xi.zone.ULEGUERAND_RANGE]
 local npcName = 'Ice Wall'
+
 local checkWaterfall = function(player)
     local waterfall = GetNPCByID(ID.npc.WATERFALL)
 
-    local waterfallOpen = waterfall:getAnimation() ~= xi.anim.OPEN_DOOR
+    -- CLOSE_DOOR = ice wall closed (blocking), OPEN_DOOR = ice wall open (path clear)
+    local waterfallBlocked = waterfall:getAnimation() == xi.anim.CLOSE_DOOR
 
-    if not waterfallOpen then
+    if not waterfallBlocked then
         player:fmt('{} : The path is currently clear!', npcName)
     end
 
-    return waterfallOpen
+    return waterfallBlocked
 end
 
 local openWaterfall = function(player)
     -- can't just use :openDoor(30) because we need to check the weather before closing it
     local waterfall = GetNPCByID(ID.npc.WATERFALL)
+
+    -- Mark as temporarily melted so weather changes don't re-block immediately
+    waterfall:setLocalVar('melted', 1)
+
+    -- OPEN_DOOR = open the path (melt the ice wall)
     waterfall:setAnimation(xi.anim.OPEN_DOOR)
 
-    -- close door after 30s, unless weather changed in that time
+    -- Re-close ice wall after 30s if weather is still snowy
     waterfall:timer(30000, function(npcArg)
+        -- Clear the melted state
+        npcArg:setLocalVar('melted', 0)
+
         local weather = npcArg:getZone():getWeather()
 
         if
-        npcArg:actionQueueEmpty() and -- don't close the door if someone else traded while it was open
-        (weather == xi.weather.SNOW or
-        weather == xi.weather.BLIZZARDS)
+            npcArg:actionQueueEmpty() and -- don't close the door if someone else traded while it was open
+            (weather == xi.weather.SNOW or weather == xi.weather.BLIZZARDS)
         then
+            -- CLOSE_DOOR = close ice wall (block the path)
             npcArg:setAnimation(xi.anim.CLOSE_DOOR)
         end
     end)
@@ -111,5 +121,29 @@ LQS.add(m, {
         },
     },
 })
+
+-- Override Zone weather change to respect temporarily melted state
+m:addOverride('xi.zones.Uleguerand_Range.Zone.onZoneWeatherChange', function(weather)
+    local waterfall = GetNPCByID(ID.npc.WATERFALL)
+
+    if waterfall then
+        -- Check if waterfall was temporarily melted by quest
+        if waterfall:getLocalVar('melted') == 1 then
+            return
+        end
+
+        if weather == xi.weather.SNOW or weather == xi.weather.BLIZZARDS then
+            -- CLOSE_DOOR = ice wall closed (blocking path)
+            if waterfall:getAnimation() ~= xi.anim.CLOSE_DOOR then
+                waterfall:setAnimation(xi.anim.CLOSE_DOOR)
+            end
+        else
+            -- OPEN_DOOR = ice wall open (path clear)
+            if waterfall:getAnimation() ~= xi.anim.OPEN_DOOR then
+                waterfall:setAnimation(xi.anim.OPEN_DOOR)
+            end
+        end
+    end
+end)
 
 return m


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixed Ice Wall quest so that it properly removes the ice wall in Uleguerand Range for 30 second and doesnt interfere with the walls normal spawning logic

## Steps to test these changes

!pos 4 -180 67 5        # Teleport to the ice wall area
  !weather 12              # Set Snow - ice wall should be VISIBLE
  !weather 0              # Set Clear - ice wall should be HIDDEN
  !weather 13              # Set Snow again - ice wall VISIBLE
!additem FIRE_CLUSTER  
Trade Fire Cluster    # Wall disappears for 30 seconds
Wait 30 seconds       # Wall reappears
