### PR TITLE
Halves the attack bonus of Impetus

### DIFF
--- a/scripts/effects/impetus.lua
+++ b/scripts/effects/impetus.lua
@@ -13,7 +13,7 @@ effectObject.onEffectGain = function(target, effect)
     local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
 
     if mainPower > 0 then
-        target:addMod(xi.mod.ATT, mainPower * 2)
+        target:addMod(xi.mod.ATT, mainPower)
         target:addMod(xi.mod.CRITHITRATE, mainPower)
     end
 
@@ -35,7 +35,7 @@ effectObject.onEffectLose = function(target, effect)
     local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
 
     if mainPower > 0 then
-        target:delMod(xi.mod.ATT, mainPower * 2)
+        target:delMod(xi.mod.ATT, mainPower)
         target:delMod(xi.mod.CRITHITRATE, mainPower)
     end
 

--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -154,7 +154,7 @@ xi.job_utils.monk.impetusMissListener = function(attacker, victim, attack)
         local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
 
         if mainPower > 0 then
-            attacker:delMod(xi.mod.ATT, mainPower * 2)
+            attacker:delMod(xi.mod.ATT, mainPower)
             attacker:delMod(xi.mod.CRITHITRATE, mainPower)
 
             effect:setPower(0)
@@ -179,7 +179,7 @@ xi.job_utils.monk.impetusHitListener = function(attacker, victim, attack)
         local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
 
         if mainPower < 50 then
-            attacker:addMod(xi.mod.ATT, 2)
+            attacker:addMod(xi.mod.ATT, 1)
             attacker:addMod(xi.mod.CRITHITRATE, 1)
 
             effect:setPower(mainPower + 1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Impetus grants +2 attack for every attack until a miss occurs and resets the bonus. 
This change reduces the attack bonus from +2  to +1 attack.

monk.lua handles listeners and power scaling
Impetus.lua handles application and removal of the effect

modified both files to only add 1 attack per hit and to reset the miss at a multiple of 1 instead of 2.

## Steps to test these changes

record base attack power before impetus.
during the use of impetus:
- make sure each hit is only increasing attack power by 1.
- make sure each miss reduces power back to base
- make sure losing the effect reduces power back to base
- does d/c rebuild effect properly after reconnecting

