### PR TITLE
Feature/refactor impetus clean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**LandSandBoat** is an open-source server emulator for Final Fantasy XI (FFXI). It is a multi-process C++20 game server with Lua scripting and a MariaDB database backend.
+
+## Build Commands
+
+```bash
+# Configure (Release)
+cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+# Configure (Debug)
+cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Debug
+
+# Build
+cmake --build build
+
+# Build specific target (e.g., xi_map)
+cmake --build build --target xi_map
+```
+
+CMake presets are defined in `CMakeSettings.json` for MSVC: `x64-Release`, `x64-Debug`, `x64-Release-Tracy`, `x64-Debug-Tracy`.
+
+## Testing
+
+```bash
+# Run all unit tests
+./xi_test
+
+# Run with output report
+./xi_test --keep-going --output tests.ctrf.json
+```
+
+Full CI test suite also includes:
+- `./tools/ci/sanity_checks.sh` — code sanity checks
+- `python ./tools/ci/lua_lang_server.py` — Lua language server lint
+- `python -m tools.ci.startup_checks` — server startup integration tests (requires running servers)
+
+## Linting / Formatting
+
+```bash
+# Format C++ code
+python ./tools/run_clang_format.py
+
+# Clang-tidy (static analysis, slow — used in CI)
+cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_CLANG_TIDY=ON
+cmake --build build
+```
+
+Style is configured via `.clang-format` (WebKit base + Allman braces) and `.clang-tidy`.
+
+## Architecture
+
+### Server Processes
+
+The emulator runs as five separate processes that communicate via **ZeroMQ (ZMQ)**:
+
+| Binary | Role | Key Ports |
+|--------|------|-----------|
+| `xi_connect` | Login/auth server | 54001, 54230–54231 |
+| `xi_map` | Game world simulation (combat, AI, entities) | 54230 UDP |
+| `xi_world` | Global coordination between map instances; HTTP API | 8088 |
+| `xi_search` | Auction house / search | 54002 |
+| `xi_test` | Test executable | — |
+
+Source for each lives under `src/<name>/`. Shared utilities are in `src/common/`.
+
+### IPC Stubs
+
+Inter-process RPC stubs are **auto-generated** from definitions. After modifying IPC definitions, regenerate with:
+```bash
+python tools/generate_ipc_stubs.py
+```
+
+### Scripting Layer
+
+Game content is implemented in **Lua (LuaJIT)**. Lua scripts are in `scripts/` and era-specific content overrides live in `modules/`. Modules are enabled via `modules/init.txt`.
+
+### Database
+
+MariaDB is used for persistence. Schema migrations are managed with:
+```bash
+python ./tools/dbtool.py update
+```
+
+SQL scripts are in `sql/`.
+
+### Key Directories
+
+| Path | Purpose |
+|------|---------|
+| `src/common/` | Shared C++ utilities, DB layer, crypto, logging, types |
+| `src/map/` | Core game logic — entities, combat, AI, zones |
+| `src/login/` | Authentication flow |
+| `src/world/` | Cross-map coordination, global state |
+| `modules/` | Era/custom content modules (Lua + optional C++) |
+| `settings/` | Lua-based server configuration |
+| `tools/` | Build helpers, DB management, CI scripts |
+| `sql/` | Database schema and migrations |
+| `navmeshes/` | AI pathfinding data (git submodule) |
+| `losmeshes/` | Line-of-sight mesh data |
+| `documentation/` | Game mechanics docs, animation/ID reference data |
+
+## Code Conventions
+
+- C++20 throughout; avoid older patterns when modern equivalents exist.
+- Run `python ./tools/run_clang_format.py` before committing C++ changes.
+- Lua files should pass the Lua language server check (`tools/ci/lua_lang_server.py`).
+- New IPC messages require regenerating stubs via `tools/generate_ipc_stubs.py`.

--- a/scripts/effects/impetus.lua
+++ b/scripts/effects/impetus.lua
@@ -7,42 +7,15 @@ local effectObject = {}
 effectObject.onEffectGain = function(target, effect)
     target:addListener('MELEE_SWING_MISS', 'IMPETUS_MISS', xi.job_utils.monk.impetusMissListener)
     target:addListener('MELEE_SWING_HIT', 'IMPETUS_HIT', xi.job_utils.monk.impetusHitListener)
-
-    -- For reload from the DB (/logout, login), add the effect power
-    local mainPower = effect:getPower()    -- Stores Attack & Critical Hit Rate bonuses
-    local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
-
-    if mainPower > 0 then
-        target:addMod(xi.mod.ATT, mainPower * 2)
-        target:addMod(xi.mod.CRITHITRATE, mainPower)
-    end
-
-    if subPower > 0 then
-        target:addMod(xi.mod.ACC, subPower * 2)
-        target:addMod(xi.mod.CRIT_DMG_INCREASE, subPower)
-    end
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:removeListener('MELEE_SWING_MISS')
-    target:removeListener('MELEE_SWING_HIT')
-
     -- TODO: Support Tantra Cyclas + 1 (does not give critical hit damage)
-    local mainPower = effect:getPower()    -- Stores Attack & Critical Hit Rate bonuses
-    local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
-
-    if mainPower > 0 then
-        target:delMod(xi.mod.ATT, mainPower * 2)
-        target:delMod(xi.mod.CRITHITRATE, mainPower)
-    end
-
-    if subPower > 0 then
-        target:delMod(xi.mod.ACC, subPower * 2)
-        target:delMod(xi.mod.CRIT_DMG_INCREASE, subPower)
-    end
+    target:removeListener('IMPETUS_MISS')
+    target:removeListener('IMPETUS_HIT')
 end
 
 return effectObject

--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -144,26 +144,35 @@ xi.job_utils.monk.useHundredFists = function(player, target, ability)
     return xi.effect.HUNDRED_FISTS
 end
 
+local IMPETUS =
+{
+    ATT_PER_STACK       = 2,
+    CRIT_RATE_PER_STACK = 1,
+    ACC_PER_STACK       = 2,
+    CRIT_DMG_PER_STACK  = 1,
+    MAX_STACKS          = 50,
+}
+
+xi.job_utils.monk.IMPETUS = IMPETUS
+
 -- TODO: Support Tantra Cyclas + 1 (does not give critical hit damage)
 -- Probably will be exceptionally jank, very low priority
 xi.job_utils.monk.impetusMissListener = function(attacker, victim, attack)
     local effect = attacker:getStatusEffect(xi.effect.IMPETUS)
 
     if effect then
-        local mainPower = effect:getPower()    -- Stores Attack & Critical Hit Rate bonuses
-        local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
+        local stacks    = effect:getPower()    -- Number of main stacks (ATT / Crit Rate)
+        local subStacks = effect:getSubPower() -- Number of sub stacks (ACC / Crit DMG)
 
-        if mainPower > 0 then
-            attacker:delMod(xi.mod.ATT, mainPower * 2)
-            attacker:delMod(xi.mod.CRITHITRATE, mainPower)
-
+        if stacks > 0 then
+            effect:addMod(xi.mod.ATT, -(stacks * IMPETUS.ATT_PER_STACK))
+            effect:addMod(xi.mod.CRITHITRATE, -(stacks * IMPETUS.CRIT_RATE_PER_STACK))
             effect:setPower(0)
         end
 
-        if subPower > 0 then
-            attacker:delMod(xi.mod.ACC, subPower * 2)
-            attacker:delMod(xi.mod.CRIT_DMG_INCREASE, subPower)
-
+        if subStacks > 0 then
+            effect:addMod(xi.mod.ACC, -(subStacks * IMPETUS.ACC_PER_STACK))
+            effect:addMod(xi.mod.CRIT_DMG_INCREASE, -(subStacks * IMPETUS.CRIT_DMG_PER_STACK))
             effect:setSubPower(0)
         end
     end
@@ -172,24 +181,24 @@ end
 -- TODO: Support Tantra Cyclas + 1 (does not give critical hit damage)
 -- Probably will be exceptionally jank, very low priority
 xi.job_utils.monk.impetusHitListener = function(attacker, victim, attack)
+    print('[IMPETUS DEBUG] impetusHitListener fired')
     local effect = attacker:getStatusEffect(xi.effect.IMPETUS)
+    print('[IMPETUS DEBUG] effect = ' .. tostring(effect))
 
     if effect then
-        local mainPower = effect:getPower()    -- Stores Attack & Critical Hit Rate bonuses
-        local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
+        local stacks    = effect:getPower()    -- Number of main stacks (ATT / Crit Rate)
+        local subStacks = effect:getSubPower() -- Number of sub stacks (ACC / Crit DMG)
 
-        if mainPower < 50 then
-            attacker:addMod(xi.mod.ATT, 2)
-            attacker:addMod(xi.mod.CRITHITRATE, 1)
-
-            effect:setPower(mainPower + 1)
+        if stacks < IMPETUS.MAX_STACKS then
+            effect:addMod(xi.mod.ATT, IMPETUS.ATT_PER_STACK)
+            effect:addMod(xi.mod.CRITHITRATE, IMPETUS.CRIT_RATE_PER_STACK)
+            effect:setPower(stacks + 1)
         end
 
-        if attacker:getMod(xi.mod.AUGMENTS_IMPETUS) > 0 and subPower < 50 then
-            attacker:addMod(xi.mod.ACC, 2)
-            attacker:addMod(xi.mod.CRIT_DMG_INCREASE, 1)
-
-            effect:setSubPower(subPower + 1)
+        if attacker:getMod(xi.mod.AUGMENTS_IMPETUS) > 0 and subStacks < IMPETUS.MAX_STACKS then
+            effect:addMod(xi.mod.ACC, IMPETUS.ACC_PER_STACK)
+            effect:addMod(xi.mod.CRIT_DMG_INCREASE, IMPETUS.CRIT_DMG_PER_STACK)
+            effect:setSubPower(subStacks + 1)
         end
     end
 end

--- a/scripts/zones/Castle_Oztroja/mobs/Tzee_Xicu_the_Manifest.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Tzee_Xicu_the_Manifest.lua
@@ -66,7 +66,10 @@ entity.spawnPoints =
 entity.onMobInitialize = function(mob)
     xi.pet.setMobPet(mob, 1, 'Yagudos_Elemental')
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+<<<<<<< HEAD
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+=======
+>>>>>>> 6cde7b8063 (Convert "Paralyze" AEs and cleanup affected mob scripts)
 end
 
 entity.onMobSpawn = function(mob)
@@ -93,10 +96,14 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
+<<<<<<< HEAD
     if player then
         player:addTitle(xi.title.DEITY_DEBUNKER)
     end
 
+=======
+    player:addTitle(xi.title.DEITY_DEBUNKER)
+>>>>>>> 6cde7b8063 (Convert "Paralyze" AEs and cleanup affected mob scripts)
     if optParams.isKiller or optParams.noKiller then
         mob:showText(mob, ID.text.YAGUDO_KING_DEATH)
     end

--- a/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
+++ b/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
@@ -60,6 +60,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
+<<<<<<< HEAD
     local pTable =
     {
         chance   = 25,
@@ -70,6 +71,24 @@ entity.onAdditionalEffect = function(mob, target, damage)
 
     return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)
 end
+=======
+    -- TODO: All en-spells overwrite innate additional effects. The check should probably be contained in this functions already.
+    if mob:hasStatusEffect(xi.effect.ENWATER) then
+        return 0, 0, 0
+    else
+        local pTable =
+        {
+            chance   = 25,
+            effectId = xi.effect.PARALYSIS,
+            power    = 20,
+            duration = 60,
+        }
+
+        return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)
+    end
+end
+
+>>>>>>> 6cde7b8063 (Convert "Paralyze" AEs and cleanup affected mob scripts)
 
 entity.onMobDespawn = function(mob)
     xi.mob.updateNMSpawnPoint(mob)

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Voluptuous_Vilma.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Voluptuous_Vilma.lua
@@ -35,11 +35,19 @@ end
 
 entity.onAdditionalEffect = function(mob, target, damage)
     -- Vilma randomly effects its target with one of the following effects
+<<<<<<< HEAD
     local effectTable =
     {
         [1] = xi.effect.BLINDNESS,
         [2] = xi.effect.BIND,
         [3] = xi.effect.PARALYSIS,
+=======
+    local effectTable
+    {
+        [1] = xi.effect.BLINDNESS,
+        [2] = xi.effect.BIND,
+        [3] = xi.effect.PARALYZE,
+>>>>>>> 6cde7b8063 (Convert "Paralyze" AEs and cleanup affected mob scripts)
         [4] = xi.effect.POISON,
         [5] = xi.effect.SILENCE,
         [6] = xi.effect.SLOW,
@@ -49,7 +57,11 @@ entity.onAdditionalEffect = function(mob, target, damage)
     local pTable =
     {
         chance   = 25,
+<<<<<<< HEAD
         effectId = effectTable[math.random(1, #effectTable)],
+=======
+        effectId = effects[math.random(1, #effects)],
+>>>>>>> 6cde7b8063 (Convert "Paralyze" AEs and cleanup affected mob scripts)
         power    = 20,
         duration = 60,
     }

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -72,6 +72,7 @@ INSERT INTO `mob_groups` VALUES (3,6765,2,'Clipper_fished',0,128,93,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,5868,2,'Greater_Pugil_fished',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,1347,2,'Fishtrap',0,128,834,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,382,2,'Beady_Beetle',300,0,249,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,3164,2,'Poison_Funguar',300,0,2009,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,3724,2,'Specter_Bat',300,2,386,0,0,0,NULL);
@@ -119,6 +120,55 @@ INSERT INTO `mob_groups` VALUES (49,576,2,'Bullheaded_Grosvez',0,128,0,0,0,0,NUL
 INSERT INTO `mob_groups` VALUES (50,2784,2,'Mycophile',0,128,1761,2500,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (51,1934,2,'Hercules_Beetle',0,128,1303,2238,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (52,6809,2,'Orcfeltrap',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,382,2,'Beady_Beetle',300,0,249,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,3164,2,'Poison_Funguar',300,0,2009,0,0,16,19,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3724,2,'Specter_Bat',300,2,386,0,0,15,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,575,2,'Bulldog_Bats',300,2,80,0,0,15,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1036,2,'Digger_Wasp',300,0,652,0,0,14,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1622,2,'Glide_Bomb',300,8,216,0,0,20,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3912,2,'Thunder_Elemental',300,4,2410,0,0,29,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1375,2,'Flytrap',300,0,852,0,0,18,22,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3017,2,'Orcish_Grunt',300,0,1913,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3033,2,'Orcish_Stonechucker',300,0,1913,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3023,2,'Orcish_Neckchopper',300,0,1913,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,2373,2,'Land_Pugil',300,0,463,0,0,17,19,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4309,2,'Water_Elemental',300,4,2629,0,0,29,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3752,2,'Stag_Beetle',300,0,2318,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,371,2,'Battrap',300,0,852,0,0,23,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3009,2,'Orcish_Fighter',300,0,283,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,3004,2,'Orcish_Cursemaker',300,0,283,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,3032,2,'Orcish_Serjeant',300,0,283,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1518,2,'Ghoul_blm',300,1,958,0,0,21,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1517,2,'Ghoul_war',300,1,958,0,0,21,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,5135,2,'Marsh_Funguar',300,0,1632,0,0,20,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,4345,2,'Will-o-the-Wisp',300,8,569,0,0,25,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1406,2,'Forest_Tiger',300,0,896,0,0,22,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1409,2,'Fosse_Pugil',300,0,463,0,0,22,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,3728,2,'Spider_Wasp',300,0,2305,0,0,19,22,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,4528,2,'Tempest_Tigon',3600,0,2895,3000,0,43,43,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (32,1065,2,'Diving_Beetle',300,0,169,0,0,27,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,421,2,'Birdtrap',300,0,852,0,0,29,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,3424,2,'Sabertooth_Tiger',300,0,2136,0,0,29,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,6570,2,'Wight_blm',300,1,2650,0,0,28,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,3747,2,'Spunkie',300,8,569,0,0,32,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,4319,2,'Wendigo_war',300,1,958,0,0,28,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,3614,2,'Shrieker',300,0,2243,0,0,28,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,3047,2,'Orctrap',0,32,2847,2700,0,37,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,3733,2,'Spinous_Pugil',300,0,279,0,0,29,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,3072,2,'Overgrown_Ivy',0,128,0,4500,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,851,2,'Cryptonberry_Executor',0,128,0,5000,0,68,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,847,2,'Cryptonberry_Assassin',0,128,0,4500,0,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,4833,2,'Cryptonberry_Assassin',0,128,0,4500,0,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,4834,2,'Cryptonberry_Assassin',0,128,0,4500,0,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,3971,2,'Tonberrys_Elemental',0,128,0,0,0,60,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,3970,2,'Tonberrys_Avatar',0,128,0,0,0,60,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,3097,2,'Para',0,128,0,0,0,35,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,576,2,'Bullheaded_Grosvez',0,128,0,0,0,40,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,2784,2,'Mycophile',0,128,1761,2500,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,1934,2,'Hercules_Beetle',0,128,1303,2238,0,34,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,6809,2,'Orcfeltrap',0,128,0,0,0,0,0,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Manaclipper (Zone 3)
@@ -150,6 +200,7 @@ INSERT INTO `mob_groups` VALUES (4,204,4,'Apsaras',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,6029,4,'Kraken_fished',0,128,504,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,2371,4,'Lancet_Jagil',0,128,2898,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (7,2128,4,'Jagil',300,0,248,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,793,4,'Coralline_Uragnite',300,0,2932,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (9,2286,4,'Kraken',300,0,504,0,0,0,NULL);
@@ -200,6 +251,58 @@ INSERT INTO `mob_groups` VALUES (53,7062,4,'Locus_Bight_Rarab',60,0,309,308300,0
 INSERT INTO `mob_groups` VALUES (54,7063,4,'Locus_Camelopard',60,0,432,308300,0,0,'ROV');
 INSERT INTO `mob_groups` VALUES (55,7064,4,'Locus_Hypnos_Eft',60,0,2379,308300,0,0,'ROV');
 INSERT INTO `mob_groups` VALUES (56,7061,4,'Locus_Ghost_Crab',60,0,2931,308300,0,0,'ROV');
+=======
+INSERT INTO `mob_groups` VALUES (7,2128,4,'Jagil',300,0,248,0,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,793,4,'Coralline_Uragnite',300,0,2932,0,0,32,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2286,4,'Kraken',300,0,504,0,0,37,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,4240,4,'Viscous_Clot',300,0,2926,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,2054,4,'Ignis_Fatuus',300,8,268,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,751,4,'Coastal_Opo-opo',300,0,2933,0,0,36,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,97,4,'Alraune',300,0,2934,0,0,37,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3980,4,'Toucan',300,0,208,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3551,4,'Serra',0,32,2899,4400,0,44,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,2286,4,'Kraken',300,0,504,0,0,37,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,5875,4,'Shankha',5400,0,3081,4800,0,52,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,3111,4,'Peerifool',0,128,0,3000,0,48,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2107,4,'Island_Rarab',300,0,309,0,0,34,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2565,4,'Marine_Dhalmel',300,0,1620,0,0,34,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3330,4,'Raven',300,0,208,0,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1181,4,'Eft',300,0,746,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1710,4,'Goblin_Shaman',300,0,1148,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,2083,4,'Intulo',0,32,1364,4400,0,46,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1694,4,'Goblin_Pathfinder',300,0,1123,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1731,4,'Goblins_Rarab',0,128,0,0,0,29,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1976,4,'Hobgoblin_Martialist',300,0,1063,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1970,4,'Hobgoblin_Animalier',300,0,1024,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1731,4,'Goblins_Rarab',0,128,0,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,3860,4,'Teine_Sith',300,8,0,0,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,4040,4,'Tropical_Rarab',300,0,326,0,0,73,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1982,4,'Hobgoblin_Venerer',300,0,1327,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,660,4,'Catoblepas',300,0,432,0,0,76,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1975,4,'Hobgoblin_Fascinator',300,0,1024,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,3984,4,'Tragopan',300,0,208,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,3848,4,'Tartarus_Eft',300,0,2379,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,5762,4,'Splacknuck',0,32,3046,7720,0,69,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1973,4,'Hobgoblin_Blagger',300,0,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1981,4,'Hobgoblin_Toreador',300,0,1024,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,4085,4,'Bight_Rarab',300,0,326,0,0,81,83,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (41,5136,4,'Camelopard',300,0,432,0,0,83,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (42,1977,4,'Hobgoblin_Physician',300,0,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1968,4,'Hobgoblin_Alastor',300,0,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,6172,4,'Hypnos_Eft',300,0,2379,0,0,81,84,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (45,1969,4,'Hobgoblin_Angler',300,0,0,0,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,3384,4,'Rohemolipaud',0,128,0,0,0,55,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,895,4,'Dalham',0,128,0,14000,0,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,3591,4,'Shen',0,128,2835,20000,10000,84,86,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,3592,4,'Shens_Filtrate',0,128,0,2300,0,74,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,4669,4,'Bismarck',0,128,0,0,9999,95,98,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,4733,4,'Primordial_Pugil',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,6810,4,'Intuila',0,128,0,0,0,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,7062,4,'Locus_Bight_Rarab',60,0,309,308300,0,135,137,0,'ROV');
+INSERT INTO `mob_groups` VALUES (54,7063,4,'Locus_Camelopard',60,0,432,308300,0,135,137,0,'ROV');
+INSERT INTO `mob_groups` VALUES (55,7064,4,'Locus_Hypnos_Eft',60,0,2379,308300,0,135,137,0,'ROV');
+INSERT INTO `mob_groups` VALUES (56,7061,4,'Locus_Ghost_Crab',60,0,2931,308300,0,137,139,0,'ROV');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 -- INSERT INTO `mob_groups` VALUES (57,6810,4,'Locus_Fiddler_Crab',0,0,0,0,0,139,139,0,NULL); -- Needs capture for Venom Shower and Mega Scissors
 
 -- ------------------------------------------------------------
@@ -279,6 +382,7 @@ INSERT INTO `mob_groups` VALUES (8,0,6,'Predataur',0,128,0,0,0,0,NULL);
 -- Attohwa_Chasm (Zone 7)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,3982,7,'Tracer_Antlion',300,0,2457,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,1454,7,'Gallinipper',300,0,925,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1715,7,'Goblin_Smithy',300,0,1162,0,0,0,NULL);
@@ -338,6 +442,67 @@ INSERT INTO `mob_groups` VALUES (56,6815,7,'Bloody_Skull',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (57,6816,7,'Muut',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (58,5724,7,'Muuts_Hound_Warrior',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (59,5723,7,'Muuts_Sacrifice',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,3982,7,'Tracer_Antlion',300,0,2457,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,1454,7,'Gallinipper',300,0,925,0,0,36,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1715,7,'Goblin_Smithy',300,0,1162,0,0,36,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,1710,7,'Goblin_Shaman',300,0,1148,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,1084,7,'Doom_Scorpion',300,0,113,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,1665,7,'Goblin_Furrier',300,0,1064,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1694,7,'Goblin_Pathfinder',300,0,1148,0,0,36,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1726,7,'Goblins_Gallinipper',0,128,0,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,281,7,'Attohwa_Coeurl',300,0,190,0,0,37,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,702,7,'Chasm_Lizard',300,0,221,0,0,40,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,586,7,'Burrow_Antlion',300,0,392,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,5537,7,'Sekhmet',3600,0,2953,5000,1000,52,53,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (13,1709,7,'Goblin_Robber',300,0,1145,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1741,7,'Goblin_Trader',300,0,1179,0,0,43,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1729,7,'Goblins_Ogrefly',0,128,0,0,0,38,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1705,7,'Goblin_Reaper',300,0,1142,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,2585,7,'Master_Coeurl',300,0,1638,0,0,46,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1701,7,'Goblin_Poacher',300,0,1138,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2953,7,'Ogrefly',300,0,925,0,0,44,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2010,7,'Hunter_Antlion',300,0,1339,0,0,45,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,337,7,'Bane_Lizard',300,0,221,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,3141,7,'Pit_Antlion',300,0,1999,0,0,49,51,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,2421,7,'Lioumere',0,128,0,4400,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,6388,7,'Hecteyes',300,0,1287,0,0,35,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1369,7,'Flesh_Eater',300,0,848,0,0,34,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,4346,7,'Will-o-the-Wykes',300,8,268,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1160,7,'Earth_Elemental',300,4,733,0,0,40,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,71,7,'Air_Elemental',300,4,38,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,4048,7,'Tulwar_Scorpion',300,0,113,0,0,58,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,3456,7,'Sand_Lizard',300,0,2151,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,2732,7,'Monarch_Ogrefly',300,0,925,0,0,65,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,5424,7,'Sargas',7200,0,2944,10000,0,77,78,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (33,3983,7,'Tracker_Antlion',300,0,2458,0,0,70,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,3996,7,'Trench_Antlion',300,0,434,0,0,70,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,871,7,'Cutlass_Scorpion',300,0,549,0,0,67,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,3943,7,'Tomb_Mage',300,1,676,0,0,70,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,3944,7,'Tomb_Warrior',300,1,678,0,0,70,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,2770,7,'Mummy',300,1,678,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,2407,7,'Lich',300,1,958,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,801,7,'Corse',300,1,517,0,0,66,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,733,7,'Citipati',0,33,475,0,0,67,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,4396,7,'Xolotl',1,1,2683,20000,20000,80,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,4397,7,'Xolotls_Hound_Warrior',0,128,0,0,0,72,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,4398,7,'Xolotls_Sacrifice',0,128,0,0,0,72,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,225,7,'Arch_Corse',300,1,162,0,0,75,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,3916,7,'Tiamat',0,128,2416,100000,100000,95,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,412,7,'Bifrons',300,8,268,0,0,74,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,662,7,'Cave_Antlion',300,0,434,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,1318,7,'Feeler_Antlion',0,128,0,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,1269,7,'Executioner_Antlion',0,128,0,0,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,80,7,'Alastor_Antlion',0,128,45,50000,10000,83,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,104,7,'Ambusher_Antlion',0,32,61,0,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,71,7,'Air_Elemental',300,4,38,0,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,1160,7,'Earth_Elemental',300,4,733,0,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,6814,7,'Fjalar',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,6815,7,'Bloody_Skull',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,6816,7,'Muut',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,5724,7,'Muuts_Hound_Warrior',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,5723,7,'Muuts_Sacrifice',0,128,0,0,0,0,0,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Boneyard_Gully (Zone 8)
@@ -461,6 +626,7 @@ INSERT INTO `mob_groups` VALUES (3,5864,11,'Cutter_fished',0,128,93,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,1516,11,'Ghost_Crab_fished',0,128,93,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,111,11,'Amoebic_Nodule',0,128,15,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,909,11,'Dark_Bats',720,0,234,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,1647,11,'Goblin_Craftsman',720,0,1162,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,1673,11,'Goblin_Gutterman',720,0,1088,0,0,0,NULL);
@@ -498,11 +664,51 @@ INSERT INTO `mob_groups` VALUES (39,1816,11,'Grimoire_Guru_Grimogek',0,128,0,0,0
 INSERT INTO `mob_groups` VALUES (40,1114,11,'Dread_Dealing_Dredodak',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (41,564,11,'Bugbear_Porterman',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (42,7321,11,'Goblins_Bat',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,909,11,'Dark_Bats',780,0,234,0,0,31,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1647,11,'Goblin_Craftsman',780,0,1162,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1673,11,'Goblin_Gutterman',780,0,1088,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2698,11,'Moblin_Pickman',780,0,1712,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1682,11,'Goblin_Leadman',780,0,1097,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1720,11,'Goblins_Bat',0,128,0,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,2708,11,'Moblin_Witchman',780,0,1718,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1674,11,'Goblin_Hammerman',780,0,1089,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,2700,11,'Moblin_Ragman',780,0,1712,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,2687,11,'Moblin_Chapman',780,0,1705,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,565,11,'Bugbear_Servingman',720,0,377,0,0,32,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1160,11,'Earth_Elemental',900,4,733,0,0,45,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,563,11,'Bugbear_Muscleman',5700,0,376,4700,0,52,52,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (19,3776,11,'Stirge',780,0,234,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,121,11,'Ancient_Bomb',900,0,83,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3912,11,'Thunder_Elemental',900,4,2411,0,0,45,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,2703,11,'Moblin_Rodman',900,0,1714,0,0,41,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,560,11,'Bugbear_Bondman',900,0,373,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1739,11,'Goblin_Tollman',900,0,1177,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,2694,11,'Moblin_Gasman',900,0,1706,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,2689,11,'Moblin_Coalman',900,0,1706,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,2701,11,'Moblin_Repairman',900,0,1706,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1650,11,'Goblin_Doorman',900,0,1043,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1691,11,'Goblin_Oilman',900,0,1121,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,2699,11,'Moblin_Pikeman',900,0,1706,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,566,11,'Bugbear_Strongman',0,32,378,4800,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1712,11,'Goblin_Shovelman',900,0,1157,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1663,11,'Goblin_Freelance',900,0,1061,0,0,45,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,2685,11,'Moblin_Ashman',900,0,1702,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,556,11,'Bugallug',0,128,0,6000,0,45,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,2696,11,'Moblin_Gurneyman',900,0,1710,0,0,46,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1746,11,'Goblin_Wolfman',0,128,1189,7400,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1703,11,'Goblin_Preceptor',0,128,0,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1816,11,'Grimoire_Guru_Grimogek',0,128,0,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,1114,11,'Dread_Dealing_Dredodak',0,128,0,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,564,11,'Bugbear_Porterman',0,128,0,0,0,45,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,1720,11,'Goblins_Bat',0,128,0,0,0,37,38,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Newton_Movalpolos (Zone 12)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,1661,12,'Goblin_Foreman',960,0,1057,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,7322,12,'Goblins_Bat',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1692,12,'Goblin_Packman',960,0,1050,0,0,0,NULL);
@@ -541,6 +747,46 @@ INSERT INTO `mob_groups` VALUES (34,562,12,'Bugbear_Matman',0,128,375,11900,0,0,
 INSERT INTO `mob_groups` VALUES (36,6718,12,'Sword_Sorcerer_Solisoq',3600,0,3224,14000,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (37,2684,12,'Moblin_Aidman',0,128,1703,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (38,2692,12,'Moblin_Engineman',0,128,1708,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,1661,12,'Goblin_Foreman',960,0,1057,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,1720,12,'Goblins_Bat',0,128,0,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1692,12,'Goblin_Packman',960,0,1050,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,567,12,'Bugbear_Trashman',960,0,379,0,0,65,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,1658,12,'Goblin_Fireman',960,0,1050,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,1684,12,'Goblin_Lengthman',960,0,1057,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,568,12,'Bugbear_Watchman',960,0,374,0,0,71,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,2709,12,'Moblin_Workman',960,0,1719,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2705,12,'Moblin_Tankman',960,0,1716,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,2690,12,'Moblin_Draftsman',960,0,1707,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1044,12,'Dire_Bat',960,0,234,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,2710,12,'Moblin_Yardman',960,0,1719,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,3806,12,'Succubus_Bats',960,0,234,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3912,12,'Thunder_Elemental',960,4,2410,0,0,70,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1160,12,'Earth_Elemental',960,4,733,0,0,70,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1676,12,'Goblin_Headman',960,0,1091,0,0,75,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1720,12,'Goblins_Bat',0,128,0,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6432,12,'Nightmare_Bats',960,0,1782,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1680,12,'Goblin_Junkman',960,0,1096,0,0,75,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2684,12,'Moblin_Aidman',960,0,1703,0,0,75,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3231,12,'Purgatory_Bat',960,0,2041,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,2706,12,'Moblin_Topsman',960,0,1717,0,0,75,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,561,12,'Bugbear_Deathsman',960,0,374,0,0,74,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1685,12,'Goblin_Marksman',960,0,1091,0,0,75,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,2692,12,'Moblin_Engineman',960,0,1708,0,0,75,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,2702,12,'Moblin_Roadman',960,0,1713,0,0,75,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1675,12,'Goblin_Hangman',960,0,1090,0,0,75,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1719,12,'Goblin_Swordsman',960,0,1166,0,0,78,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,3824,12,'Swashstox_Beadblinker',0,32,2366,0,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,2695,12,'Moblin_Groundman',960,0,1709,0,0,77,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,2664,12,'Mimic',0,128,1675,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,2704,12,'Moblin_Scalpelman',960,0,1715,0,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1645,12,'Goblin_Collector',0,128,1037,20000,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,562,12,'Bugbear_Matman',0,128,375,20000,0,75,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1160,12,'Earth_Elemental',960,4,733,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,6718,12,'Sword_Sorcerer_Solisoq',3600,0,3224,14000,0,83,83,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (37,2684,12,'Moblin_Aidman',0,128,1703,0,0,75,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,2692,12,'Moblin_Engineman',0,128,1708,0,0,75,79,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Mine_Shaft_2716 (Zone 13)
@@ -678,6 +924,7 @@ INSERT INTO `mob_groups` VALUES (91,7132,15,'Cryptonberry_Occultist',300,0,541,5
 -- Promyvion-Holla (Zone 16)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (3,2048,16,'Idle_Wanderer',960,0,0,260000,0,0,'ABYSSEA'); -- TODO: Apex Idle Drifter
 INSERT INTO `mob_groups` VALUES (1,6651,16,'Wanderer',600,0,2612,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,6652,16,'Weeper',600,0,2634,0,0,0,NULL);
@@ -701,6 +948,31 @@ INSERT INTO `mob_groups` VALUES (19,6651,16,'Wanderer',720,0,2612,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (21,681,16,'Cerebrator',14400,0,447,3000,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (22,298,16,'Woeful_Weeper',960,0,1350,260000,0,0,'ABYSSEA'); -- TODO: Apex Woeful Lamenter
 INSERT INTO `mob_groups` VALUES (23,4527,16,'Livid_Seether',960,0,1350,260000,0,0,'ABYSSEA'); -- TODO: Apex Livid Rager
+=======
+INSERT INTO `mob_groups` VALUES (3,2048,16,'Idle_Wanderer',960,0,0,260000,0,139,142,0,'ABYSSEA'); -- TODO: Apex Idle Drifter
+INSERT INTO `mob_groups` VALUES (1,6651,16,'Wanderer',600,0,2612,0,0,22,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,6652,16,'Weeper',600,0,2634,0,0,24,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,3897,16,'Thinker',600,0,2398,0,0,28,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,2614,16,'Memory_Receptacle',300,0,0,0,0,30,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3784,16,'Stray',0,128,0,0,0,21,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,6651,16,'Wanderer',600,0,2612,0,0,26,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,6652,16,'Weeper',600,0,2634,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,3897,16,'Thinker',720,0,2398,0,0,33,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,3539,16,'Seether',720,0,2192,0,0,30,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3784,16,'Stray',0,128,0,0,0,23,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,6651,16,'Wanderer',600,0,2612,0,0,29,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,6652,16,'Weeper',720,0,2634,0,0,31,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3539,16,'Seether',720,0,2192,0,0,33,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3897,16,'Thinker',720,0,2398,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3784,16,'Stray',0,128,0,0,0,26,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,6652,16,'Weeper',720,0,2634,0,0,33,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,3539,16,'Seether',720,0,2192,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,6651,16,'Wanderer',720,0,2612,0,0,32,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3897,16,'Thinker',720,0,2398,0,0,37,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,681,16,'Cerebrator',14400,0,447,3000,0,38,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,298,16,'Woeful_Weeper',960,0,1350,260000,0,139,142,0,'ABYSSEA');  -- TODO: Apex Woeful Lamenter
+INSERT INTO `mob_groups` VALUES (23,4527,16,'Livid_Seether',960,0,1350,260000,0,139,142,0,'ABYSSEA'); -- TODO: Apex Livid Rager
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Spire_of_Holla (Zone 17)
@@ -725,6 +997,7 @@ INSERT INTO `mob_groups` VALUES (14,0,17,'Constant_Wanderer',0,128,0,0,0,0,NULL)
 -- Promyvion-Dem (Zone 18)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (2,2048,18,'Idle_Wanderer',960,0,0,260000,0,0,'ABYSSEA'); -- TODO: Apex Idle Drifter
 INSERT INTO `mob_groups` VALUES (1,6651,18,'Wanderer',600,0,2613,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,6652,18,'Weeper',600,0,2635,0,0,0,NULL);
@@ -748,6 +1021,31 @@ INSERT INTO `mob_groups` VALUES (19,6651,18,'Wanderer',720,0,2613,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (21,3483,18,'Satiator',14400,0,2166,3000,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (22,298,18,'Woeful_Weeper',960,0,0,260000,0,0,'ABYSSEA'); -- TODO: Apex Woeful Lamenter
 INSERT INTO `mob_groups` VALUES (23,4527,18,'Livid_Seether',960,0,0,260000,0,0,'ABYSSEA'); -- TODO: Apex Livid Rager
+=======
+INSERT INTO `mob_groups` VALUES (2,2048,18,'Idle_Wanderer',960,0,0,260000,0,139,142,0,'ABYSSEA'); -- TODO: Apex Idle Drifter
+INSERT INTO `mob_groups` VALUES (1,6651,18,'Wanderer',600,0,2613,0,0,22,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,6652,18,'Weeper',600,0,2635,0,0,24,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,1768,18,'Gorger',600,0,1207,0,0,29,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,6645,18,'Memory_Receptacle',300,0,0,0,0,30,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3784,18,'Stray',0,128,0,0,0,20,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,6652,18,'Weeper',600,0,2635,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,6651,18,'Wanderer',600,0,2613,0,0,26,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,3539,18,'Seether',720,0,2193,0,0,30,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1768,18,'Gorger',720,0,1207,0,0,32,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3784,18,'Stray',0,128,0,0,0,23,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,6651,18,'Wanderer',600,0,2613,0,0,29,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,6652,18,'Weeper',720,0,2635,0,0,31,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3539,18,'Seether',720,0,2193,0,0,33,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1768,18,'Gorger',720,0,1207,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3784,18,'Stray',0,128,0,0,0,26,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3539,18,'Seether',720,0,2193,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6652,18,'Weeper',720,0,2635,0,0,33,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,6651,18,'Wanderer',720,0,2613,0,0,31,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1768,18,'Gorger',720,0,1207,0,0,37,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3483,18,'Satiator',14400,0,2166,3000,0,38,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,298,18,'Woeful_Weeper',960,0,0,260000,0,139,142,0,'ABYSSEA');  -- TODO: Apex Woeful Lamenter
+INSERT INTO `mob_groups` VALUES (23,4527,18,'Livid_Seether',960,0,0,260000,0,139,142,0,'ABYSSEA'); -- TODO: Apex Livid Rager
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Spire_of_Dem (Zone 19)
@@ -769,6 +1067,7 @@ INSERT INTO `mob_groups` VALUES (11,0,19,'Disconsolate_Weeper',0,128,0,0,0,0,NUL
 -- Promyvion-Mea (Zone 20)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,6651,20,'Wanderer',600,0,2614,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,6652,20,'Weeper',600,0,2636,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,2048,20,'Idle_Wanderer',960,0,0,260000,0,0,'ABYSSEA'); -- TODO: Apex Idle Drifter
@@ -792,6 +1091,31 @@ INSERT INTO `mob_groups` VALUES (19,6651,20,'Wanderer',720,0,2614,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (21,820,20,'Coveter',14400,0,522,3000,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (22,298,20,'Woeful_Weeper',960,0,0,260000,0,0,'ABYSSEA'); -- TODO: Apex Woeful Lamenter
 INSERT INTO `mob_groups` VALUES (23,4527,20,'Livid_Seether',960,0,0,260000,0,0,'ABYSSEA'); -- TODO: Apex Livid Rager
+=======
+INSERT INTO `mob_groups` VALUES (1,6651,20,'Wanderer',600,0,2614,0,0,22,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,6652,20,'Weeper',600,0,2636,0,0,25,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,2048,20,'Idle_Wanderer',960,0,0,260000,0,139,142,0,'ABYSSEA'); -- TODO: Apex Idle Drifter
+INSERT INTO `mob_groups` VALUES (4,830,20,'Craver',600,0,526,0,0,29,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,6646,20,'Memory_Receptacle',300,0,0,0,0,30,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3784,20,'Stray',0,128,0,0,0,21,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,6651,20,'Wanderer',600,0,2614,0,0,26,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,6652,20,'Weeper',600,0,2636,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,3539,20,'Seether',720,0,2194,0,0,30,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,830,20,'Craver',720,0,526,0,0,32,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3784,20,'Stray',0,128,0,0,0,23,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,6651,20,'Wanderer',600,0,2614,0,0,29,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,6652,20,'Weeper',720,0,2636,0,0,31,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3539,20,'Seether',720,0,2194,0,0,33,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,830,20,'Craver',720,0,526,0,0,35,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3784,20,'Stray',0,128,0,0,0,26,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3539,20,'Seether',720,0,2194,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6652,20,'Weeper',720,0,2636,0,0,33,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,6651,20,'Wanderer',720,0,2614,0,0,31,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,830,20,'Craver',720,0,526,0,0,36,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,820,20,'Coveter',14400,0,522,3000,0,38,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,298,20,'Woeful_Weeper',960,0,0,260000,0,139,142,0,'ABYSSEA');  -- TODO: Apex Woeful Lamenter
+INSERT INTO `mob_groups` VALUES (23,4527,20,'Livid_Seether',960,0,0,260000,0,139,142,0,'ABYSSEA'); -- TODO: Apex Livid Rager
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Spire_of_Mea (Zone 21)
@@ -812,6 +1136,7 @@ INSERT INTO `mob_groups` VALUES (10,0,21,'Quenchless_Seether',0,128,0,0,0,0,NULL
 -- Promyvion-Vahzl (Zone 22)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,3172,22,'Ponderer',0,128,0,3850,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,3206,22,'Propagator',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,2947,22,'Offspring',0,128,0,0,0,0,NULL);
@@ -852,6 +1177,48 @@ INSERT INTO `mob_groups` VALUES (37,4527,22,'Livid_Seether',960,0,1350,0,0,0,'AB
 INSERT INTO `mob_groups` VALUES (38,298,22,'Woeful_Weeper',960,0,1350,0,0,0,'ABYSSEA');
 INSERT INTO `mob_groups` VALUES (39,7290,22,'Wanderer',960,0,2192,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (40,7291,22,'Weeper',960,0,2636,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,3172,22,'Ponderer',0,128,0,3850,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,3206,22,'Propagator',0,128,0,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,2947,22,'Offspring',0,128,0,0,0,47,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,3699,22,'Solicitor',0,128,0,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,6651,22,'Wanderer',960,0,2192,0,0,46,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,6652,22,'Weeper',960,0,2636,0,0,48,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,2048,22,'Idle_Wanderer',960,0,1350,0,0,84,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (8,6649,22,'Thinker',960,0,2399,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,6644,22,'Gorger',960,0,1208,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,6643,22,'Craver',960,0,527,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,6647,22,'Memory_Receptacle',300,0,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,6650,22,'Stray',0,128,0,0,0,39,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,6652,22,'Weeper',960,0,2636,0,0,48,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,6651,22,'Wanderer',960,0,2192,0,0,46,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,6648,22,'Seether',960,0,2194,0,0,52,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,6649,22,'Thinker',960,0,2399,0,0,54,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,6644,22,'Gorger',960,0,1208,0,0,54,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6643,22,'Craver',960,0,527,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,6650,22,'Stray',0,128,0,0,0,41,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,6651,22,'Wanderer',960,0,2192,0,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,6652,22,'Weeper',960,0,2636,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,6648,22,'Seether',960,0,2194,0,0,54,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1016,22,'Deviator',0,128,642,7000,7000,58,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,6649,22,'Thinker',960,0,2399,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,6644,22,'Gorger',960,0,1208,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,6643,22,'Craver',960,0,527,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,6650,22,'Stray',0,128,0,0,0,43,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,6651,22,'Wanderer',960,0,2192,0,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,6652,22,'Weeper',960,0,2636,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,6648,22,'Seether',960,0,2194,0,0,54,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,4274,22,'Wailer',0,128,2600,8000,0,58,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,6649,22,'Thinker',960,0,2399,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,6644,22,'Gorger',960,0,1208,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,6643,22,'Craver',960,0,527,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,6650,22,'Stray',0,128,0,0,0,45,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,3212,22,'Provoker',0,128,2028,9600,0,58,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,4527,22,'Livid_Seether',960,0,1350,0,0,85,86,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (38,298,22,'Woeful_Weeper',960,0,1350,0,0,85,86,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (39,7290,22,'Wanderer',960,0,2192,0,0,46,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,7291,22,'Weeper',960,0,2636,0,0,52,54,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Spire_of_Vahzl (Zone 23)
@@ -905,6 +1272,7 @@ INSERT INTO `mob_groups` VALUES (9,683,24,'Cetic_Parasite',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (10,1326,24,'Ferrocrab',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (11,2801,24,'Nakki',0,128,0,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (12,2672,24,'Miner_Bee',300,0,584,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (13,3854,24,'Tavnazian_Sheep',300,0,2382,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (14,557,24,'Bugard',300,0,371,0,0,0,NULL);
@@ -977,6 +1345,80 @@ INSERT INTO `mob_groups` VALUES (80,4856,24,'Immanibugard',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (81,6738,24,'Vermillion_Fishfly',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (82,6817,24,'Yal-un_Eke',0,128,0,5000,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (83,7284,24,'Fomor_Ranger',300,1,858,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (12,2672,24,'Miner_Bee',300,0,584,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,3854,24,'Tavnazian_Sheep',300,0,2382,0,0,33,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,557,24,'Bugard',300,0,371,0,0,34,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,749,24,'Cluster',300,8,490,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,6271,24,'Orcish_Brawler',300,0,3257,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,6269,24,'Orcish_Beastrider',300,0,3257,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6270,24,'Orcish_Nightraider',300,0,3257,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,6273,24,'Orcish_Impaler',300,0,283,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3083,24,'Padfoot',0,128,0,3000,0,38,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3034,24,'Orcish_Stonelauncher',300,0,1942,0,0,37,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,71,24,'Air_Elemental',300,4,38,0,0,85,86,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,839,24,'Crimson_Knight_Crab',300,0,536,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,40,24,'Acrophies',300,0,17,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,3912,24,'Thunder_Elemental',300,4,2410,0,0,43,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1559,24,'Gigas_Fighter',300,0,981,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1600,24,'Gigas_Wrestler',300,0,981,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1583,24,'Gigas_Slinger',300,0,981,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,4127,24,'Vampire_Bat',300,0,386,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,4353,24,'Wingrats',300,0,386,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,20,24,'Abraxas',300,0,2,0,0,85,86,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,4689,24,'Flockbock',3600,0,3288,17000,0,82,82,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (33,1386,24,'Fomor_Ninja',300,1,0,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,6522,24,'Fomor_Monk',300,1,867,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,3853,24,'Tavnazian_Ram',300,0,2381,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,6515,24,'Fomor_Bard',300,1,0,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,6525,24,'Fomor_Red_Mage',300,1,0,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1390,24,'Fomor_Samurai',300,1,867,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1398,24,'Fomor_Warrior',300,1,867,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,913,24,'Dark_Elemental',300,4,568,0,0,84,86,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,6523,24,'Fomor_Paladin',300,1,867,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,6521,24,'Fomor_Dragoon',300,1,0,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1396,24,'Fomors_Wyvern',0,128,0,0,0,34,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,6520,24,'Fomor_Dark_Knight',300,1,0,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,6519,24,'Fomor_Black_Mage',300,1,0,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1388,24,'Fomor_Ranger',300,1,858,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,1391,24,'Fomor_Summoner',300,1,858,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,1395,24,'Fomors_Elemental',0,128,0,0,0,34,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,6517,24,'Fomor_Beastmaster',300,1,858,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,1393,24,'Fomors_Bat',0,128,0,0,0,34,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,940,24,'Death_Jacket',300,0,584,0,0,37,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,1549,24,'Gigantobugard',300,0,371,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,277,24,'Atomic_Cluster',300,8,187,0,0,44,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,1553,24,'Gigas_Braver',300,0,981,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,1573,24,'Gigas_Martialist',300,0,981,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,1555,24,'Gigas_Catapulter',300,0,981,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,6276,24,'Orcish_Bowshooter',300,0,3257,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,6278,24,'Orcish_Footsoldier',300,0,3257,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,3015,24,'Orcish_Gladiator',300,0,3257,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,3039,24,'Orcish_Trooper',300,0,3257,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,1397,24,'Fomor_Thief',300,1,858,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (62,2392,24,'Leshachikha',300,0,2463,0,0,49,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (63,1599,24,'Gigas_Warwolf',300,0,981,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (64,1592,24,'Gigass_Sheep',0,128,0,0,0,34,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (65,2608,24,'Megalobugard',0,32,1653,0,0,52,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (66,2394,24,'Leshy',300,0,1534,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (67,767,24,'Colorful_Leshy',0,128,501,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (68,957,24,'Defoliate_Leshy',0,128,596,0,0,57,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (69,3736,24,'Splinterspine_Grukjuk',0,128,283,0,0,47,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (70,429,24,'Blackbone_Frazdiz',0,128,0,2700,0,40,41,0,NULL);
+INSERT INTO `mob_groups` VALUES (71,3311,24,'Rainbringer_Yjatvot',0,128,0,1900,0,40,41,0,NULL);
+INSERT INTO `mob_groups` VALUES (72,375,24,'Baumesel',0,128,0,1950,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (73,2299,24,'Kurrea',0,128,1470,20000,20000,84,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (74,100,24,'Amaltheia',0,128,55,30000,30000,83,87,0,NULL);
+INSERT INTO `mob_groups` VALUES (75,4692,24,'Abununnu',0,128,0,0,9999,105,106,0,NULL);
+INSERT INTO `mob_groups` VALUES (76,4691,24,'Gloam_Servitor_mage',0,128,0,0,9999,101,102,0,NULL);
+INSERT INTO `mob_groups` VALUES (77,4690,24,'Gloam_Servitor_melee',0,128,0,0,0,101,102,0,NULL);
+INSERT INTO `mob_groups` VALUES (78,3912,24,'Thunder_Elemental',300,4,2410,0,0,62,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (79,6818,24,'Sengann',0,128,0,6000,0,58,58,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (80,4856,24,'Immanibugard',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (81,6738,24,'Vermillion_Fishfly',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (82,6817,24,'Yal-un_Eke',0,128,0,5000,0,0,0,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (83,7284,24,'Fomor_Ranger',300,1,858,0,0,41,44,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Misareaux_Coast (Zone 25)
@@ -988,6 +1430,7 @@ INSERT INTO `mob_groups` VALUES (2,1817,25,'Grindylow',0,128,203,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,5868,25,'Greater_Pugil_fished',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,5866,25,'Mantrap_fished',0,128,0,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,2672,25,'Miner_Bee',300,0,584,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,3854,25,'Tavnazian_Sheep',300,0,2383,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,557,25,'Bugard',300,0,372,0,0,0,NULL);
@@ -1048,6 +1491,68 @@ INSERT INTO `mob_groups` VALUES (61,6740,25,'Bloodswiller_Fly',0,128,0,0,0,0,NUL
 INSERT INTO `mob_groups` VALUES (62,6741,25,'Tiyanak',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (63,6742,25,'Volatile_Cluster',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (64,7284,25,'Fomor_Ranger',300,1,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,2672,25,'Miner_Bee',300,0,584,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3854,25,'Tavnazian_Sheep',300,0,2383,0,0,33,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,557,25,'Bugard',300,0,372,0,0,34,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3912,25,'Thunder_Elemental',300,4,2410,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,5877,25,'Goaftrap',5400,0,3084,5500,0,50,51,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (10,1385,25,'Fomor_Monk',300,1,0,0,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1390,25,'Fomor_Samurai',300,1,0,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1398,25,'Fomor_Warrior',300,1,0,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1397,25,'Fomor_Thief',300,1,0,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,71,25,'Air_Elemental',300,4,38,0,0,49,51,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,839,25,'Crimson_Knight_Crab',300,0,536,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,913,25,'Dark_Elemental',300,4,568,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1382,25,'Fomor_Black_Mage',300,1,0,0,0,37,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1388,25,'Fomor_Ranger',300,1,0,0,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1383,25,'Fomor_Dark_Knight',300,1,0,0,0,37,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1386,25,'Fomor_Ninja',300,1,0,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,1387,25,'Fomor_Paladin',300,1,855,0,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1380,25,'Fomor_Bard',300,1,855,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,4127,25,'Vampire_Bat',300,0,386,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,4353,25,'Wingrats',300,0,386,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1549,25,'Gigantobugard',300,0,979,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,6028,25,'Seaboard_Vulture',300,0,43,0,0,83,84,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (27,1553,25,'Gigas_Braver',300,0,982,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1573,25,'Gigas_Martialist',300,0,982,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,3034,25,'Orcish_Stonelauncher',300,0,1942,0,0,43,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,6283,25,'Orcish_Trooper',300,0,3255,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,6277,25,'Orcish_Bowshooter',300,0,3256,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,940,25,'Death_Jacket',300,0,584,0,0,37,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,277,25,'Atomic_Cluster',300,8,187,0,0,44,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1599,25,'Gigas_Warwolf',300,0,982,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1555,25,'Gigas_Catapulter',300,0,983,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,6279,25,'Orcish_Footsoldier',300,0,283,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1592,25,'Gigass_Sheep',0,128,0,0,0,34,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,6281,25,'Orcish_Gladiator',300,0,3255,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,2945,25,'Odqan',7200,0,1839,0,0,50,51,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,2556,25,'Mantrap',300,0,3077,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,3073,25,'Overgrown_Rose',300,0,1964,0,0,47,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,4105,25,'Upyri',86400,0,2526,0,0,43,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1389,25,'Fomor_Red_Mage',300,1,855,0,0,49,51,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,1391,25,'Fomor_Summoner',300,1,858,0,0,48,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,1395,25,'Fomors_Elemental',0,128,0,0,0,43,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1035,25,'Diatryma',300,0,651,0,0,47,51,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,5773,25,'Okyupete',0,32,3057,5550,0,57,60,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (48,4814,25,'Bigclaw',300,0,271,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,2491,25,'Makara',300,0,278,0,0,46,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,1384,25,'Fomor_Dragoon',300,1,0,0,0,49,51,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,1396,25,'Fomors_Wyvern',0,128,0,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,4291,25,'Warder_Aglaia',0,128,0,5000,0,62,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,4292,25,'Warder_Euphrosyne',0,128,0,5000,0,62,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,4293,25,'Warder_Thalia',0,128,0,5000,0,62,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,466,25,'Bloody_Coffin',0,128,0,3500,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,484,25,'Boggelmann',0,128,0,7600,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,98,25,'Alsha',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,1792,25,'Gration',0,128,0,30000,0,79,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,4505,25,'Ziphius',0,128,2801,0,0,60,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,6739,25,'Tsui-Goab',0,128,0,0,0,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,6740,25,'Bloodswiller_Fly',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (62,6741,25,'Tiyanak',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (63,6742,25,'Volatile_Cluster',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (64,7284,25,'Fomor_Ranger',300,1,0,0,0,36,38,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Phomiuna_Aqueducts (Zone 27)
@@ -1086,6 +1591,7 @@ INSERT INTO `mob_groups` VALUES (28,1380,27,'Fomor_Bard',840,0,856,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (29,2488,27,'Mahisha',0,128,1575,5000,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (30,2675,27,'Minotaur',600,0,0,5000,0,0,NULL);
 -- zone 27 group 31: free
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (32,71,27,'Air_Elemental',960,4,38,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (33,3912,27,'Thunder_Elemental',960,4,2410,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (34,913,27,'Dark_Elemental',960,4,568,0,0,0,NULL);
@@ -1100,6 +1606,22 @@ INSERT INTO `mob_groups` VALUES (42,1389,27,'Fomor_Red_Mage',840,0,875,0,0,0,NUL
 INSERT INTO `mob_groups` VALUES (43,1169,27,'Eba',0,128,739,5000,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (44,4531,27,'Aqueduct_Spider',960,0,3006,0,0,0,'ABYSSEA');
 INSERT INTO `mob_groups` VALUES (45,7284,27,'Fomor_Ranger',840,0,873,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (32,71,27,'Air_Elemental',960,4,38,0,0,45,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,3912,27,'Thunder_Elemental',960,4,2410,0,0,45,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,913,27,'Dark_Elemental',960,4,568,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1385,27,'Fomor_Monk',840,0,868,0,0,44,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1390,27,'Fomor_Samurai',840,0,878,0,0,44,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1388,27,'Fomor_Ranger',840,0,873,0,0,44,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1383,27,'Fomor_Dark_Knight',840,0,863,0,0,44,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1382,27,'Fomor_Black_Mage',840,0,861,0,0,44,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,3997,27,'Tres_Duendes',86400,0,2468,5000,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,1128,27,'Duendes_Amoroso',0,128,0,1800,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,1389,27,'Fomor_Red_Mage',840,0,875,0,0,44,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1169,27,'Eba',0,128,739,5000,0,48,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,4531,27,'Aqueduct_Spider',960,0,3006,0,0,84,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (45,7284,27,'Fomor_Ranger',840,0,873,0,0,44,48,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Sacrarium (Zone 28)
@@ -1152,6 +1674,7 @@ INSERT INTO `mob_groups` VALUES (42,7284,28,'Fomor_Ranger',960,0,874,0,0,0,NULL)
 -- Riverne-Site_B01 (Zone 29)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,2399,29,'Lesser_Roc',300,0,1514,2100,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,3242,29,'Pyrodrake',300,0,2048,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,2882,29,'Nimbus_Hippogryph',300,0,1810,0,0,0,NULL);
@@ -1179,11 +1702,41 @@ INSERT INTO `mob_groups` VALUES (24,1160,29,'Earth_Elemental',0,128,733,0,0,0,NU
 INSERT INTO `mob_groups` VALUES (25,3124,29,'Pey',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (26,2105,29,'Iruci',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (27,70,29,'Airi',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,2399,29,'Lesser_Roc',300,0,1514,2100,0,47,51,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,3242,29,'Pyrodrake',300,0,2048,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,2882,29,'Nimbus_Hippogryph',300,0,1810,0,0,49,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,3912,29,'Thunder_Elemental',300,4,2410,0,0,57,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,3783,29,'Strato_Hippogryph',300,0,488,0,0,54,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,2452,29,'Lunantishee',300,0,1550,0,0,55,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,2051,29,'Ignidrake',300,0,1352,0,0,57,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,2891,29,'Nitro_Cluster',960,0,1818,0,0,55,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,4530,29,'Blazedrake',300,0,3298,0,0,85,87,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (10,71,29,'Air_Elemental',300,4,38,0,0,57,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,2060,29,'Imdugud',0,32,1358,5000,0,56,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,513,29,'Boroka',86400,0,341,9000,0,56,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,3725,29,'Spell_Spitter_Spilospok',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,708,29,'Chemical_Cook_Chemachiq',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,503,29,'Book_Browser_Bokabraq',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,4102,29,'Unstable_Cluster',0,128,2523,10000,0,56,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,325,29,'Bahamut',0,128,0,26000,15000,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,3070,29,'Ouryu',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3916,29,'Tiamat',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2156,29,'Jormungand',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,4261,29,'Vrtra',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,4507,29,'Ziryu',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,4309,29,'Water_Elemental',0,128,2629,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1160,29,'Earth_Elemental',0,128,733,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,3124,29,'Pey',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,2105,29,'Iruci',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,70,29,'Airi',0,128,0,0,0,15,17,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Riverne-Site_A01 (Zone 30)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,6962,30,'Hawkertrap',300,0,852,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,3370,30,'Riverne_Vulture',300,0,2100,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1960,30,'Hippogryph',720,0,1319,0,0,0,NULL);
@@ -1205,6 +1758,29 @@ INSERT INTO `mob_groups` VALUES (18,4507,30,'Ziryu',0,128,2804,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (19,215,30,'Arcane_Phantasm',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (20,3596,30,'Shieldtrap',0,128,2235,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (21,7286,30,'Ouryu',0,128,1962,50000,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,6962,30,'Hawkertrap',300,0,852,0,0,38,41,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,3370,30,'Riverne_Vulture',300,0,2100,0,0,39,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1960,30,'Hippogryph',720,0,1319,0,0,40,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,1918,30,'Heliodromos',0,128,1291,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,71,30,'Air_Elemental',300,4,38,0,0,47,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,1340,30,'Firedrake',300,0,830,0,0,41,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,3912,30,'Thunder_Elemental',300,4,2410,0,0,44,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1901,30,'Hawker',300,0,571,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,747,30,'Cloud_Hippogryph',300,0,488,0,0,45,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,277,30,'Atomic_Cluster',300,0,188,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1355,30,'Flamedrake',300,0,841,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,641,30,'Carmine_Dobsonfly',86400,0,418,1200,0,44,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,4532,30,'Darner',300,0,141,0,0,84,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (14,68,30,'Aiatar',0,32,35,5200,0,48,51,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,4309,30,'Water_Elemental',0,128,2629,1100,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1160,30,'Earth_Elemental',0,128,733,1100,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3070,30,'Ouryu',0,128,1962,50000,0,90,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4507,30,'Ziryu',0,128,2804,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,215,30,'Arcane_Phantasm',0,128,0,0,0,44,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3596,30,'Shieldtrap',0,128,2235,0,0,39,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,7286,30,'Ouryu',0,128,1962,50000,0,90,90,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Monarch_Linn (Zone 31)
@@ -2730,6 +3306,7 @@ INSERT INTO `mob_groups` VALUES (3,3344,51,'Red_Osculator',0,128,174,0,0,0,NULL)
 INSERT INTO `mob_groups` VALUES (4,2269,51,'Kissing_Leech',0,128,174,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,2616,51,'Mercurial_Makara',0,128,463,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,714,51,'Chigoe_pet',0,128,466,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,2396,51,'Lesser_Colibri',300,0,1509,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,4650,51,'Fomor_Thief',300,1,0,0,0,0,NULL);
@@ -2859,6 +3436,137 @@ INSERT INTO `mob_groups` VALUES (131,7152,51,'Siege_Scorpion',0,128,0,0,0,0,NULL
 INSERT INTO `mob_groups` VALUES (132,7153,51,'Gurfurlur_the_Menacing',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (133,7154,51,'Troll_Destroyer',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (134,7188,51,'Chigoe_pet',0,128,466,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,714,51,'Chigoe_pet',0,128,466,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,2396,51,'Lesser_Colibri',300,0,1509,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,4650,51,'Fomor_Thief',300,1,0,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,6518,51,'Fomor_Beastmaster',300,1,0,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1394,51,'Fomors_Bats',0,128,0,0,0,58,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,6524,51,'Fomor_Paladin',300,1,0,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,6516,51,'Fomor_Bard',300,1,0,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,3698,51,'Soldier_Pephredo',300,0,2293,0,0,64,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,4376,51,'Worker_Pephredo',300,0,2293,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,2562,51,'Marid',300,0,1617,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3343,51,'Red_Kisser',300,0,174,0,0,68,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1787,51,'Grand_Marid',0,32,1617,0,0,78,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,106,51,'Ameretat',300,0,63,0,0,66,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,4275,51,'Wajaom_Tiger',300,0,2601,0,0,67,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,5555,51,'Chelicerata',0,128,3041,0,0,78,78,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (21,4518,51,'Zoraal_Jas_Pkuucha',0,32,2810,8300,8300,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,3118,51,'Percipient_Zoraal_Ja',0,128,0,8300,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,67,51,'Aht_Urhgan_Attercop',300,0,34,0,0,65,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1900,51,'Haunt',300,1,1279,0,0,65,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,3223,51,'Puk_WW',300,0,2035,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,4360,51,'Woodland_Runner',300,0,600,0,0,71,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,2526,51,'Mamool_Ja_Mimicker',300,0,1588,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,958,51,'Defoliate_Treant',300,0,597,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,3991,51,'Treant_Sapling',300,0,2463,0,0,66,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,768,51,'Colorful_Treant',300,0,502,0,0,75,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,642,51,'Carmine_Eruca',300,0,419,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,4369,51,'Woodtroll_Warrior',300,0,2480,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,4367,51,'Woodtroll_Monk',300,0,2474,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,4364,51,'Woodtroll_Dark_Knight',300,0,2480,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,4368,51,'Woodtroll_Ranger',300,0,2474,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,5863,51,'Gharial',7200,0,3076,16000,0,82,83,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (37,71,51,'Air_Elemental',300,4,38,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,2018,51,'Hydra',172800,0,1333,73000,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,2534,51,'Mamool_Ja_Sophist',300,0,1593,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,2508,51,'Mamool_Ja_Bounder',300,0,1588,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,2533,51,'Mamool_Ja_Savant',300,0,1593,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,1809,51,'Great_Ameretat',300,0,63,0,0,71,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,2123,51,'Jaded_Jody',0,32,1389,13800,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,2545,51,'Mamool_Ja_Zenist',300,0,1588,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,393,51,'Berried_Chigoe',0,128,255,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,716,51,'Chigoes_Nit',0,128,0,0,0,48,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,916,51,'Dark_Rider',0,128,0,0,0,95,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,910,51,'Dark_Bugler',0,128,0,0,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,914,51,'Dark_Esquire',0,128,569,0,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,4265,51,'Vulpangue',0,128,2594,15000,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,2090,51,'Iriz_Ima',0,128,1368,28000,0,87,88,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,1773,51,'Gotoh_Zha_the_Redolent',0,128,1210,35000,0,83,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,3922,51,'Tinnin',0,128,2418,46000,0,88,89,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,2532,51,'Mamool_Ja_Sapper',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,2520,51,'Mamool_Ja_Hospitaler',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,2517,51,'Mamool_Ja_Fetial',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,2536,51,'Mamool_Ja_Spotter',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,2519,51,'Mamool_Ja_Handler',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,2539,51,'Mamool_Jas_Lizard',0,128,0,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,2510,51,'Mamool_Ja_Cataphract',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,2541,51,'Mamool_Jas_Wyvern',0,128,0,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (62,2514,51,'Mamool_Ja_Entrancer',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (63,3505,51,'Scout_Puk',0,128,0,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (64,3309,51,'Raid_Raptor',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (65,280,51,'Attack_Ziz',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (66,361,51,'Battering_Bugard',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (67,4302,51,'War_Wyvern',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (68,3179,51,'Poroggo_Charmer',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (69,1846,51,'Gulool_Ja_Ja',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (70,944,51,'Decimator_Mabel_Ja',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (71,3910,51,'Thunderclap_Sareel_Ja',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (72,3909,51,'Thunderbolt_Piraal_Ja',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (73,3093,51,'Panurgic_Ryubool_Ja',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (74,3437,51,'Sagelord_Molaal_Ja',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (75,3789,51,'Strifelord_Bakool_Ja',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (76,2541,51,'Mamool_Jas_Wyvern',0,128,0,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (77,1182,51,'Eidolic_Qufeel_Ja',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (78,3516,51,'Searing_Vogaal_Ja',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (79,3493,51,'Scalding_Fafool_Ja',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (80,2521,51,'Mamool_Ja_Hussar',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (81,4025,51,'Troll_Paviser',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (82,4033,51,'Troll_Stormer',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (83,4020,51,'Troll_Hoplite',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (84,4026,51,'Troll_Pezhetairoi',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (85,4011,51,'Troll_Cannoneer',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (86,4037,51,'Troll_Velites',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (87,4031,51,'Troll_Speculator',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (88,4035,51,'Trolls_Automaton',0,128,0,0,0,78,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (89,1357,51,'Flame_Eruca',0,128,0,0,0,81,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (90,4301,51,'War_Wamouracampa',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (91,2072,51,'Incendiary_Bombs',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (92,1335,51,'Fighting_Flan',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (93,3620,51,'Siege_Scorpion',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (94,4300,51,'War_Wamoura',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (95,1851,51,'Gurfurlur_the_Menacing',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (96,1608,51,'Girzorhor_the_Imprudent',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (97,3812,51,'Surmerdar_the_Unbridled',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (98,922,51,'Dartorgor_the_Austere',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (99,4257,51,'Vorporlor_the_Barbaric',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (100,4255,51,'Vorjirzur_the_Valiant',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (101,4373,51,'Wordorbor_the_Artificer',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (102,754,51,'Cobalt_Sentinel',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (103,4335,51,'White_Sentinel',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (104,1904,51,'Hazel_Sentinel',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (105,643,51,'Carmine_Sentinel',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (106,4393,51,'Xarhorkur_the_Claviger',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (107,4524,51,'Zurmurwur_the_Ruthless',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (108,4014,51,'Troll_Destroyer',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (109,6744,51,'Kubool_Jas_Mhuufya',0,128,0,0,0,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (110,6745,51,'Vigilant_Kubool_Ja',0,128,0,0,0,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (111,6746,51,'Thuban',0,128,0,0,0,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (112,7133,51,'Mamool_Ja_Sapper',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (113,7134,51,'Mamool_Ja_Hospitaler',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (114,7135,51,'Mamool_Ja_Spotter',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (115,7136,51,'Mamool_Ja_Cataphract',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (116,7137,51,'Scout_Puk',0,128,0,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (117,7138,51,'Raid_Raptor',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (118,7139,51,'Attack_Ziz',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (119,7140,51,'Battering_Bugard',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (120,7141,51,'War_Wyvern',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (121,7142,51,'Gulool_Ja_Ja',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (122,7143,51,'Mamool_Ja_Hussar',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (123,7144,51,'Troll_Stormer',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (124,7145,51,'Troll_Hoplite',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (125,7146,51,'Troll_Cannoneer',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (126,7147,51,'Troll_Speculator',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (127,7148,51,'Flame_Eruca',0,128,0,0,0,81,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (128,7149,51,'War_Wamouracampa',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (129,7150,51,'Incendiary_Bombs',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (130,7151,51,'Fighting_Flan',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (131,7152,51,'Siege_Scorpion',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (132,7153,51,'Gurfurlur_the_Menacing',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (133,7154,51,'Troll_Destroyer',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (134,7188,51,'Chigoe_pet',0,128,466,0,0,71,73,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Bhaflau_Thickets (Zone 52)
@@ -2871,6 +3579,7 @@ INSERT INTO `mob_groups` VALUES (3,3344,52,'Red_Osculator',0,128,174,0,0,0,NULL)
 INSERT INTO `mob_groups` VALUES (4,2269,52,'Kissing_Leech',0,128,174,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,2616,52,'Mercurial_Makara',0,128,463,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,67,52,'Aht_Urhgan_Attercop',300,0,34,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,2396,52,'Lesser_Colibri',300,0,1509,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,6518,52,'Fomor_Beastmaster',300,1,0,0,0,0,NULL);
@@ -2964,6 +3673,101 @@ INSERT INTO `mob_groups` VALUES (95,7164,52,'Qutrub_Wastrel',0,128,0,0,0,0,NULL)
 INSERT INTO `mob_groups` VALUES (96,7165,52,'Expunger',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (97,7166,52,'Medusa',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (98,7188,52,'Chigoe_pet',0,128,466,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,67,52,'Aht_Urhgan_Attercop',300,0,34,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,2396,52,'Lesser_Colibri',300,0,1509,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,6518,52,'Fomor_Beastmaster',300,1,0,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1394,52,'Fomors_Bats',0,128,0,0,0,58,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,6516,52,'Fomor_Bard',300,1,0,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1900,52,'Haunt',300,1,1279,0,0,63,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,6524,52,'Fomor_Paladin',300,1,0,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,106,52,'Ameretat',300,0,63,0,0,65,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,4275,52,'Wajaom_Tiger',300,0,2601,0,0,67,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,4650,52,'Fomor_Thief',300,1,0,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,5137,52,'Harvestman',7200,0,2891,10000,0,72,72,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (17,3991,52,'Treant_Sapling',300,0,2463,0,0,66,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,714,52,'Chigoe_pet',0,128,466,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1787,52,'Grand_Marid',0,32,1617,0,0,78,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2562,52,'Marid',300,0,1617,0,0,77,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,765,52,'Colibri',300,0,500,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,5139,52,'Mahishasura',0,32,2893,15000,0,80,80,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (23,3343,52,'Red_Kisser',300,0,174,0,0,68,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,4034,52,'Troll_Surveillant',300,0,2477,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,4035,52,'Trolls_Automaton',0,128,0,0,0,70,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,4029,52,'Troll_Shieldbearer',300,0,2478,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,4027,52,'Troll_Sabreur',300,0,2477,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,923,52,'Date_Eruca',300,0,419,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,71,52,'Air_Elemental',300,4,38,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,2961,52,'Olden_Treant',300,0,597,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,768,52,'Colorful_Treant',300,0,502,0,0,74,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,2073,52,'Incubus_Bats',300,2,234,0,0,61,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1208,52,'Emergent_Elm',0,32,764,14000,0,77,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,3525,52,'Sea_Puk',300,0,2038,0,0,77,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,2537,52,'Mamool_Ja_Stabler',300,0,1594,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,2540,52,'Mamool_Jas_Raptor',0,128,0,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,2522,52,'Mamool_Ja_Infiltrator',300,0,1591,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,2525,52,'Mamool_Ja_Mimer',300,0,1592,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,2528,52,'Mamool_Ja_Philosopher',300,0,1587,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,3652,52,'Skoffin',300,0,2268,0,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,2529,52,'Mamool_Ja_Pikeman',300,0,1591,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,2541,52,'Mamool_Jas_Wyvern',0,128,0,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,5140,52,'Nis_Puk',0,32,2894,13000,0,77,77,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (44,2523,52,'Mamool_Ja_Lurker',300,0,1592,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,2507,52,'Mamool_Ja_Blusterer',300,0,1587,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,3153,52,'Plague_Chigoe',0,128,0,4500,0,62,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,393,52,'Berried_Chigoe',0,128,255,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,716,52,'Chigoes_Nit',0,128,0,0,0,48,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,916,52,'Dark_Rider',0,128,0,0,0,95,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,910,52,'Dark_Bugler',0,128,0,0,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,914,52,'Dark_Esquire',0,128,569,0,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,1802,52,'Locus_Colibri',60,0,1225,0,0,133,135,0,'ROV');
+INSERT INTO `mob_groups` VALUES (53,4355,52,'Locus_Wivre',60,0,2952,0,0,135,137,0,'ROV');
+INSERT INTO `mob_groups` VALUES (54,2423,52,'Lividroot_Amooshah',0,128,1526,30000,0,85,87,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,930,52,'Dea',0,128,577,25000,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,2336,52,'Lamia_Immolator',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,2337,52,'Lamia_Jaeger',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,2327,52,'Lamia_Commandress',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,2359,52,'Lamias_Elemental',0,128,0,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,2358,52,'Lamias_Avatar',0,128,0,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,2356,52,'Lamia_Rover',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (62,2626,52,'Merrow_Seafarer',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (63,2618,52,'Merrow_Cantatrice',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (64,2628,52,'Merrow_Shiranuhi',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (65,1505,52,'Gespenst',0,128,0,0,0,81,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (66,1520,52,'Assault_Draugar_blm',0,128,0,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (67,6719,52,'Assault_Draugar_thf',0,128,0,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (68,6721,52,'Assault_Draugar_drk',0,128,0,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (69,273,52,'Assault_Draugar_drg',0,128,0,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (70,1112,52,'Draugars_Wyvern',0,128,0,0,0,77,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (71,272,52,'Assault_Bhoot',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (72,3295,52,'Qutrub_Extortionist',0,128,0,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (73,3297,52,'Qutrub_Wastrel',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (74,1276,52,'Expunger',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (75,2606,52,'Medusa',0,128,0,0,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (76,2351,52,'Lamia_No34',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (77,2347,52,'Lamia_No21',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (78,2342,52,'Lamia_No15',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (79,2622,52,'Merrow_No11',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (80,2353,52,'Lamia_No9',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (81,2359,52,'Lamias_Elemental',0,128,0,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (82,2358,52,'Lamias_Avatar',0,128,0,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (83,2623,52,'Merrow_No12',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (84,2350,52,'Lamia_No3',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (85,2346,52,'Lamia_No2',0,128,0,0,0,85,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (86,39,52,'Acrolith',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (87,7155,52,'Lamia_Commandress',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (88,7156,52,'Lamia_Rover',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (89,7157,52,'Merrow_Seafarer',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (90,7158,52,'Merrow_Cantatrice',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (91,7159,52,'Merrow_Shiranuhi',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (92,7160,52,'Gespenst',0,128,0,0,0,81,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (93,7162,52,'Assault_Bhoot',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (94,7163,52,'Qutrub_Extortionist',0,128,0,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (95,7164,52,'Qutrub_Wastrel',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (96,7165,52,'Expunger',0,128,0,0,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (97,7166,52,'Medusa',0,128,0,0,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (98,7188,52,'Chigoe_pet',0,128,466,0,0,71,73,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Arrapago_Reef (Zone 54)
@@ -2977,6 +3781,7 @@ INSERT INTO `mob_groups` VALUES (4,4813,54,'Lahama_fished',0,128,1482,0,0,0,NULL
 INSERT INTO `mob_groups` VALUES (5,2426,54,'Llamhigyn_Y_Dwr',0,128,1528,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,1534,54,'Giant_Orobon',0,128,0,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (7,5192,54,'Reserve_Draugar_thf',960,0,2088,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,3355,54,'Reserve_Draugar_blm',960,0,2088,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (9,2619,54,'Merrow_Chantress',960,0,1658,0,0,0,NULL);
@@ -3069,6 +3874,100 @@ INSERT INTO `mob_groups` VALUES (95,6747,54,'Qutrub_blm',960,0,2885,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (96,6748,54,'Lamia_Idolater_blm',960,0,1492,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (97,2318,54,'Lahama',960,0,1482,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (98,7169,54,'Merrow_Typhoondancer',960,0,1657,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (7,5192,54,'Reserve_Draugar_thf',960,0,2088,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3355,54,'Reserve_Draugar_blm',960,0,2088,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2619,54,'Merrow_Chantress',960,0,1658,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,253,54,'Arrapago_Apkallu',960,0,145,0,0,70,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,2334,54,'Lamia_Graverobber',960,0,1487,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3130,54,'Phasma',960,0,1996,0,0,73,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,5193,54,'Reserve_Draugar_drk',960,0,2088,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,2329,54,'Lamia_Dartist',960,0,1487,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,2328,54,'Lamia_Dancer',960,0,1487,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,2359,54,'Lamias_Elemental',0,128,0,0,0,68,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,5194,54,'Reserve_Draugar_drg',960,0,2088,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1112,54,'Draugars_Wyvern',0,128,0,0,0,67,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2154,54,'Jnun',960,0,1408,0,0,77,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2890,54,'Nipper',960,0,555,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,2332,54,'Lamia_Fatedealer',960,0,1490,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,3294,54,'Qutrub_drk',960,0,2885,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,2366,54,'Lamie_No8',0,128,3310,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,258,54,'Ashakku',960,0,174,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,3231,54,'Purgatory_Bat',960,0,234,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,3267,54,'Qiqirn_Treasure_Hunter',960,0,2050,0,0,77,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,3258,54,'Qiqirn_Mine',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,3265,54,'Qiqirn_Trailer',960,0,2050,0,0,77,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1933,54,'Heraldic_Imp',960,0,1302,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,2365,54,'Lamie_No7',259200,0,3309,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,2627,54,'Merrow_Shadowdancer',960,0,1658,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,2620,54,'Merrow_Icedancer',960,0,1658,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,2621,54,'Merrow_Kabukidancer',960,0,1658,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,404,54,'Bhoot',960,0,262,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,2625,54,'Merrow_No5',259200,0,3308,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1292,54,'Fallen_Volunteer',960,0,0,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1286,54,'Fallen_Imperial_Wizard',960,0,0,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1285,54,'Fallen_Imperial_Trooper',960,0,0,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,5326,54,'Naraka_Bat',960,0,234,0,0,81,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,5327,54,'Nirgali',960,0,174,0,0,87,89,0,'ROV');
+INSERT INTO `mob_groups` VALUES (41,2324,54,'Lamia_Bellydancer',960,0,1485,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,1111,54,'Draugar_Servant_drk',960,0,702,0,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,3704,54,'Soulflayer',960,0,2030,0,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,5195,54,'Draugar_Servant_blm',960,0,702,0,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,5196,54,'Draugar_Servant_drg',960,0,702,0,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,2330,54,'Lamia_Deathdancer',960,0,1485,0,0,83,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,5197,54,'Draugar_Servant_thf',960,0,702,0,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,465,54,'Bloody_Bones',0,32,306,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,2629,54,'Merrow_Songstress',960,0,1657,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,2617,54,'Merrow_Bladedancer',960,0,1657,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,2043,54,'Ice_Elemental',960,4,1347,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,5328,54,'Nostokulshedra',960,0,290,0,0,88,89,0,'ROV');
+INSERT INTO `mob_groups` VALUES (53,2631,54,'Merrow_Wavedancer',960,0,1657,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,2335,54,'Lamia_Idolater_drk',960,0,1492,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,2338,54,'Lamia_Necromancer',960,0,1494,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,5892,54,'Euryale',7200,0,3091,20000,0,87,87,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (57,2361,54,'Lamia_Toxophilite',960,0,1495,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,6749,54,'Seneschal_Imp',960,0,1002,0,0,77,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,2630,54,'Merrow_Typhoondancer',960,0,1657,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,1211,54,'Emperor_Apkallu',960,0,767,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,2894,54,'Nix_Songstress',960,0,1657,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (62,913,54,'Dark_Elemental',960,4,568,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (63,2367,54,'Lamie_No9',259200,0,3011,0,0,80,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (64,2358,54,'Lamias_Avatar',0,128,0,0,0,72,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (65,5329,54,'Dweomershell',960,0,2668,0,0,88,90,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (66,2896,54,'Nix_Wavedancer',960,0,1657,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (67,2893,54,'Nix_Bladedancer',960,0,1657,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (68,2895,54,'Nix_Typhoondancer',960,0,1657,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (69,2364,54,'Lamie_Necromancer',960,0,1485,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (70,2362,54,'Lamie_Bellydancer',960,0,1485,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (71,2363,54,'Lamie_Deathdancer',960,0,1485,0,0,77,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (72,2368,54,'Lamie_Toxophilite',960,0,1495,0,0,77,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (73,5203,54,'Ephramadian_Shade_mnk',960,0,786,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (74,5202,54,'Ephramadian_Shade_rdm',960,0,786,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (75,5204,54,'Ephramadian_Shade_rng',960,0,786,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (76,5205,54,'Ephramadian_Shade_cor',960,0,786,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (77,573,54,'Bukki',0,128,0,7500,0,72,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (78,2339,54,'Lamia_No11',0,128,0,0,0,80,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (79,2348,54,'Lamia_No24',0,128,0,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (80,2344,54,'Lamia_No18',0,128,0,0,0,80,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (81,220,54,'Archaic_Mirror',0,128,160,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (82,2354,54,'Lamia_Palace_Guard_rng',0,128,0,0,0,81,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (83,2606,54,'Medusa',259200,0,1651,55000,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (84,2331,54,'Lamia_Exon',0,128,0,0,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (85,3057,54,'Ornery_Orobon',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (86,2345,54,'Lamia_No19',0,128,2996,18000,9000,78,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (87,2360,54,'Lamias_Skeleton',0,128,0,5000,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (88,2417,54,'Lil_Apkallu',0,128,1523,15000,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (89,4217,54,'Velionis',0,128,2576,15000,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (90,4490,54,'Zareehkl_the_Jubilant',0,128,2794,75000,0,85,86,0,NULL);
+INSERT INTO `mob_groups` VALUES (91,2920,54,'Nuhn',0,128,1828,36000,0,86,86,0,NULL);
+INSERT INTO `mob_groups` VALUES (92,5198,54,'Dimgruzub',0,128,0,0,5000,95,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (93,5199,54,'Assassins_Apprentice',0,128,0,0,5000,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (94,6673,54,'Lamia_Palace_Guard_cor',0,128,0,0,0,81,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (95,6747,54,'Qutrub_blm',960,0,2885,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (96,6748,54,'Lamia_Idolater_blm',960,0,1492,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (97,2318,54,'Lahama',960,0,1482,0,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (98,7169,54,'Merrow_Typhoondancer',960,0,1657,0,0,81,83,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Ilrusi_Atoll (Zone 55)
@@ -3255,6 +4154,7 @@ INSERT INTO `mob_groups` VALUES (4,4492,61,'Zazalda_Jagil',0,128,37,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,4260,61,'Vozold_Jagil',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,1534,61,'Giant_Orobon',0,128,969,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (7,4371,61,'Wootzshell',300,0,2668,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,3616,61,'Sicklemoon_Jagil',300,0,463,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (9,5330,61,'Sulphuric_Jagil',300,0,279,0,0,0,'ABYSSEA');
@@ -3310,11 +4210,69 @@ INSERT INTO `mob_groups` VALUES (58,6753,61,'Sarama',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (59,6750,61,'Fahrafahr_the_Bloodied',0,32,3259,0,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (60,4280,61,'Wamoura',0,128,2607,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (61,7287,61,'Assassin_Fly',300,0,571,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (7,4371,61,'Wootzshell',300,0,2668,0,0,70,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3616,61,'Sicklemoon_Jagil',300,0,463,0,0,73,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,5330,61,'Sulphuric_Jagil',300,0,279,0,0,87,88,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (10,3130,61,'Phasma',300,1,1996,0,0,73,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1160,61,'Earth_Elemental',300,4,733,0,0,74,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,271,61,'Assassin_Fly',300,0,571,0,0,71,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,2485,61,'Magmatic_Eruca',300,0,419,0,0,71,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1341,61,'Fire_Elemental',300,4,831,0,0,74,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,2758,61,'Mountain_Clot',300,0,0,0,0,72,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1954,61,'Hilltroll_Warrior',300,0,1313,0,0,79,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1951,61,'Hilltroll_Puppetmaster',300,0,1311,0,0,79,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4035,61,'Trolls_Automaton',0,128,0,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1946,61,'Hilltroll_Dark_Knight',300,0,1308,0,0,79,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1949,61,'Hilltroll_Monk',300,0,1309,0,0,79,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,4247,61,'Volcanic_Leech',300,0,17,0,0,72,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1953,61,'Hilltroll_Red_Mage',300,0,1312,0,0,79,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1950,61,'Hilltroll_Paladin',300,0,1310,0,0,79,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,4282,61,'Wamoura_Prince',300,0,2610,0,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,4280,61,'Wamoura',300,0,2608,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,3825,61,'Sweeping_Cluster',300,0,2367,0,0,73,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,4501,61,'Zhayolm_Apkallu',300,0,1447,0,0,70,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,5190,61,'Chary_Apkallu',0,0,3287,0,0,76,77,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (29,1170,61,'Ebony_Pudding',300,0,740,0,0,79,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1952,61,'Hilltroll_Ranger',300,0,1309,0,0,79,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,4031,61,'Troll_Speculator',0,128,0,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,2253,61,'King_Apkallu',300,0,1447,0,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,5331,61,'Orichalcumshell',300,0,2668,0,0,88,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (34,5843,61,'Ignamoth',0,32,3026,0,0,84,84,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (35,5332,61,'Scoriaceous_Eruca',300,0,419,0,0,88,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (36,894,61,'Dahak',1800,0,0,0,0,81,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,680,61,'Cerberus',172800,0,446,50000,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,916,61,'Dark_Rider',0,128,0,0,0,95,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,910,61,'Dark_Bugler',0,128,0,0,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,914,61,'Dark_Esquire',0,128,569,0,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,1215,61,'Energetic_Eruca',0,32,770,22500,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,1468,61,'Garharlor_the_Unruly',0,128,929,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1460,61,'Garfurlar_the_Rabid',0,128,0,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,1469,61,'Garhorlur_the_Brutal',0,128,0,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,122,61,'Ancient_Bombs',0,128,84,0,0,74,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,524,61,'Brass_Borer',0,128,347,15000,0,83,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,738,61,'Claret',0,128,477,15000,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,118,61,'Anantaboga',0,128,78,30000,0,85,87,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,2223,61,'Khromasoul_Bhurborlor',0,128,1438,39000,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,6686,61,'Troll_Grenadier',0,128,0,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,6685,61,'Troll_Cuirasser',0,128,0,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,6684,61,'Troll_Artilleryman',0,128,0,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,4019,61,'Troll_Hammersmith',0,128,0,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,3465,61,'Sarameya',0,128,2162,50000,0,88,89,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,5191,61,'Vanasarvik',0,128,0,0,25000,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,6751,61,'Elders_Imp',0,128,0,0,0,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,6752,61,'Grand_Grenade',0,128,0,0,0,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,6753,61,'Sarama',0,128,0,0,0,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,6750,61,'Fahrafahr_the_Bloodied',0,32,3259,0,0,80,80,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (60,4280,61,'Wamoura',0,128,2607,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,7287,61,'Assassin_Fly',300,0,571,0,0,71,76,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Halvung (Zone 62)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,3257,62,'Qiqirn_Mercenary',960,0,2050,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,3249,62,'Qiqirn_Diamantaire',960,0,2050,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,3258,62,'Qiqirn_Mine',0,128,0,0,0,0,NULL);
@@ -3338,6 +4296,31 @@ INSERT INTO `mob_groups` VALUES (20,1341,62,'Fire_Elemental',960,4,831,0,0,0,NUL
 INSERT INTO `mob_groups` VALUES (21,1426,62,'Friars_Lantern',960,0,908,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (22,5210,62,'Flammeri',0,128,0,22500,5000,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (23,4280,62,'Wamoura',0,128,2607,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,3257,62,'Qiqirn_Mercenary',960,0,2050,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,3249,62,'Qiqirn_Diamantaire',960,0,2050,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,3258,62,'Qiqirn_Mine',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,4244,62,'Volcanic_Bats',960,0,234,0,0,69,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,6471,62,'Purgatory_Bat',960,0,234,0,0,70,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,4017,62,'Troll_Gemologist',960,0,2478,0,0,71,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,4032,62,'Troll_Stoneworker',960,0,2474,0,0,71,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,4022,62,'Troll_Lapidarist',960,0,2480,0,0,71,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,4030,62,'Troll_Smelter',960,0,2474,0,0,71,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,4015,62,'Troll_Engraver',960,0,2477,0,0,71,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,4035,62,'Trolls_Automaton',0,128,0,0,0,69,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,4010,62,'Troll_Cameist',960,0,2477,0,0,71,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,4021,62,'Troll_Ironworker',960,0,2480,0,0,71,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1160,62,'Earth_Elemental',960,4,733,0,0,74,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,437,62,'Black_Pudding',960,0,740,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,4281,62,'Wamouracampa',960,0,2608,0,0,72,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,2485,62,'Magmatic_Eruca',960,0,419,0,0,71,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,5209,62,'Copper_Borer',7200,0,3291,22500,0,82,82,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (19,2686,62,'Moblin_Billionaire',960,0,1704,0,0,74,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1341,62,'Fire_Elemental',960,4,831,0,0,74,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,1426,62,'Friars_Lantern',960,0,908,0,0,72,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,5210,62,'Flammeri',0,128,0,22500,5000,79,80,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (23,4280,62,'Wamoura',0,128,2607,0,0,81,82,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 -- zone 62 group 24: free
 INSERT INTO `mob_groups` VALUES (25,4009,62,'Troll_Artilleryman',960,0,2473,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (26,4012,62,'Troll_Combatant',960,0,2473,0,0,0,NULL);
@@ -3426,6 +4409,7 @@ INSERT INTO `mob_groups` VALUES (2,2506,65,'Mamool_Ja_Bloodsucker',0,128,79,0,0,
 INSERT INTO `mob_groups` VALUES (3,2504,65,'Mamook_Mush',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,2503,65,'Mamook_Crab',0,128,203,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,2526,65,'Mamool_Ja_Mimicker',300,0,1588,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,2013,65,'Hunting_Raptor',960,0,600,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,765,65,'Colibri',960,0,500,0,0,0,NULL);
@@ -3494,6 +4478,76 @@ INSERT INTO `mob_groups` VALUES (69,6755,65,'Yalungur',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (70,6756,65,'Predatory_Colibri',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (71,3807,65,'Suhur_Mas',960,0,2359,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (72,7056,65,'Hundredfaced_clone',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,2526,65,'Mamool_Ja_Mimicker',300,0,1588,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,2013,65,'Hunting_Raptor',960,0,600,0,0,73,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,765,65,'Colibri',960,0,500,0,0,70,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,2545,65,'Mamool_Ja_Zenist',300,0,1593,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2533,65,'Mamool_Ja_Savant',300,0,1593,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,2534,65,'Mamool_Ja_Sophist',300,0,1593,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,2508,65,'Mamool_Ja_Bounder',300,0,1588,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,2538,65,'Mamool_Ja_Strapper',300,0,1588,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,2539,65,'Mamool_Jas_Lizard',0,128,0,0,0,66,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,648,65,'Carriage_Lizard',960,0,424,0,0,70,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,4508,65,'Ziz',960,0,2805,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,2535,65,'Mamool_Ja_Spearman',300,0,1588,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,2541,65,'Mamool_Jas_Wyvern',0,128,0,0,0,66,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6604,65,'Puk_M',960,0,2036,0,0,70,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1019,65,'Devout_Radol_Ja',0,128,646,0,0,83,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,4509,65,'Zizzy_Zillah',0,32,2807,0,0,79,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,2518,65,'Mamool_Ja_Frogman',300,0,1590,0,0,75,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,2513,65,'Mamool_Ja_Diver',960,0,1590,0,0,75,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,3177,65,'Poroggo',960,0,2014,0,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,71,65,'Air_Elemental',960,4,38,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,370,65,'Battle_Bugard',960,0,242,0,0,78,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1102,65,'Dragonscaled_Bugaal_Ja',100800,0,698,0,0,75,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,4067,65,'Tyrannobugard',0,128,0,0,0,78,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,527,65,'Brei',960,0,15,0,0,77,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,2008,65,'Hundredfaced_Hapool_Ja',259200,0,1337,0,0,75,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,3263,65,'Qiqirn_Poulterer',960,0,2050,0,0,77,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,3254,65,'Qiqirn_Goldsmith',960,0,2050,0,0,77,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,3258,65,'Qiqirn_Mine',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,3732,65,'Spinner',960,0,2337,0,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,2523,65,'Mamool_Ja_Lurker',300,0,1592,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,2528,65,'Mamool_Ja_Philosopher',300,0,1587,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,2525,65,'Mamool_Ja_Mimer',960,0,1592,0,0,80,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,2522,65,'Mamool_Ja_Infiltrator',300,0,1591,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,2507,65,'Mamool_Ja_Blusterer',300,0,1587,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,4308,65,'Watch_Wyvern',960,0,2628,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,6605,65,'Sea_Puk',960,0,2038,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,921,65,'Darting_Kachaal_Ja',259200,0,572,0,0,75,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,6363,65,'Nipper',960,0,271,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,2529,65,'Mamool_Ja_Pikeman',300,0,1591,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,2537,65,'Mamool_Ja_Stabler',300,0,1594,0,0,80,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,2540,65,'Mamool_Jas_Raptor',0,128,0,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,4737,65,'Firedance_Magmaal_Ja',0,32,3286,0,0,80,82,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (47,220,65,'Archaic_Mirror',0,128,160,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,2512,65,'Mamool_Ja_Conservator',0,128,0,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,2543,65,'Mamool_Ja_Treasurer',0,128,0,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,2505,65,'Mamool_Ja',0,128,0,0,0,75,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,6969,65,'Sagelord_Molaal_Ja',0,128,0,0,0,80,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,3560,65,'Shadelurking_Zolool_Ja',0,128,0,0,0,80,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,1400,65,'Forbidding_Koheel_Ja',0,128,0,0,0,80,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,1846,65,'Gulool_Ja_Ja',259200,0,1257,70000,0,85,88,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,2511,65,'Mamool_Ja_Chamberlain',0,128,0,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,2527,65,'Mamool_Ja_Palatine',0,128,0,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,647,65,'Carpophagous_Puk',0,128,0,0,0,77,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,3178,65,'Poroggo_Casanova',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,2656,65,'Mikilulu',0,128,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,2659,65,'Mikiruru',0,128,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,2881,65,'Nikilulu',0,128,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (62,2657,65,'Mikiluru',0,128,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (63,2658,65,'Mikirulu',0,128,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (64,691,65,'Chamrosh',0,128,450,9000,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (65,2089,65,'Iriri_Samariri',0,128,1367,28000,0,84,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (66,4295,65,'Wartkin',0,128,0,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (67,2541,65,'Mamool_Jas_Wyvern',0,128,0,0,0,77,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (68,6754,65,'Venomfang',0,128,0,0,0,78,78,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (69,6755,65,'Yalungur',0,128,0,0,0,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (70,6756,65,'Predatory_Colibri',0,128,0,0,0,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (71,3807,65,'Suhur_Mas',960,0,2359,0,0,68,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (72,7056,65,'Hundredfaced_clone',0,128,0,0,0,75,90,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Mamool_Ja_Training_Grounds (Zone 66)
@@ -3571,6 +4625,7 @@ INSERT INTO `mob_groups` VALUES (2,119,68,'Anautogenous_Slug',0,128,2738,0,0,0,N
 INSERT INTO `mob_groups` VALUES (3,665,68,'Cave_Pugil',0,128,2900,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,306,68,'Aydeewa_Crab',0,128,203,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,6354,68,'Treant_Sapling',960,0,2463,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,3224,68,'Puktrap',960,0,852,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,3670,68,'Slime_Mold',960,0,15,0,0,0,NULL);
@@ -3611,6 +4666,48 @@ INSERT INTO `mob_groups` VALUES (41,7174,68,'Pandemonium_Warden',0,128,1977,1470
 INSERT INTO `mob_groups` VALUES (42,7175,68,'Pandemonium_Warden',0,128,1977,147000,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (43,7176,68,'Pandemonium_Warden',0,128,1977,147000,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (44,7177,68,'Pandemonium_Warden',0,128,1977,147000,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,6354,68,'Treant_Sapling',960,0,2463,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3224,68,'Puktrap',960,0,852,0,0,67,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,3670,68,'Slime_Mold',960,0,15,0,0,67,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3252,68,'Qiqirn_Enterpriser',960,0,2050,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,3256,68,'Qiqirn_Lieuter',960,0,2050,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,3258,68,'Qiqirn_Mine',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1411,68,'Fossorial_Flea',960,0,466,0,0,64,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3131,68,'Phlebotomic_Slug',960,0,174,0,0,67,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,959,68,'Defoliator',960,0,598,0,0,68,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,71,68,'Air_Elemental',960,4,38,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,307,68,'Aydeewa_Diremite',960,0,204,0,0,70,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,2782,68,'Mycohopper',960,0,1439,0,0,68,71,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (17,1809,68,'Great_Ameretat',960,0,1238,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,5333,68,'Deforester',960,0,598,0,0,87,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (19,3245,68,'Qiqirn_Archaeologist',960,0,2050,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3261,68,'Qiqirn_Mosstrooper',960,0,2050,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,2720,68,'Mold_Eater',960,0,428,0,0,69,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,667,68,'Cave_Tiger',960,0,437,0,0,73,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,5334,68,'Mycoskulker',960,0,1759,0,0,89,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,5335,68,'Slime_Eater',960,0,428,0,0,87,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (25,5188,68,'Lizardtrap',7200,0,3083,10000,0,72,72,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (26,858,68,'Crystal_Eater',0,128,545,0,0,69,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,477,68,'Bluestreak_Gyugyuroon',0,32,317,0,0,82,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,2910,68,'Nosferatu',0,128,1824,33000,0,87,88,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,2911,68,'Nosferatu_Bats',0,128,0,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,2913,68,'Nosferatu_Wolf',0,128,0,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,2912,68,'Nosferatu_Murk',0,128,0,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,3090,68,'Pandemonium_Warden',0,128,1977,147000,0,86,88,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,3089,68,'Pandemonium_Lamp',0,128,0,9000,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,717,68,'Chigre',0,128,467,15000,0,82,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,4668,68,'Morta',0,128,0,0,9999,94,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,5187,68,'Ravishing_Rafflesia',0,128,0,0,0,92,93,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,0,68,'Tumult_Curator',0,128,0,0,0,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,0,68,'Tumult_Lamp',0,128,0,0,0,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,7172,68,'Pandemonium_Warden',0,128,1977,147000,0,86,88,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,7173,68,'Pandemonium_Warden',0,128,1977,147000,0,86,88,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,7174,68,'Pandemonium_Warden',0,128,1977,147000,0,86,88,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,7175,68,'Pandemonium_Warden',0,128,1977,147000,0,86,88,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,7176,68,'Pandemonium_Warden',0,128,1977,147000,0,86,88,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,7177,68,'Pandemonium_Warden',0,128,1977,147000,0,86,88,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Leujaoam_Sanctum (Zone 69)
@@ -3674,6 +4771,7 @@ INSERT INTO `mob_groups` VALUES (1,3145,71,'Pit_Monster',0,128,0,0,0,0,NULL);
 -- Alzadaal_Undersea_Ruins (Zone 72)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,2834,72,'Nepionic_Soulflayer',0,128,0,9600,9600,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,3263,72,'Qiqirn_Poulterer',300,0,2050,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,3254,72,'Qiqirn_Goldsmith',300,0,2050,0,0,0,NULL);
@@ -3686,6 +4784,20 @@ INSERT INTO `mob_groups` VALUES (9,705,72,'Cheese_Hoarder_Gigiroon',0,128,460,15
 INSERT INTO `mob_groups` VALUES (10,243,72,'Armed_Gears',0,128,168,32000,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (11,4594,72,'Wulgaru',0,128,2829,32000,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (12,6757,72,'Vidmapire',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,2834,72,'Nepionic_Soulflayer',0,128,0,6800,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,3263,72,'Qiqirn_Poulterer',300,0,2050,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,3254,72,'Qiqirn_Goldsmith',300,0,2050,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,6713,72,'Qiqirn_Mine',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,504,72,'Boompadu',7200,0,339,0,0,82,82,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (6,783,72,'Cookieduster_Lipiroon',0,32,507,15000,0,80,82,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (7,3069,72,'Oupire',14400,0,1961,0,0,85,85,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (8,2931,72,'Ob',0,128,1832,15000,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,705,72,'Cheese_Hoarder_Gigiroon',0,128,460,15000,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,243,72,'Armed_Gears',0,128,168,32000,0,86,88,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,4594,72,'Wulgaru',0,128,2829,32000,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,6757,72,'Vidmapire',0,128,0,0,0,99,99,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Zhayolm_Remnants (Zone 73)
@@ -4517,6 +5629,7 @@ INSERT INTO `mob_groups` VALUES (2,604,79,'Caedarva_Marshscum',0,128,15,0,0,0,NU
 INSERT INTO `mob_groups` VALUES (3,6767,79,'Suhur_Mas_fished',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,2426,79,'Llamhigyn_Y_Dwr',0,128,1528,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,714,79,'Chigoe',300,0,466,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,3224,79,'Puktrap',300,0,852,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,2580,79,'Marsh_Murre',300,0,1635,0,0,0,NULL);
@@ -4585,6 +5698,76 @@ INSERT INTO `mob_groups` VALUES (69,6758,79,'Shedu',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (70,0,79,'Vidhuwa_the_Wrathborn',0,128,0,0,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (71,7299,79,'Chigoe_pet',0,128,466,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (72,7188,79,'Chigoe',300,0,466,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,714,79,'Chigoe',300,0,466,0,0,62,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3224,79,'Puktrap',300,0,852,0,0,64,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,2580,79,'Marsh_Murre',300,0,1635,0,0,64,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,6354,79,'Treant_Sapling',300,0,0,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,4309,79,'Water_Elemental',300,4,2629,0,0,70,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,603,79,'Caedarva_Leech',300,0,174,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3049,79,'Orderly_Imp',300,0,1002,0,0,63,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,4342,79,'Wild_Karakul',300,0,2657,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,6483,79,'Jnun',300,0,1408,0,0,72,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,2957,79,'Oil_Slick',300,0,15,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,2587,79,'Mature_Treant',300,0,597,0,0,70,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,2332,79,'Lamia_Fatedealer',300,0,1490,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,6575,79,'Reserve_Draugar_blm',960,0,2088,0,0,73,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6576,79,'Reserve_Draugar_thf',960,0,2088,0,0,73,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,6636,79,'Heraldic_Imp',300,0,1302,0,0,79,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3738,79,'Spongilla_Fly',300,0,2310,0,0,78,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3912,79,'Thunder_Elemental',300,4,2410,0,0,70,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,2753,79,'Mosshorn',300,0,1741,0,0,80,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1193,79,'Elder_Treant',300,0,502,0,0,79,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,3264,79,'Qiqirn_Rock_Hound',960,0,2054,0,0,67,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1835,79,'Guard_Skeleton_blm',300,1,678,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,3260,79,'Qiqirn_Mireguide',960,0,2054,0,0,67,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,3258,79,'Qiqirn_Mine',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,5336,79,'Slough_Skua',300,0,1635,0,0,87,90,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (29,5203,79,'Ephramadian_Shade_mnk',960,0,786,0,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,5204,79,'Ephramadian_Shade_rng',960,0,786,0,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,5202,79,'Ephramadian_Shade_rdm',960,0,786,0,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,5205,79,'Ephramadian_Shade_cor',960,0,786,0,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1833,79,'Guard_Bhoot',300,0,1246,0,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,913,79,'Dark_Elemental',300,4,568,0,0,74,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,5195,79,'Draugar_Servant_blm',960,0,702,0,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1112,79,'Draugars_Wyvern',0,128,0,0,0,74,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,5196,79,'Draugar_Servant_drg',960,0,702,0,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,2335,79,'Lamia_Idolater_drk',300,0,1493,0,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,5197,79,'Draugar_Servant_thf',960,0,702,0,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,1111,79,'Draugar_Servant_drk',960,0,702,0,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,6674,79,'Lamia_Toxophilite',300,0,1495,0,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,2326,79,'Lamia_Chaukidar',300,0,1486,0,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,6672,79,'Lamia_Necromancer',300,0,1494,0,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,5206,79,'Aynu-Kaysey',0,128,2936,20000,5000,80,80,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (45,5337,79,'Vauxia_Fly',300,0,2310,0,0,86,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (46,6748,79,'Lamia_Idolater_blm',300,0,1493,0,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,2330,79,'Lamia_Deathdancer',0,128,0,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,916,79,'Dark_Rider',0,128,0,0,0,95,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,910,79,'Dark_Bugler',0,128,0,0,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,914,79,'Dark_Esquire',0,128,0,0,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,3109,79,'Peallaidh',0,32,2656,14400,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,4503,79,'Zikko',0,128,2799,9000,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,606,79,'Caedarva_Toad',0,128,0,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,2144,79,'Jazaraat',0,128,0,0,0,67,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,3331,79,'Ravin_Raven',0,128,2078,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,2349,79,'Lamia_No27',0,128,0,0,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,2752,79,'Moshdahn',0,128,0,25000,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,3704,79,'Soulflayer',300,0,2030,0,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,2220,79,'Khimaira',0,128,1437,72000,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,4221,79,'Verdelet',0,128,2578,22000,0,85,86,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,4063,79,'Tyger',0,128,2508,48000,0,88,90,0,NULL);
+INSERT INTO `mob_groups` VALUES (62,2489,79,'Mahjlaef_the_Paintorn',0,128,1576,37000,0,83,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (63,1272,79,'Experimental_Lamia',0,128,801,32000,0,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (64,2627,79,'Merrow_Shadowdancer',0,128,0,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (65,2630,79,'Merrow_Typhoondancer',0,128,0,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (66,5207,79,'Brekekekex',0,128,0,0,20000,95,96,0,NULL);
+INSERT INTO `mob_groups` VALUES (67,5208,79,'Chorus_Toad',0,128,0,0,20000,95,96,0,NULL);
+INSERT INTO `mob_groups` VALUES (68,6554,79,'Guard_Skeleton_war',300,1,678,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (69,6758,79,'Shedu',0,128,0,0,0,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (70,0,79,'Vidhuwa_the_Wrathborn',0,128,0,0,0,0,0,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (71,714,79,'Chigoe_pet',0,128,466,0,0,62,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (72,7188,79,'Chigoe',300,0,466,0,0,62,66,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Southern_San_dOria_[S] (Zone 80)
@@ -4869,6 +6052,7 @@ INSERT INTO `mob_groups` VALUES (3,1323,82,'Ferocious_Pugil',0,128,147,0,0,0,NUL
 INSERT INTO `mob_groups` VALUES (4,5133,82,'Thread_Leech_fished',0,128,895,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,2001,82,'Huge_Leech',0,128,0,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,2166,82,'Jugner_Funguar',300,0,1418,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,1405,82,'Forest_Leech',300,0,895,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,6274,82,'Orcish_Bowshooter',300,0,1871,0,0,0,NULL);
@@ -4915,6 +6099,54 @@ INSERT INTO `mob_groups` VALUES (48,3993,82,'Treefeller_Snogrog',0,128,0,0,0,0,N
 INSERT INTO `mob_groups` VALUES (49,3837,82,'Tainted_Treant',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (50,3150,82,'Pixietrap',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (51,3546,82,'Sentry_Sapling',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,2166,82,'Jugner_Funguar',300,0,1418,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1405,82,'Forest_Leech',300,0,895,0,0,38,41,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,6274,82,'Orcish_Bowshooter',300,0,1871,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,5733,82,'Snipper',300,0,483,0,0,38,41,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,4299,82,'War_Smilodon',300,0,828,0,0,59,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,2373,82,'Land_Pugil',300,0,2354,0,0,38,41,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3506,82,'Screamer',300,0,207,0,0,40,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,6309,82,'Stag_Beetle',300,0,2318,0,0,42,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,4285,82,'Wandering_Sapling',300,0,2616,0,0,38,41,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,947,82,'Decrepit_Gnole',300,0,590,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1517,82,'Ghoul_war',300,1,953,0,0,39,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3912,82,'Thunder_Elemental',300,4,2410,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,411,82,'Biddybug',300,0,267,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,548,82,'Brutal_Sheep',300,0,367,0,0,39,41,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,6760,82,'Voirloup',0,32,3311,0,0,88,88,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,1902,82,'Hawkertrap',300,0,243,0,0,40,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,4309,82,'Water_Elemental',300,4,2629,0,0,40,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,2052,82,'Ignis_Djinn',300,0,915,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,6358,82,'Walking_Tree',300,0,2604,0,0,48,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,2428,82,'Lobison',300,0,920,0,0,81,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,6289,82,'Orcish_Champion',300,0,1871,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,3005,82,'Orcish_Dragonbrander',300,0,1062,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,5154,82,'Orcish_Veteran',300,0,1922,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,6291,82,'Orcish_Protector',300,0,1922,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,5846,82,'Boll_Weevil',5400,0,3023,0,0,56,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,5155,82,'Gnoletrap',300,0,2913,0,0,92,93,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (32,5847,82,'Drumskull_Zogdregg',0,32,3029,15000,9999,83,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1639,82,'Goblin_Bombardier',300,0,1023,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1657,82,'Goblin_Field_Doctor',300,0,1025,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1693,82,'Goblin_Paratrooper',300,0,1122,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1697,82,'Goblin_Picket',300,0,1135,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1688,82,'Goblin_Mine',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,3645,82,'Skeleton_Esquire',0,128,769,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,3745,82,'Sprite',300,0,2000,0,0,66,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,1339,82,'Fingerfilcher_Dradzad',0,128,0,0,0,62,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,4264,82,'Vulkodlac',0,128,2593,0,0,74,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,755,82,'Cobraclaw_Buchzvotch',0,128,0,0,0,78,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,3038,82,'Orcish_Transporter',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,3018,82,'Orcish_Guard',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,915,82,'Dark_Ixion',0,128,573,100000,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,4514,82,'Zmag_Ognjeni_Vuk',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,1805,82,'Greater_Gnole',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,3993,82,'Treefeller_Snogrog',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,3837,82,'Tainted_Treant',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,3150,82,'Pixietrap',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,3546,82,'Sentry_Sapling',0,128,0,0,0,1,1,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- Voidwalker
 INSERT INTO `mob_groups` VALUES (52,6999,82,'Yilbegan',86400,0,3185,90000,5000,0,NULL);
@@ -5051,6 +6283,7 @@ INSERT INTO `mob_groups` VALUES (2,3885,83,'Thalassic_Pugil',0,128,463,0,0,0,NUL
 INSERT INTO `mob_groups` VALUES (3,23,83,'Abyssal_Pugil',0,128,463,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,7314,83,'Bloodsucker_fished',0,128,174,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,5174,83,'Duriumshell',300,0,0,0,0,0,'ABYSSEA');
 INSERT INTO `mob_groups` VALUES (6,1334,83,'Fierce_Smilodon',300,0,828,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,653,83,'Carrion_Marabou',300,0,43,0,0,0,NULL);
@@ -5201,6 +6434,158 @@ INSERT INTO `mob_groups` VALUES (151,5173,83,'Gaunab',0,128,0,0,9999,0,NULL);
 INSERT INTO `mob_groups` VALUES (152,6608,83,'Shadoweye',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (153,7180,83,'War_Smilodon',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (154,7266,83,'Chigoe',300,0,466,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,5174,83,'Duriumshell',300,0,0,0,0,92,94,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (6,1334,83,'Fierce_Smilodon',300,0,828,0,0,67,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,653,83,'Carrion_Marabou',300,0,43,0,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,71,83,'Air_Elemental',300,4,38,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2052,83,'Ignis_Djinn',300,0,915,0,0,70,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1572,83,'Gigas_Marine',300,0,985,0,0,78,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1558,83,'Gigas_Deckhand',300,0,985,0,0,78,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1568,83,'Gigas_Jack',300,0,985,0,0,78,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1565,83,'Gigas_Helmsman',300,0,985,0,0,78,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1594,83,'Gigass_Tiger',0,128,0,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3085,83,'Pallas',0,32,1974,14000,0,83,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3086,83,'Pallass_Tiger',0,128,0,4000,0,78,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1660,83,'Goblin_Flagman',300,0,1024,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1669,83,'Goblin_Grenadier',300,0,1086,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1671,83,'Goblin_Guerrilla',300,0,1056,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1720,83,'Goblins_Bat',0,128,0,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,1740,83,'Goblin_Toxophilite',300,0,1178,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1688,83,'Goblin_Mine',0,128,0,0,0,63,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1085,83,'Doom_Soldier',300,1,769,0,0,69,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1083,83,'Doom_Mage',300,1,678,0,0,69,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,557,83,'Bugard',300,0,371,0,0,66,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,5172,83,'Warabouc',7200,0,3075,8500,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,7048,83,'Robber_Crab',300,0,2107,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,6375,83,'Stygian_Pugil',300,0,2354,0,0,64,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,4285,83,'Wandering_Sapling',300,0,2323,0,0,35,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1900,83,'Haunt',300,1,264,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,3912,83,'Thunder_Elemental',300,4,2410,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,5876,83,'Big_Bang',0,32,3050,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,3990,83,'Treant',300,0,2461,0,0,73,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,6282,83,'Orcish_Gladiator',300,0,1910,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,5558,83,'Orcish_Hexspinner',300,0,1910,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,6286,83,'Orcish_Zerker',300,0,1922,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,6280,83,'Orcish_Footsoldier',300,0,1907,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,6350,83,'Demonic_Rose',300,0,2924,0,0,74,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,5171,83,'Judgmental_Julika',9000,0,3312,19000,0,82,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,6402,83,'Royal_Leech',300,0,895,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,6327,83,'Dragonfly',300,0,141,0,0,58,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,6312,83,'Chigoe',300,0,466,0,0,75,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1755,83,'Goliath_Beetle',300,0,169,0,0,34,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,1631,83,'Gnole',300,0,1011,0,0,66,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,6457,83,'Dire_Bat',300,2,234,0,0,61,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,3745,83,'Sprite',300,0,2000,0,0,66,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,3038,83,'Orcish_Transporter',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,3018,83,'Orcish_Guard',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,3203,83,'Procrustes',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,2160,83,'Jotunn_Ruffian',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,2470,83,'Madthrasher_Zradbodd',0,128,0,0,0,70,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,95,83,'Almops',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,1177,83,'Edonus',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,1617,83,'Glacial_Wisp',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,4121,83,'Valaineral_R_Davilles',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,3403,83,'Royal_Guard',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,2390,83,'Leonoyne',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,3486,83,'Savage_Hound_Condottiere',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,260,83,'Ashmea_B_Greinner',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,3495,83,'Scarlet_Boar_Esquire',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,1321,83,'Feldrautte_I_Rouhent',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (62,2909,83,'Norvallen_Knight',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (63,4481,83,'Yrvaulair_S_Cousseraux',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (64,3405,83,'Royal_Knight',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (65,2904,83,'Noillurie',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (66,3345,83,'Red_Rose_Condottiere',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (67,1752,83,'Gold_Badger_Esquire',0,128,0,0,0,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (68,91,83,'Allied_Mantelet',0,128,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (69,2799,83,'Nail_Bomb',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (70,90,83,'Allied_Belfry',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (71,3400,83,'Royal_Banneret',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (72,89,83,'Allied_Armored_Belfry',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (73,3401,83,'Royal_Esquire',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (74,3407,83,'Royal_Palliator',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (75,3408,83,'Royal_Provisioner',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (76,777,83,'Conqueror_Bakgodek',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (77,3767,83,'Steelhide_Protector',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (78,6759,83,'One-eyed_Gwajboj',0,128,0,10000,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (79,1852,83,'Gutrender_Trooper',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (80,935,83,'Deathlord_Rojgnoj',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (81,3730,83,'Spinebeak_Neckchopper',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (82,2127,83,'Jagidbods_Warmachine',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (83,6677,83,'Jagidbod_of_Clan_Reaper',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (84,737,83,'Clan_Reaper_Grunt',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (85,96,83,'Alpha_Gnole_Anders',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (86,132,83,'Anderss_Guard',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (87,2734,83,'Moonfang_Warrior',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (88,3902,83,'Three-eyed_Prozpuz',0,128,0,10000,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (89,3907,83,'Throatripper_Predator',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (90,735,83,'Clan_Bear_Fighter',0,128,0,0,0,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (91,776,83,'Confederate_Mantelet',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (92,2100,83,'Iron_Bomb',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (93,775,83,'Confederate_Belfry',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (94,3037,83,'Orcish_Strongarm',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (95,3040,83,'Orcish_Turret',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (96,4299,83,'War_Smilodon',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (97,1333,83,'Fiendish_Leechkeeper',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (98,3569,83,'Shadowhorn',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (99,3570,83,'Shadowhorn_Stormer',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (100,3565,83,'Shadowhand',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (101,3566,83,'Shadowhand_Cuirassier',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (102,3563,83,'Shadowfang',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (103,3564,83,'Shadowfang_Void',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (104,3562,83,'Shadoweye_Gnat',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (105,1408,83,'Fortification',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (106,3366,83,'Rikoh_Wahcondalo',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (107,2179,83,'Kagetora',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (108,896,83,'Dalzakk',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (109,2949,83,'Oggbi',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (110,3312,83,'Rainemard',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (111,6823,83,'Maat',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (112,960,83,'Degenhard',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (113,311,83,'Azima',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (114,725,83,'Choh_Moui',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (115,312,83,'Azo',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (116,4118,83,'Vahi',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (117,3391,83,'Rongo-Nango',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (118,2391,83,'Lerren',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (119,2137,83,'Jajaro',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (120,3176,83,'Popochu',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (121,3096,83,'Papako',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (122,2730,83,'Momowa',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (123,4081,83,'Ulla',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (124,2226,83,'Kilhwch',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (125,84,83,'Alfons',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (126,37,83,'Achtelle',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (127,526,83,'Bravo',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (128,1141,83,'Duskraven',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (129,1143,83,'Dusk_Raider',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (130,227,83,'Areuhat',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (131,2946,83,'Odzmanouk',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (132,502,83,'Boodlix',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (133,1681,83,'Goblin_Lansquenet',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (134,3926,83,'Titania',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (135,1279,83,'Faerie',0,128,0,0,0,77,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (136,320,83,'Babban_Ny_Mheillea',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (137,18,83,'Abenzio',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (138,549,83,'Bryher',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (139,616,83,'Camlin',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (140,903,83,'Darach',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (141,3310,83,'Raigegue_R_dOraguille',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (142,126,83,'Ancient_Royal_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (143,1262,83,'Eurytos',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (144,1574,83,'Gigas_Mercenary',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (145,3184,83,'Poroggo_Prince',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (146,3186,83,'Poroggo_Servant',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (147,2180,83,'Kaiser_Behemoth',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (148,1324,83,'Ferreous_Coffin',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (149,2403,83,'Lewenhart',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (150,291,83,'Auroral_Alicorn',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (151,5173,83,'Gaunab',0,128,0,0,9999,98,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (152,6608,83,'Shadoweye',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (153,7180,83,'War_Smilodon',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (154,7266,83,'Chigoe',300,0,466,0,0,75,78,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Batallia_Downs_[S] (Zone 84)
@@ -5213,6 +6598,7 @@ INSERT INTO `mob_groups` VALUES (3,7310,84,'Cutter_fished',0,128,93,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,7311,84,'Greater_Pugil_fished',0,128,279,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,6029,84,'Kraken_fished',0,128,1464,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,1072,84,'Djinn',300,0,671,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,1160,84,'Earth_Elemental',300,4,733,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,3435,84,'Sadfly',300,0,141,0,0,0,NULL);
@@ -5250,6 +6636,45 @@ INSERT INTO `mob_groups` VALUES (39,3512,84,'Scythefang_Liger',0,128,0,0,0,0,NUL
 INSERT INTO `mob_groups` VALUES (40,4055,84,'Tusked_Tigon',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (41,1627,84,'Gnashfang_Rahskhas',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (42,3307,84,'Rahskhass_Pet',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,1072,84,'Djinn',300,0,671,0,0,55,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1160,84,'Earth_Elemental',300,4,733,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3435,84,'Sadfly',300,0,141,0,0,29,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1664,84,'Goblin_Freesword',300,0,1063,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1646,84,'Goblin_Corpsman',300,0,1024,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1638,84,'Goblin_Blastmaster',300,0,1024,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1698,84,'Goblin_Pioneer',300,0,1136,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1688,84,'Goblin_Mine',0,128,0,0,0,58,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,5364,84,'Smilodon',300,0,828,0,0,46,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,6571,84,'Wight_war',300,1,958,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,6570,84,'Wight_blm',300,1,958,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,6353,84,'Stalking_Sapling',300,0,2323,0,0,24,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1266,84,'Evil_Spirit',300,1,795,0,0,41,41,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2456,84,'Lycopodium',300,0,1552,0,0,28,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,6445,84,'Ba',300,0,207,0,0,33,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,5759,84,'Burlibix_Brawnback',0,32,3043,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,6361,84,'Clipper',300,0,480,0,0,32,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,2043,84,'Ice_Elemental',300,4,1347,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,5338,84,'Tsetse_Fly',300,0,923,0,0,93,94,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (25,1402,84,'Forester_Beetle',300,0,140,0,0,47,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,2382,84,'La_Velue',0,32,1503,0,0,62,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,5760,84,'Habergoass',0,32,3044,8000,0,64,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,5546,84,'Chaneque',5400,0,2986,5000,0,56,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,3020,84,'Orcish_Impaler',300,0,1884,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,3001,84,'Orcish_Chasseur',300,0,1884,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,6272,84,'Orcish_Brawler',300,0,1878,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,6284,84,'Orcish_Trooper',300,0,1879,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1631,84,'Gnole',300,0,1011,0,0,65,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,3148,84,'Pixie',300,0,2000,0,0,57,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,3448,84,'Sandworm',86400,0,0,0,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,3038,84,'Orcish_Transporter',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,3018,84,'Orcish_Guard',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,915,84,'Dark_Ixion',0,128,573,100000,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,3512,84,'Scythefang_Liger',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,4055,84,'Tusked_Tigon',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,1627,84,'Gnashfang_Rahskhas',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,3307,84,'Rahskhass_Pet',0,128,0,0,0,0,0,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- Voidwalker
 INSERT INTO `mob_groups` VALUES (43,6999,84,'Yilbegan',86400,0,3185,90000,5000,0,NULL);
@@ -5709,6 +7134,7 @@ INSERT INTO `mob_groups` VALUES (3,6771,88,'Land_Crab_fished',0,128,93,0,0,0,NUL
 INSERT INTO `mob_groups` VALUES (4,6769,88,'Pug_Pugil_fished',0,128,463,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,1336,88,'Fighting_Pugil',0,128,279,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,6336,88,'Huge_Spider',300,0,635,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,6423,88,'Ding_Bats',300,2,3373,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,3058,88,'Ornery_Sheep',300,0,367,0,0,0,NULL);
@@ -5758,6 +7184,57 @@ INSERT INTO `mob_groups` VALUES (51,1319,88,'Feeorin',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (52,1307,88,'Fay',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (53,3750,88,'Stabnix_Skewerfinger',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (54,3151,88,'Pixie_Impaler',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,6336,88,'Huge_Spider',300,0,635,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,6423,88,'Ding_Bats',300,2,3373,0,0,26,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3058,88,'Ornery_Sheep',300,0,367,0,0,25,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,6511,88,'Revenant',300,1,2093,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,5844,88,'Ankabut',0,32,3027,0,0,50,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,4053,88,'Tunnel_Worm',300,0,428,0,0,10,12,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,4277,88,'Walking_Sapling',300,0,2603,0,0,12,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,3371,88,'River_Crab',0,128,481,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,4266,88,'Vulture',300,0,207,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1662,88,'Goblin_Franctireur',300,0,1058,0,0,56,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1652,88,'Goblin_Draftee',300,0,1044,0,0,56,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,789,88,'Coppercap',300,0,346,0,0,41,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,441,88,'Black_Wolf',300,1,287,0,0,31,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,6236,88,'Young_Quadav',300,0,1233,0,0,59,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,107,88,'Amethyst_Quadav',300,0,65,0,0,59,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,103,88,'Amber_Quadav',300,0,57,0,0,59,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,6543,88,'Enchanted_Bones_war',300,1,677,0,0,30,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,6546,88,'Enchanted_Bones_blm',300,1,677,0,0,30,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,6419,88,'Rock_Eater',300,0,428,0,0,32,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1623,88,'Gloomanita',0,32,1006,0,0,42,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,6464,88,'Fledermaus',300,2,461,0,0,45,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,5870,88,'Olgoi-Khorkhoi',0,128,3285,4500,5000,53,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,6239,88,'Veteran_Quadav',300,0,1233,0,0,59,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,6237,88,'Greater_Quadav',300,0,1233,0,0,59,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,6238,88,'Onyx_Quadav',300,0,1861,0,0,59,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1644,88,'Goblin_Chapman',300,0,1036,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1633,88,'Goblin_Aidman',300,0,1013,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,6661,88,'Goblin_Freelance',300,0,1060,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,2000,88,'Huge_Hornet',300,0,584,0,0,38,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1695,88,'Goblin_Patrolman',300,0,1134,0,0,56,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,6304,88,'Goblins_Bee',0,128,0,0,0,52,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,6301,88,'Maneating_Hornet',300,0,584,0,0,40,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,3148,88,'Pixie',300,0,2000,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,3780,88,'Stone_Eater',300,0,428,0,0,18,22,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,3381,88,'Rock_Lizard',300,0,2119,0,0,21,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,5871,88,'Peaseblossom',0,128,3082,0,0,74,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,2400,88,'Lesser_Wivre',300,0,1515,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,6241,88,'Copper_Quadav',300,0,511,0,0,59,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,5339,88,'Drachenlizard',300,0,3024,0,0,92,94,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (45,1713,88,'Goblin_Skirmisher',300,0,1158,0,0,56,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1688,88,'Goblin_Mine',0,128,0,0,0,51,51,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,3448,88,'Sandworm',86400,0,0,0,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,1696,88,'Goblin_Picaroon',300,0,0,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,3276,88,'Quadav_Transporter',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,3274,88,'Quadav_Guard',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,1319,88,'Feeorin',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,1307,88,'Fay',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,3750,88,'Stabnix_Skewerfinger',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,3151,88,'Pixie_Impaler',0,128,0,0,0,0,0,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- Voidwalker
 INSERT INTO `mob_groups` VALUES (55,6999,88,'Yilbegan',86400,0,3185,90000,5000,0,NULL);
@@ -5880,6 +7357,7 @@ INSERT INTO `mob_groups` VALUES (3,1955,89,'Hill_Crab',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,1336,89,'Fighting_Pugil',0,128,279,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,1603,89,'Gill_Pugil',0,128,147,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,6419,89,'Rock_Eater',300,0,428,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,5642,89,'War_Lizard',300,0,221,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,71,89,'Air_Elemental',300,4,38,0,0,0,NULL);
@@ -6036,6 +7514,164 @@ INSERT INTO `mob_groups` VALUES (158,7167,89,'Goblin_Lansquenet',0,128,0,0,0,0,N
 INSERT INTO `mob_groups` VALUES (159,7171,89,'Air_Elemental',300,4,38,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (160,7178,89,'Goblin_Mine',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (161,7267,89,'Ajattara',300,0,42,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,6419,89,'Rock_Eater',300,0,428,0,0,33,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,5642,89,'War_Lizard',300,0,221,0,0,41,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,71,89,'Air_Elemental',300,4,38,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,4285,89,'Wandering_Sapling',300,0,2617,0,0,36,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,441,89,'Black_Wolf',300,1,287,0,0,49,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,6440,89,'Wingrats',300,2,234,0,0,41,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,5648,89,'Wivre',300,0,2665,0,0,68,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,2275,89,'Knotty_Treant',300,0,1458,0,0,62,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1664,89,'Goblin_Freesword',300,0,1063,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1646,89,'Goblin_Corpsman',300,0,1024,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,5340,89,'Feyweald_Sapling',300,0,2620,0,0,92,94,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (17,1638,89,'Goblin_Blastmaster',300,0,1024,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,3912,89,'Thunder_Elemental',300,4,2410,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,6312,89,'Chigoe',300,0,466,0,0,43,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,4883,89,'Sarcopsylla',7200,0,3085,7860,7000,72,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,7073,89,'Vasiliceratops',0,32,3299,18750,0,88,89,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,6473,89,'Vampire_Bat',300,2,80,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,6238,89,'Onyx_Quadav',300,0,1861,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,6236,89,'Young_Quadav',300,0,1233,0,0,61,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,6241,89,'Copper_Quadav',300,0,511,0,0,61,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,107,89,'Amethyst_Quadav',300,0,65,0,0,61,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1083,89,'Doom_Mage',300,1,678,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1085,89,'Doom_Soldier',300,1,769,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,71,89,'Air_Elemental',300,4,38,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1793,89,'Grauberg_Hippogryph',300,0,1219,0,0,73,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,4869,89,'Kotan-kor_Kamuy',0,32,2950,13000,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,74,89,'Ajattara',300,0,42,0,0,79,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,3501,89,'Scitalis',0,32,2182,10800,0,83,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,3617,89,'Sidhe',300,0,2250,0,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,523,89,'Brasscap',300,0,346,0,0,59,61,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,3114,89,'Peiste',300,0,1986,0,0,66,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,3464,89,'Sapphirine_Quadav',300,0,2160,0,0,61,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1917,89,'Heliodor_Quadav',300,0,354,0,0,61,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,6243,89,'Bronze_Quadav',300,0,360,0,0,61,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,3628,89,'Silver_Quadav',300,0,2251,0,0,61,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,6242,89,'Old_Quadav',300,0,348,0,0,61,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,6240,89,'Brass_Quadav',300,0,349,0,0,61,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,6239,89,'Veteran_Quadav',300,0,1233,0,0,61,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,6237,89,'Greater_Quadav',300,0,1233,0,0,61,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,6503,89,'Blood_Soul',300,1,311,0,0,53,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,3148,89,'Pixie',300,0,2000,0,0,51,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,1698,89,'Goblin_Pioneer',300,0,1136,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,1688,89,'Goblin_Mine',0,128,0,0,0,59,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,2654,89,'Migratory_Hippogryph',0,128,0,2000,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,3276,89,'Quadav_Transporter',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,3274,89,'Quadav_Guard',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,915,89,'Dark_Ixion',0,128,573,100000,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,3629,89,'Simorg',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,1959,89,'Hippocentaur',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,3421,89,'RuBha_Stonewall',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,3544,89,'Sentinel_Wivre',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,352,89,'Bartholomaus',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,2,89,'1st_Iron_Musketeer',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,2590,89,'Maximilian',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,3,89,'1st_Legionnaire',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,2445,89,'Ludwig',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (62,7,89,'2nd_Legionnaire',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (63,1198,89,'Elivira',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (64,1,89,'1st_Gold_Musketeer',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (65,2300,89,'Kurt',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (66,13,89,'8th_Iron_Musketeer',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (67,50,89,'Adelheid',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (68,3098,89,'Paralyzing_Tube',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (69,3624,89,'Silencing_Tube',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (70,420,89,'Binding_Tube',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (71,9,89,'2nd_Legion_Scout',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (72,11,89,'4th_Legionnaire',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (73,91,89,'Allied_Mantelet',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (74,2799,89,'Nail_Bomb',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (75,90,89,'Allied_Belfry',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (76,4,89,'1st_Legion_Aidman',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (77,89,89,'Allied_Armored_Belfry',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (78,5,89,'1st_Legion_Mercenary',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (79,1332,89,'Field_Woundpatcher',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (80,3354,89,'Republic_Supplier',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (81,1066,89,'DiDha_Adamantfist',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (82,1067,89,'DiDhas_Elite_Guard',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (83,516,89,'BoDho_Hundredfist',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (84,4315,89,'Waughroon_Heavyshell',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (85,6681,89,'DeVyu_Headhunter',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (86,381,89,'Beadeaux_Vanguard',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (87,6680,89,'BiGho_Headtaker',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (88,3293,89,'Qulun_Heavyshell',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (89,1779,89,'GoBhu_Herohunter',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (90,1780,89,'GoBhus_Elite_Raider',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (91,6682,89,'NoMho_Crimsonarmor',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (92,2917,89,'NoMhos_Elite_Guard',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (93,517,89,'BoDhos_Shieldwarrior',0,128,0,0,0,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (94,776,89,'Confederate_Mantelet',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (95,2100,89,'Iron_Bomb',0,128,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (96,775,89,'Confederate_Belfry',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (97,2224,89,'Khroma_Quadav',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (98,3277,89,'Quadav_Turret',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (99,4296,89,'War_Ajattara',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (100,1333,89,'Fiendish_Leechkeeper',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (101,3569,89,'Shadowhorn',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (102,3570,89,'Shadowhorn_Stormer',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (103,3565,89,'Shadowhand',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (104,3566,89,'Shadowhand_Cuirassier',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (105,3563,89,'Shadowfang',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (106,3564,89,'Shadowfang_Void',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (107,6608,89,'Shadoweye',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (108,3562,89,'Shadoweye_Gnat',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (109,1408,89,'Fortification',0,128,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (110,3366,89,'Rikoh_Wahcondalo',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (111,2179,89,'Kagetora',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (112,896,89,'Dalzakk',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (113,2949,89,'Oggbi',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (114,3312,89,'Rainemard',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (115,6823,89,'Maat',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (116,960,89,'Degenhard',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (117,311,89,'Azima',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (118,725,89,'Choh_Moui',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (119,6312,89,'Chigoe',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (120,312,89,'Azo',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (121,4118,89,'Vahi',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (122,3391,89,'Rongo-Nango',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (123,2391,89,'Lerren',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (124,2137,89,'Jajaro',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (125,3176,89,'Popochu',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (126,3096,89,'Papako',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (127,2730,89,'Momowa',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (128,4081,89,'Ulla',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (129,2226,89,'Kilhwch',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (130,84,89,'Alfons',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (131,37,89,'Achtelle',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (132,526,89,'Bravo',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (133,1141,89,'Duskraven',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (134,1143,89,'Dusk_Raider',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (135,227,89,'Areuhat',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (136,2946,89,'Odzmanouk',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (137,502,89,'Boodlix',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (138,1681,89,'Goblin_Lansquenet',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (139,3926,89,'Titania',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (140,1279,89,'Faerie',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (141,320,89,'Babban_Ny_Mheillea',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (142,18,89,'Abenzio',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (143,549,89,'Bryher',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (144,616,89,'Camlin',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (145,903,89,'Darach',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (146,3310,89,'Raigegue_R_dOraguille',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (147,126,89,'Ancient_Royal_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (148,1262,89,'Eurytos',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (149,1574,89,'Gigas_Mercenary',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (150,3184,89,'Poroggo_Prince',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (151,3186,89,'Poroggo_Servant',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (152,2180,89,'Kaiser_Behemoth',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (153,1324,89,'Ferreous_Coffin',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (154,2403,89,'Lewenhart',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (155,291,89,'Auroral_Alicorn',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (156,4679,89,'Ocythoe',0,128,0,0,9999,90,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (157,6821,89,'Cetus',0,128,0,90000,0,150,150,0,NULL);
+INSERT INTO `mob_groups` VALUES (158,7167,89,'Goblin_Lansquenet',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (159,7171,89,'Air_Elemental',300,4,38,0,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (160,7178,89,'Goblin_Mine',0,128,0,0,0,59,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (161,7267,89,'Ajattara',300,0,42,0,0,79,83,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Pashhow_Marshlands_[S] (Zone 90)
@@ -6214,6 +7850,7 @@ INSERT INTO `mob_groups` VALUES (3,1991,91,'Horrid_Fluke',0,128,895,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,5868,91,'Greater_Pugil_fished',0,128,279,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,418,91,'Big_Leech',0,128,0,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,2456,91,'Lycopodium',300,0,1552,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,6302,91,'Death_Wasp',300,0,584,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,2369,91,'Lamina',0,128,2991,6525,0,0,NULL);
@@ -6266,6 +7903,60 @@ INSERT INTO `mob_groups` VALUES (54,1147,91,'DuVha_Grimewind',0,128,0,0,0,0,NULL
 INSERT INTO `mob_groups` VALUES (55,1168,91,'EaZhu_Tremorcrag',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (56,1615,91,'GiRho_Wrathstorm',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (57,1940,91,'HeDho_Spatesurge',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,2456,91,'Lycopodium',300,0,1552,0,0,28,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,6302,91,'Death_Wasp',300,0,584,0,0,38,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,2369,91,'Lamina',0,128,2991,6525,0,57,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1757,91,'Goobbue_Farmer',300,0,1197,0,0,59,61,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1341,91,'Fire_Elemental',300,4,831,0,0,43,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,6312,91,'Chigoe',300,0,466,0,0,75,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,6467,91,'Moon_Bat',300,2,461,0,0,38,41,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,6571,91,'Wight_war',300,1,958,0,0,50,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,6573,91,'Wight_blm',300,1,958,0,0,50,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,789,91,'Coppercap',300,0,346,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,6430,91,'Midnight_Wings',300,2,82,0,0,38,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,6400,91,'Poison_Leech',300,0,895,0,0,44,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1695,91,'Goblin_Patrolman',300,0,1134,0,0,56,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1662,91,'Goblin_Franctireur',300,0,1058,0,0,56,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1724,91,'Goblins_Crawler',0,128,0,0,0,51,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3492,91,'Scabrous_Slug',300,0,2172,0,0,56,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1652,91,'Goblin_Draftee',300,0,1044,0,0,56,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1151,91,'Dyinyinga',0,32,728,7700,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,4309,91,'Water_Elemental',300,4,2629,0,0,43,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,6505,91,'Evil_Spirit',300,1,795,0,0,43,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,6305,91,'Death_Jacket',300,0,584,0,0,38,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,6822,91,'Erle',0,32,3297,6200,0,62,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,6327,91,'Dragonfly',300,0,141,0,0,58,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,5840,91,'Champion_Crawler',300,0,3025,0,0,93,94,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (30,6315,91,'Berry_Grub',300,0,256,0,0,42,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,6361,91,'Clipper',300,0,93,0,0,43,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,2940,91,'Ochu',300,0,2920,0,0,64,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,6242,91,'Old_Quadav',300,0,348,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1917,91,'Heliodor_Quadav',300,0,354,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,6324,91,'Hawker',300,0,141,0,0,38,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,4375,91,'Worker_Crawler',300,0,256,0,0,60,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,4702,91,'Delicieuse_Delphine',0,32,3038,9000,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,3628,91,'Silver_Quadav',300,0,2251,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1207,91,'Emerald_Quadav',300,0,761,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,6243,91,'Bronze_Quadav',300,0,360,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,3464,91,'Sapphirine_Quadav',300,0,2161,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,6240,91,'Brass_Quadav',300,0,349,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,3745,91,'Sprite',300,0,2000,0,0,61,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,1713,91,'Goblin_Skirmisher',300,0,1158,0,0,58,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,1688,91,'Goblin_Mine',0,128,0,0,0,53,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,3448,91,'Sandworm',0,128,0,0,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,3276,91,'Quadav_Transporter',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,3274,91,'Quadav_Guard',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,915,91,'Dark_Ixion',0,128,573,100000,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,1847,91,'Gummy_Guillaume',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,2270,91,'Kloesse',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,14,91,'AaBho_Slashburner',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,518,91,'BoGha_Winterkill',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,1147,91,'DuVha_Grimewind',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,1168,91,'EaZhu_Tremorcrag',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,1615,91,'GiRho_Wrathstorm',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,1940,91,'HeDho_Spatesurge',0,128,0,0,0,0,0,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- Voidwalker
 INSERT INTO `mob_groups` VALUES (58,6999,91,'Yilbegan',86400,0,3185,90000,5000,0,NULL);
@@ -6704,6 +8395,7 @@ INSERT INTO `mob_groups` VALUES (3,2768,95,'Mud_Pugil',0,128,975,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,6769,95,'Pug_Pugil_fished',0,128,463,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,1336,95,'Fighting_Pugil',0,128,279,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,2472,95,'Mad_Fox',300,1,287,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,3304,95,'Rafflesia',300,0,2070,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,583,95,'Bumblebee',300,0,387,0,0,0,NULL);
@@ -6750,6 +8442,54 @@ INSERT INTO `mob_groups` VALUES (48,6736,95,'Kindred_Incantor',0,128,0,0,0,0,NUL
 INSERT INTO `mob_groups` VALUES (49,6737,95,'Blurry_Eye',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (50,3387,95,'Romaa_Mihgo',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (51,0,95,'Protective_Ward',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,2472,95,'Mad_Fox',300,1,287,0,0,48,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,3304,95,'Rafflesia',300,0,2070,0,0,49,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,583,95,'Bumblebee',300,0,387,0,0,15,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,650,95,'Carrion_Crow',300,0,425,0,0,22,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,3489,95,'Savanna_Dhalmel',300,0,2169,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,831,95,'Crawler',300,0,256,0,0,18,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3490,95,'Savanna_Rarab',300,0,2170,0,0,12,15,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1695,95,'Goblin_Patrolman',300,0,1134,0,0,56,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1731,95,'Goblins_Rarab',0,128,0,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1652,95,'Goblin_Draftee',300,0,1044,0,0,56,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,5731,95,'Belladonna',6000,0,2995,4000,0,53,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3923,95,'Tiny_Lycopodium',300,0,1552,0,0,10,12,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1662,95,'Goblin_Franctireur',300,0,1058,0,0,56,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2145,95,'Jeduah',0,32,1406,0,0,17,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3371,95,'River_Crab',300,0,481,0,0,22,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,5341,95,'Hispid_Rarab',300,0,326,0,0,92,93,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (22,6262,95,'Yagudo_Mendicant',300,0,2730,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,4454,95,'Yagudos_Elemental',0,128,0,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,6263,95,'Yagudo_Piper',300,0,2742,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,6261,95,'Yagudo_Scribe',300,0,2760,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,6259,95,'Yagudo_Acolyte',300,0,2691,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,6260,95,'Yagudo_Initiate',300,0,2715,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,6733,95,'Tiffenotte',7200,0,3082,0,0,72,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,4440,95,'Yagudo_Persecutor',300,0,2740,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,4411,95,'Yagudo_Condottiere',300,0,2700,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1713,95,'Goblin_Skirmisher',300,0,1158,0,0,56,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1688,95,'Goblin_Mine',0,128,0,0,0,52,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,3148,95,'Pixie',300,0,2000,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,3181,95,'Poroggo_Gent',300,8,2033,0,0,56,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,3934,95,'Toad',300,0,2033,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,4710,95,'Ramponneau',0,32,2987,0,5000,47,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,3448,95,'Sandworm',86400,0,0,0,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1696,95,'Goblin_Picaroon',300,0,0,0,0,57,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,4457,95,'Yagudo_Transporter',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,4421,95,'Yagudo_Guard',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,915,95,'Dark_Ixion',0,128,573,100000,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,802,95,'Cosmos_Cocora',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,803,95,'Cosmos_Stamen',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,3182,95,'Poroggo_Gourmand',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,3187,95,'Poroggos_Toady',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,6734,95,'Yagudo_Parivir',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,6735,95,'Giganotaur',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,6736,95,'Kindred_Incantor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,6737,95,'Blurry_Eye',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,3387,95,'Romaa_Mihgo',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,0,95,'Protective_Ward',0,128,0,0,0,0,0,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- Voidwalker
 INSERT INTO `mob_groups` VALUES (52,6999,95,'Yilbegan',86400,0,3185,90000,5000,0,NULL);
@@ -7020,6 +8760,7 @@ INSERT INTO `mob_groups` VALUES (141,7178,96,'Goblin_Mine',0,128,0,0,0,0,NULL);
 -- Meriphataud_Mountains_[S] (Zone 97)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,5493,97,'Yagudo_Chanter',300,0,2697,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,4446,97,'Yagudo_Prioress',300,0,2759,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,4454,97,'Yagudos_Elemental',0,128,0,0,0,0,NULL);
@@ -7069,6 +8810,57 @@ INSERT INTO `mob_groups` VALUES (46,4472,97,'Yii_Haqi_the_Threnodist',0,128,0,0,
 INSERT INTO `mob_groups` VALUES (47,2926,97,'Nuu_Gazo_the_Dirgerimer',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (48,3663,97,'Slate_Scorpion',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (49,2939,97,'Ochre_Scorpion',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,5493,97,'Yagudo_Chanter',300,0,2697,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,4446,97,'Yagudo_Prioress',300,0,2759,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,4454,97,'Yagudos_Elemental',0,128,0,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,4430,97,'Yagudo_Knight_Templar',300,0,2707,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,5478,97,'Yagudo_High_Priest',300,0,2712,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,4417,97,'Yagudo_Eradicator',300,0,2707,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,4442,97,'Yagudo_Prelate',300,0,2746,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,5481,97,'Yagudo_Sentinel',300,0,2764,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,4298,97,'War_Lynx',300,0,0,0,0,68,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,2772,97,'Muq_Shabeel',5400,0,3094,9000,0,72,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,6355,97,'Treant_Sapling',300,0,2464,0,0,56,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,6309,97,'Stag_Beetle',300,0,2318,0,0,44,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,6326,97,'Dragonfly',300,0,141,0,0,58,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,6435,97,'Night_Bats',300,2,80,0,0,55,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,6452,97,'Black_Bat',300,2,461,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,5641,97,'Hill_Lizard',300,0,1314,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,6529,97,'Scavenging_Hound',300,1,226,0,0,49,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4285,97,'Wandering_Sapling',300,0,2618,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2456,97,'Lycopodium',300,0,1552,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1693,97,'Goblin_Paratrooper',300,0,1122,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,1639,97,'Goblin_Bombardier',300,0,1023,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,2458,97,'Lynx',300,0,1557,0,0,49,51,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1657,97,'Goblin_Field_Doctor',300,0,1025,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,2167,97,'Jumbo_Rafflesia',300,0,313,0,0,68,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1628,97,'Gnat',300,0,1008,0,0,78,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,6825,97,'Hemodrosophila',0,32,3318,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,3503,97,'Scolopendrid',300,0,1743,0,0,67,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,2760,97,'Mountain_Scolopendrid',300,0,1743,0,0,78,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,5772,97,'Centipedal_Centruroides',0,32,3056,9500,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,3324,97,'Raptor',300,0,600,0,0,64,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,303,97,'Axe_Beak',300,0,201,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,2759,97,'Mountain_Jubjub',300,0,208,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,6447,97,'Jubjub',300,0,208,0,0,42,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,5342,97,'Condor',300,0,207,0,0,90,93,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (35,1160,97,'Earth_Elemental',300,4,733,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1341,97,'Fire_Elemental',300,4,831,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,3745,97,'Sprite',300,0,2000,0,0,66,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1697,97,'Goblin_Picket',300,0,1135,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1688,97,'Goblin_Mine',0,128,0,0,0,66,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,3448,97,'Sandworm',86400,0,0,0,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,459,97,'Bloodlapper',0,128,300,12000,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,4457,97,'Yagudo_Transporter',0,128,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,4421,97,'Yagudo_Guard',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,545,97,'Brummbar',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,546,97,'Brummer',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,4472,97,'Yii_Haqi_the_Threnodist',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,2926,97,'Nuu_Gazo_the_Dirgerimer',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,3663,97,'Slate_Scorpion',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,2939,97,'Ochre_Scorpion',0,128,0,0,0,1,1,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- Voidwalker
 INSERT INTO `mob_groups` VALUES (50,6999,97,'Yilbegan',86400,0,3185,90000,5000,0,NULL);
@@ -7187,6 +8979,7 @@ INSERT INTO `mob_groups` VALUES (159,4684,97,'Akupara',0,128,0,0,9999,0,NULL);
 -- Sauromugue_Champaign_[S] (Zone 98)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,2456,98,'Lycopodium',300,0,1552,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,6310,98,'Diving_Beetle',300,0,169,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1628,98,'Gnat',300,0,1008,0,0,0,NULL);
@@ -7226,6 +9019,47 @@ INSERT INTO `mob_groups` VALUES (36,3309,98,'Raid_Raptor',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (37,2307,98,'Laa_Heha_the_Falconer',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (38,727,98,'Cinderwing',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (39,1764,98,'Gorebeak',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,2456,98,'Lycopodium',300,0,1552,0,0,28,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,6310,98,'Diving_Beetle',300,0,169,0,0,44,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1628,98,'Gnat',300,0,1008,0,0,75,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,6431,98,'Midnight_Wings',300,2,80,0,0,49,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,6466,98,'Moon_Bat',300,2,234,0,0,49,51,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,4949,98,'Tabar_Beak',300,0,2370,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,792,98,'Coquecigrue',7200,0,515,12000,0,68,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,5343,98,'Gouger_Beetle',300,0,670,0,0,92,94,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (9,5646,98,'Sauromugue_Skink',300,0,600,0,0,51,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1740,98,'Goblin_Toxophilite',300,0,1178,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1688,98,'Goblin_Mine',0,128,0,0,0,61,61,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1669,98,'Goblin_Grenadier',300,0,1086,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1660,98,'Goblin_Flagman',300,0,1024,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1671,98,'Goblin_Guerrilla',300,0,1056,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1723,98,'Goblins_Beetle',0,128,0,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,5151,98,'Herensugue',7200,0,3099,5500,0,63,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,5348,98,'Lynx',300,0,1557,0,0,47,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6529,98,'Scavenging_Hound',300,1,226,0,0,49,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,329,98,'Balam-Quitz',0,32,214,0,0,69,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,5641,98,'Hill_Lizard',300,0,1314,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,6264,98,'Yagudo_Abbot',300,0,96,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,4433,98,'Yagudo_Missionary',300,0,2719,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,5482,98,'Yagudo_Zealot',300,0,2687,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,5491,98,'Yagudo_Prior',300,0,2753,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,5485,98,'Yagudo_Inquisitor',300,0,2719,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,5492,98,'Yagudo_Lutenist',300,0,2729,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,4447,98,'Yagudo_Pythoness',300,0,2758,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,4454,98,'Yagudos_Elemental',0,128,0,0,0,66,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1160,98,'Earth_Elemental',300,4,733,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,5725,98,'Hyakinthos',5400,0,2990,6200,0,58,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,3745,98,'Sprite',300,0,2000,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,3448,98,'Sandworm',86400,0,0,0,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,4457,98,'Yagudo_Transporter',0,128,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,4421,98,'Yagudo_Guard',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,2087,98,'Iqi-Balam',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,3309,98,'Raid_Raptor',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,2307,98,'Laa_Heha_the_Falconer',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,727,98,'Cinderwing',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1764,98,'Gorebeak',0,128,0,0,0,1,1,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- Voidwalker
 INSERT INTO `mob_groups` VALUES (40,6999,98,'Yilbegan',86400,0,3185,90000,5000,0,NULL);
@@ -7526,6 +9360,7 @@ INSERT INTO `mob_groups` VALUES (3,6771,100,'Land_Crab_fished',0,128,481,0,0,0,N
 INSERT INTO `mob_groups` VALUES (4,4225,100,'Vermivorous_Crab',0,128,481,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,7304,100,'Passage_Crab',0,128,481,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,4343,100,'Wild_Rabbit',60,0,894,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,4053,100,'Tunnel_Worm',60,0,2496,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,1038,100,'Ding_Bats',180,2,82,0,0,0,NULL); -- TODO: 1 min respawn near Sandy
@@ -7550,6 +9385,32 @@ INSERT INTO `mob_groups` VALUES (26,1659,100,'Goblin_Fisher',300,0,1051,0,0,0,NU
 INSERT INTO `mob_groups` VALUES (27,3371,100,'River_Crab',180,0,2101,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (28,1648,100,'Goblin_Digger',300,0,1039,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (29,2557,100,'Marauder_Dvogzog',0,128,307,16000,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,4343,100,'Wild_Rabbit',60,0,894,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,4053,100,'Tunnel_Worm',60,0,2496,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1038,100,'Ding_Bats',180,2,82,0,0,1,5,0,NULL); -- TODO: 1 min respawn near Sandy
+INSERT INTO `mob_groups` VALUES (9,1404,100,'Forest_Hare',180,0,893,0,0,1,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,656,100,'Carrion_Worm',180,0,428,0,0,1,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3494,100,'Scarab_Beetle',300,0,2174,0,0,3,7,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3013,100,'Orcish_Fodder',300,0,1904,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,3016,100,'Orcish_Grappler',300,0,1913,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,2763,100,'Mouse_Bat',180,2,19,0,0,3,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1403,100,'Forest_Funguar',300,0,892,0,0,3,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,5421,100,'Amanita',3600,0,2941,230,0,5,6,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (17,3022,100,'Orcish_Mesmerizer',300,0,1924,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4344,100,'Wild_Sheep',300,0,367,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1737,100,'Goblin_Thug',300,0,1169,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1744,100,'Goblin_Weaver',300,0,1182,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3836,100,'Tainted_Hound',300,1,226,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1214,100,'Enchanted_Bones_blm',300,1,769,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1438,100,'Fungus_Beetle',0,32,917,320,0,10,15,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,490,100,'Bomb',300,8,216,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,2125,100,'Jaggedy-Eared_Jack',0,32,1390,220,0,9,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1659,100,'Goblin_Fisher',300,0,1051,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,3371,100,'River_Crab',180,0,2101,0,0,3,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1648,100,'Goblin_Digger',300,0,1039,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,2557,100,'Marauder_Dvogzog',0,128,307,16000,0,67,67,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (30,6975,100,'Orcish_Cursemaker',0,128,3226,0,0,0,NULL);
@@ -7595,6 +9456,7 @@ INSERT INTO `mob_groups` VALUES (3,2768,101,'Mud_Pugil',0,128,975,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,6769,101,'Pug_Pugil_fished',0,128,463,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,1336,101,'Fighting_Pugil',0,128,279,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,4343,101,'Wild_Rabbit',60,0,893,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,4053,101,'Tunnel_Worm',60,0,2496,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,1038,101,'Ding_Bats',180,2,82,0,0,0,NULL); -- TODO: 1 min respawn near Sandy
@@ -7642,6 +9504,55 @@ INSERT INTO `mob_groups` VALUES (47,6997,101,'Yacumama',3600,0,3169,13500,0,0,'W
 INSERT INTO `mob_groups` VALUES (48,6996,101,'Capricornus',3600,0,3168,13500,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (49,6995,101,'Quagmire_Pugil',300,0,0,5200,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (50,6994,101,'Sunderclaw',300,0,0,4930,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (6,4343,101,'Wild_Rabbit',60,0,893,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,4053,101,'Tunnel_Worm',60,0,2496,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1038,101,'Ding_Bats',180,2,82,0,0,1,5,0,NULL); -- TODO: 1 min respawn near Sandy
+INSERT INTO `mob_groups` VALUES (9,1404,101,'Forest_Hare',180,0,894,0,0,1,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,656,101,'Carrion_Worm',180,0,428,0,0,1,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1403,101,'Forest_Funguar',300,0,892,0,0,3,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3494,101,'Scarab_Beetle',300,0,2174,0,0,3,7,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,3013,101,'Orcish_Fodder',300,0,1904,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,2763,101,'Mouse_Bat',180,2,19,0,0,3,7,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3022,101,'Orcish_Mesmerizer',300,0,1924,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3016,101,'Orcish_Grappler',300,0,1913,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1659,101,'Goblin_Fisher',300,0,1051,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4344,101,'Wild_Sheep',300,0,367,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3836,101,'Tainted_Hound',300,1,226,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,5734,101,'Rambukk',3600,0,2997,420,0,12,15,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (21,1737,101,'Goblin_Thug',300,0,1169,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1744,101,'Goblin_Weaver',300,0,1182,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1214,101,'Enchanted_Bones_blm',300,1,769,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,490,101,'Bomb',300,8,216,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,3818,101,'Swamfisk',0,32,2364,0,0,11,15,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,414,101,'Bigmouth_Billy',0,32,276,400,0,9,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1648,101,'Goblin_Digger',300,0,1039,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,3148,101,'Pixie',0,128,2001,0,0,53,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1479,101,'Gawky_Gawain',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,5165,101,'Sarimanok',0,128,0,0,9999,94,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,579,101,'Bull_[Herd1]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,821,101,'Cow_[Herd1]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,611,101,'Calf_[Herd1]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,580,101,'Bull_[Herd2]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,822,101,'Cow_[Herd2]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,612,101,'Calf_[Herd2]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,581,101,'Bull_[Herd3]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,823,101,'Cow_[Herd3]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,613,101,'Calf_[Herd3]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,4850,101,'Hugemaw_Harold',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,3241,101,'Pyracmon',0,128,2047,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,4381,101,'Wraith_Bat',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,6543,101,'Enchanted_Bones_war',300,1,769,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,3221,101,'Pugil',180,0,279,0,0,1,5,0,NULL);
+
+-- Voidwalker
+INSERT INTO `mob_groups` VALUES (45,6999,101,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (46,6998,101,'Krabkatoa',7200,0,3180,39100,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (47,6997,101,'Yacumama',3600,0,3169,13500,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (48,6996,101,'Capricornus',3600,0,3168,13500,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (49,6995,101,'Quagmire_Pugil',300,0,0,5200,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (50,6994,101,'Sunderclaw',300,0,0,4930,0,80,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 INSERT INTO `mob_groups` VALUES (51,0,101,'Tatenashi_Armor',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (52,0,101,'Hizamaru_Armor',0,128,0,0,0,0,NULL);
@@ -7664,6 +9575,7 @@ INSERT INTO `mob_groups` VALUES (3,6774,102,'Thickshell_fished',0,128,2397,0,0,0
 INSERT INTO `mob_groups` VALUES (4,6766,102,'Giant_Pugil_fished',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,3220,102,'Puffer_Pugil',0,128,975,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,3771,102,'Steppe_Hare',300,0,2150,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,3792,102,'Strolling_Sapling',300,0,2345,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,77,102,'Akbaba',300,0,43,0,0,0,NULL);
@@ -7715,6 +9627,59 @@ INSERT INTO `mob_groups` VALUES (51,7019,102,'Tammuz',3600,0,3179,18510,0,0,'WOT
 INSERT INTO `mob_groups` VALUES (52,7018,102,'Chesma',3600,0,3178,14700,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (53,7017,102,'Void_Hare',300,0,0,4900,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (54,7016,102,'Prickly_Sheep',300,0,0,5300,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (6,3771,102,'Steppe_Hare',300,0,2150,0,0,7,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,3792,102,'Strolling_Sapling',300,0,2345,0,0,7,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,77,102,'Akbaba',300,0,43,0,0,9,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,3013,102,'Orcish_Fodder',300,0,1904,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,3022,102,'Orcish_Mesmerizer',300,0,1924,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3016,102,'Orcish_Grappler',300,0,1913,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3647,102,'Skeleton_Warrior',300,1,769,0,0,10,12,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,3646,102,'Skeleton_Sorcerer',300,1,769,0,0,11,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3378,102,'Rock_Eater',300,0,428,0,0,7,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,2473,102,'Mad_Sheep',300,0,368,0,0,11,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,2003,102,'Huge_Wasp',300,0,1336,0,0,8,12,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1737,102,'Goblin_Thug',300,0,1169,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1744,102,'Goblin_Weaver',300,0,1182,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1450,102,'Gale_Bats',300,2,82,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,41,102,'Acro_Bat',300,2,19,0,0,8,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,4359,102,'Wolf_Zombie',300,1,226,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,71,102,'Air_Elemental',300,4,38,0,0,18,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,3017,102,'Orcish_Grunt',300,0,1913,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,3033,102,'Orcish_Stonechucker',300,0,1913,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,3023,102,'Orcish_Neckchopper',300,0,1913,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1812,102,'Grenade',300,8,569,0,0,15,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1635,102,'Goblin_Ambusher',300,0,1017,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1738,102,'Goblin_Tinkerer',300,0,1032,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1643,102,'Goblin_Butcher',300,0,1032,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,362,102,'Battering_Ram',600,0,236,500,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,3164,102,'Poison_Funguar',300,0,2010,0,0,14,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1791,102,'Grass_Funguar',300,0,1217,0,0,11,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1514,102,'Ghost',300,1,956,0,0,15,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,3896,102,'Thickshell',300,0,2397,0,0,12,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1659,102,'Goblin_Fisher',300,0,1051,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,4309,102,'Water_Elemental',300,4,2629,0,0,18,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,5422,102,'Slumbering_Samwell',0,128,2942,550,0,17,18,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (38,3152,102,'Plague_Bats',300,0,82,0,0,9,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,3163,102,'Poison_Bat',300,2,19,0,0,11,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,4049,102,'Tumbling_Truffle',0,32,2493,550,0,19,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,2449,102,'Lumbering_Lambert',0,32,1548,1930,0,27,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,462,102,'Bloodtear_Baldurf',0,32,304,20500,0,55,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,3170,102,'Poltergeist',300,0,0,0,0,18,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,6658,102,'Goblin_Digger',300,0,1039,0,0,11,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,1636,102,'Goblin_Archaeologist',0,128,1021,0,0,30,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,2880,102,'Nihniknoovi',0,128,1809,715,0,14,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,3148,102,'Pixie',0,128,2001,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,4488,102,'Zagh',0,128,0,0,0,1,1,0,NULL);
+
+-- Voidwalker
+INSERT INTO `mob_groups` VALUES (49,6999,102,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (50,7020,102,'Dawon',7200,0,3184,24700,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (51,7019,102,'Tammuz',3600,0,3179,18510,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (52,7018,102,'Chesma',3600,0,3178,14700,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (53,7017,102,'Void_Hare',300,0,0,4900,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (54,7016,102,'Prickly_Sheep',300,0,0,5300,0,80,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 INSERT INTO `mob_groups` VALUES (55,5167,102,'Stachysaurus',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (56,0,102,'Wayward_Worm',0,128,0,0,0,0,NULL);
@@ -7737,6 +9702,7 @@ INSERT INTO `mob_groups` VALUES (3,3682,103,'Snipper_fished',0,128,2281,0,0,0,NU
 INSERT INTO `mob_groups` VALUES (4,6775,103,'Beach_Pugil_fished',0,128,248,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,5864,103,'Cutter_fished',0,128,93,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,3455,103,'Sand_Hare',300,0,2150,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,1635,103,'Goblin_Ambusher',300,0,1017,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,1643,103,'Goblin_Butcher',300,0,1032,0,0,0,NULL);
@@ -7792,6 +9758,63 @@ INSERT INTO `mob_groups` VALUES (57,2639,103,'Metaquadav_Red_Mage',0,128,0,0,0,0
 INSERT INTO `mob_groups` VALUES (58,2640,103,'Metaquadav_Thief',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (59,2638,103,'Metaquadav_Paladin',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (60,2637,103,'Metaquadav_Dark_Knight',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,3455,103,'Sand_Hare',300,0,2150,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1635,103,'Goblin_Ambusher',300,0,1017,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1643,103,'Goblin_Butcher',300,0,1032,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2877,103,'Night_Bats',300,2,82,0,0,12,15,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,3756,103,'Star_Bat',300,2,461,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,548,103,'Brutal_Sheep',300,0,368,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,899,103,'Damselfly',300,0,562,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1738,103,'Goblin_Tinkerer',300,0,1032,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1517,103,'Ghoul_war',300,1,960,0,0,18,22,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,4345,103,'Will-o-the-Wisp',300,8,569,0,0,25,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,5733,103,'Snipper',300,0,2281,0,0,18,22,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,5738,103,'Metal_Shears',0,128,3001,750,0,22,22,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (18,1690,103,'Goblin_Mugger',300,0,1117,0,0,22,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1683,103,'Goblin_Leecher',300,0,1098,0,0,22,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1666,103,'Goblin_Gambler',300,0,1081,0,0,22,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,1518,103,'Ghoul_blm',300,1,960,0,0,18,22,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1341,103,'Fire_Elemental',300,4,831,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1956,103,'Hill_Lizard',300,0,1316,0,0,15,19,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1160,103,'Earth_Elemental',300,4,733,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,3449,103,'Sand_Bats',300,0,2145,0,0,12,15,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,3901,103,'Thread_Leech',300,0,18,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,485,103,'Bogy',300,1,321,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,380,103,'Beach_Pugil',300,0,248,0,0,23,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,5735,103,'Hippomaritimus',0,128,2998,2250,0,37,38,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (30,4124,103,'Valkurm_Emperor',0,32,2533,1180,0,29,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1522,103,'Giant_Bat',300,0,461,0,0,20,22,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1751,103,'Golden_Bat',0,32,1191,640,0,26,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,6658,103,'Goblin_Digger',300,0,1040,0,0,19,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,2558,103,'Marchelute',0,128,1616,6500,0,41,41,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1077,103,'Doman',0,128,0,0,0,52,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,2984,103,'Onryo',0,128,0,0,0,52,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1983,103,'Hobgoblin_Warrior',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1984,103,'Hobgoblin_White_Mage',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1972,103,'Hobgoblin_Black_Mage',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,1979,103,'Hobgoblin_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,1980,103,'Hobgoblin_Thief',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,1974,103,'Hobgoblin_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1978,103,'Hobgoblin_Ranger',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,1971,103,'Hobgoblin_Beastmaster',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,1725,103,'Goblins_Dragonfly',0,128,0,0,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1884,103,'Halforc_Warrior',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,1881,103,'Halforc_Monk',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,1878,103,'Halforc_Black_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,1882,103,'Halforc_Paladin',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,1879,103,'Halforc_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,1883,103,'Halforc_Ranger',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,1880,103,'Halforc_Dragoon',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,3048,103,'Orcs_Wyvern',0,128,0,0,0,31,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,2641,103,'Metaquadav_Warrior',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,2642,103,'Metaquadav_White_Mage',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,2636,103,'Metaquadav_Black_Mage',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,2639,103,'Metaquadav_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,2640,103,'Metaquadav_Thief',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,2638,103,'Metaquadav_Paladin',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,2637,103,'Metaquadav_Dark_Knight',0,128,0,0,0,35,35,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (61,1718,103,'Goblin_Swordmaker',0,128,3226,0,0,0,NULL);
@@ -7822,6 +9845,7 @@ INSERT INTO `mob_groups` VALUES (3,5133,104,'Thread_Leech_fished',0,128,895,0,0,
 INSERT INTO `mob_groups` VALUES (4,1323,104,'Ferocious_Pugil',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,2001,104,'Huge_Leech',0,128,895,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,2271,104,'Knight_Crab',0,128,552,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,2254,104,'King_Arthro',0,128,1449,35000,7500,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,3752,104,'Stag_Beetle',300,0,2319,0,0,0,NULL);
@@ -7881,6 +9905,67 @@ INSERT INTO `mob_groups` VALUES (61,1880,104,'Halforc_Dragoon',0,128,0,0,0,0,NUL
 INSERT INTO `mob_groups` VALUES (62,3048,104,'Orcs_Wyvern',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (63,1605,104,'Giollemitte_B_Feroun',0,128,0,2950,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (64,3645,104,'Skeleton_Esquire_NM',0,128,0,2120,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,2271,104,'Knight_Crab',0,128,552,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,2254,104,'King_Arthro',0,128,1449,35000,7500,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3752,104,'Stag_Beetle',300,0,2319,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,6356,104,'Wandering_Sapling',300,0,2619,0,0,13,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,548,104,'Brutal_Sheep',300,0,368,0,0,18,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3497,104,'Scavenging_Hound',300,1,226,0,0,18,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,2166,104,'Jugner_Funguar',300,0,1419,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1405,104,'Forest_Leech',300,0,79,0,0,19,22,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3506,104,'Screamer',300,0,43,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,4278,104,'Walking_Tree',300,0,2605,0,0,25,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1406,104,'Forest_Tiger',300,0,896,0,0,22,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3017,104,'Orcish_Grunt',300,0,1917,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,3033,104,'Orcish_Stonechucker',300,0,1917,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3023,104,'Orcish_Neckchopper',300,0,1917,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3009,104,'Orcish_Fighter',300,0,1886,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3004,104,'Orcish_Cursemaker',300,0,1886,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,3032,104,'Orcish_Serjeant',300,0,1886,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1517,104,'Ghoul_war',300,1,960,0,0,16,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,6574,104,'Zombie_blm',300,1,2809,0,0,16,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,3912,104,'Thunder_Elemental',300,4,2410,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1690,104,'Goblin_Mugger',300,0,1117,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1635,104,'Goblin_Ambusher',300,0,1017,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1683,104,'Goblin_Leecher',300,0,1098,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1738,104,'Goblin_Tinkerer',300,0,1032,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1666,104,'Goblin_Gambler',300,0,1081,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1643,104,'Goblin_Butcher',300,0,1032,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,5733,104,'Snipper',300,0,482,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,2373,104,'Land_Pugil',300,0,463,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,485,104,'Bogy',300,1,322,0,0,25,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,4309,104,'Water_Elemental',300,4,2629,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,4345,104,'Will-o-the-Wisp',300,8,569,0,0,24,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,2643,104,'Meteormauler_Zhagtegg',0,128,1664,0,0,35,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1421,104,'Fraelissa',3600,0,905,2500,0,33,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1420,104,'Fradubio',0,32,904,10000,0,55,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,1129,104,'Duessa',0,128,0,0,0,40,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,5768,104,'Supplespine_Mujwuj',0,32,3052,3000,0,50,50,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (42,483,104,'Boggart',300,0,319,0,0,25,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,5739,104,'Sappy_Sycamore',0,128,3002,2920,0,43,50,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (44,3095,104,'Panzer_Percival',0,32,1981,1680,0,25,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,6658,104,'Goblin_Digger',300,0,1040,0,0,18,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1983,104,'Hobgoblin_Warrior',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,1984,104,'Hobgoblin_White_Mage',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,1972,104,'Hobgoblin_Black_Mage',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,1979,104,'Hobgoblin_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,1980,104,'Hobgoblin_Thief',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,1974,104,'Hobgoblin_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,1978,104,'Hobgoblin_Ranger',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,1971,104,'Hobgoblin_Beastmaster',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,1723,104,'Goblins_Beetle',0,128,0,0,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,1884,104,'Halforc_Warrior',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,1881,104,'Halforc_Monk',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,1878,104,'Halforc_Black_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,1882,104,'Halforc_Paladin',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,1879,104,'Halforc_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,1883,104,'Halforc_Ranger',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,1880,104,'Halforc_Dragoon',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (62,3048,104,'Orcs_Wyvern',0,128,0,0,0,32,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (63,1605,104,'Giollemitte_B_Feroun',0,128,0,2950,0,38,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (64,3645,104,'Skeleton_Esquire_NM',0,128,0,2120,0,35,35,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (65,3009,104,'Orcish_Fighter_G',0,128,3226,0,0,0,NULL);
@@ -7894,12 +9979,21 @@ INSERT INTO `mob_groups` VALUES (71,3745,104,'Sprite',0,128,2001,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (72,2297,104,'Kumbaba',0,128,0,0,0,0,NULL);
 
 -- Voidwalker
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (73,6999,104,'Yilbegan',86400,0,3185,90000,5000,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (74,6998,104,'Krabkatoa',7200,0,3180,39100,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (75,6997,104,'Yacumama',3600,0,3169,13500,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (76,6996,104,'Capricornus',3600,0,3168,13500,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (77,6995,104,'Quagmire_Pugil',300,0,0,5200,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (78,6994,104,'Sunderclaw',300,0,0,4930,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (73,6999,104,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (74,6998,104,'Krabkatoa',7200,0,3180,39100,0,90,90,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (75,6997,104,'Yacumama',3600,0,3169,13500,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (76,6996,104,'Capricornus',3600,0,3168,13500,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (77,6995,104,'Quagmire_Pugil',300,0,0,5200,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (78,6994,104,'Sunderclaw',300,0,0,4930,0,80,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 INSERT INTO `mob_groups` VALUES (79,5152,104,'Belphoebe',0,128,0,0,9999,0,NULL);
 INSERT INTO `mob_groups` VALUES (80,6828,104,'Emperor_Arthro',0,128,0,0,0,0,NULL);
@@ -7923,6 +10017,7 @@ INSERT INTO `mob_groups` VALUES (3,5864,105,'Cutter_fished',0,128,93,0,0,0,NULL)
 INSERT INTO `mob_groups` VALUES (4,5868,105,'Greater_Pugil_fished',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,6029,105,'Kraken_fished',0,128,1464,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,4318,105,'Weeping_Willow',86400,0,0,1875,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,3694,105,'Sobbing_Sapling',0,128,462,1400,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,2450,105,'Lumber_Jack',0,128,1549,35000,0,0,NULL);
@@ -7981,6 +10076,66 @@ INSERT INTO `mob_groups` VALUES (58,7022,105,'Pruina',300,0,0,4400,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (59,7024,105,'Beorht',300,0,0,4400,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (60,7027,105,'Thunor',300,0,0,4400,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (61,7029,105,'Lacus',300,0,0,4400,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (6,4318,105,'Weeping_Willow',86400,0,0,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,3694,105,'Sobbing_Sapling',0,128,462,0,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,2450,105,'Lumber_Jack',0,128,1549,25000,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2597,105,'May_Fly',300,0,923,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,3754,105,'Stalking_Sapling',300,0,2912,0,0,20,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3424,105,'Sabertooth_Tiger',300,0,2136,0,0,28,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,2589,105,'Mauthe_Doog',300,1,226,0,0,28,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1266,105,'Evil_Spirit',300,1,795,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1690,105,'Goblin_Mugger',300,0,1117,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1694,105,'Goblin_Pathfinder',300,0,1123,0,0,28,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1725,105,'Goblins_Dragonfly',0,128,0,0,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1683,105,'Goblin_Leecher',300,0,1098,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1665,105,'Goblin_Furrier',300,0,1064,0,0,28,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1666,105,'Goblin_Gambler',300,0,1081,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1715,105,'Goblin_Smithy',300,0,1162,0,0,28,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,1710,105,'Goblin_Shaman',300,0,1148,0,0,28,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,4337,105,'Wight_war',300,1,2651,0,0,26,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,2054,105,'Ignis_Fatuus',300,8,569,0,0,34,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1160,105,'Earth_Elemental',300,4,733,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,5740,105,'Skirling_Liger',0,128,3003,3250,0,40,42,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (26,3009,105,'Orcish_Fighter',300,0,283,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,3020,105,'Orcish_Impaler',300,0,1873,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,2996,105,'Orcish_Beastrider',300,0,1873,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,3024,105,'Orcish_Nightraider',300,0,1873,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,3004,105,'Orcish_Cursemaker',300,0,283,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,3032,105,'Orcish_Serjeant',300,0,283,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,2998,105,'Orcish_Brawler',300,0,1873,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,2043,105,'Ice_Elemental',300,4,1347,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,3979,105,'Tottering_Toby',0,32,2456,1300,0,27,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,3990,105,'Treant',300,0,2462,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,316,105,'Ba',300,0,207,0,0,25,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,743,105,'Clipper',300,0,93,0,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,5852,105,'Eyegouger',3600,0,3063,4000,0,46,46,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (39,1267,105,'Evil_Weapon',300,0,0,0,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,5758,105,'Prankster_Maverix',0,32,1610,5500,0,51,51,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (41,66,105,'Ahtu',0,128,33,2500,0,51,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,6658,105,'Goblin_Digger',300,0,1040,0,0,28,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,3800,105,'Sturmtiger',0,128,0,0,0,52,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,3809,105,'Suparna',0,128,0,10000,0,65,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,3810,105,'Suparna_Fledgling',0,128,0,8000,0,65,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,322,105,'Badshah',0,128,0,1200,1200,43,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,3745,105,'Sprite',0,128,2001,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,2375,105,'Lanky_Lenglen',300,0,0,0,0,26,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,4215,105,'Vegnix_Greenthumb',0,128,0,0,0,26,36,0,NULL);
+
+-- Voidwalker
+INSERT INTO `mob_groups` VALUES (50,6999,105,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (51,7032,105,'Verthandi',7200,0,3183,25500,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (52,7031,105,'Urd',3600,0,3175,12900,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (53,7030,105,'Skuld',3600,0,3174,12900,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (54,7021,105,'Aither',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (55,7023,105,'Deorc',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (56,7025,105,'Eorthe',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (57,7028,105,'Puretos',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (58,7022,105,'Pruina',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (59,7024,105,'Beorht',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (60,7027,105,'Thunor',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (61,7029,105,'Lacus',300,0,0,4400,0,80,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 INSERT INTO `mob_groups` VALUES (62,5185,105,'Cherufe',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (63,0,105,'Lumber_Jill',0,128,0,0,0,0,NULL);
@@ -8004,6 +10159,7 @@ INSERT INTO `mob_groups` VALUES (3,6771,106,'Land_Crab_fished',0,128,481,0,0,0,N
 INSERT INTO `mob_groups` VALUES (4,6769,106,'Pug_Pugil_fished',0,128,463,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,1336,106,'Fighting_Pugil',0,128,279,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,2000,106,'Huge_Hornet',60,0,1334,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,4053,106,'Tunnel_Worm',60,0,2496,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,1038,106,'Ding_Bats',180,2,82,0,0,0,NULL); -- TODO: 1 min respawn near Bastok
@@ -8033,6 +10189,37 @@ INSERT INTO `mob_groups` VALUES (31,1683,106,'Goblin_Leecher',300,0,1098,0,0,0,N
 INSERT INTO `mob_groups` VALUES (32,1666,106,'Goblin_Gambler',300,0,1081,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (33,1648,106,'Goblin_Digger',300,0,1039,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (34,1456,106,'Gambilox_Wanderling',0,128,0,8525,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,2000,106,'Huge_Hornet',60,0,1334,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,4053,106,'Tunnel_Worm',60,0,2496,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1038,106,'Ding_Bats',180,2,82,0,0,1,4,0,NULL); -- TODO: 1 min respawn near Bastok
+INSERT INTO `mob_groups` VALUES (9,2547,106,'Maneating_Hornet',180,0,584,0,0,2,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,3780,106,'Stone_Eater',300,0,428,0,0,2,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3058,106,'Ornery_Sheep',300,0,1958,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1737,106,'Goblin_Thug',300,0,1169,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1364,106,'Fledermaus',180,2,461,0,0,3,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,441,106,'Black_Wolf',300,1,288,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1744,106,'Goblin_Weaver',300,0,1182,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3774,106,'Stinging_Sophie',0,32,2336,480,0,9,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1214,106,'Enchanted_Bones_blm',300,1,769,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,3371,106,'River_Crab',180,0,481,0,0,1,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3381,106,'Rock_Lizard',300,0,2120,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,4277,106,'Walking_Sapling',180,0,2603,0,0,2,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,4266,106,'Vulture',180,0,207,0,0,2,7,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,4477,106,'Young_Quadav',300,0,2789,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,103,106,'Amber_Quadav',300,0,58,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,107,106,'Amethyst_Quadav',300,0,67,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,3611,106,'Shrapnel',300,8,216,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,5418,106,'Bedrock_Barry',0,128,2938,275,800,11,12,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (27,1659,106,'Goblin_Fisher',300,0,1051,0,0,4,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,2490,106,'Maighdean_Uaine',0,32,1578,315,0,11,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,3458,106,'Sand_Pugil',300,0,279,0,0,18,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1690,106,'Goblin_Mugger',300,0,1117,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1683,106,'Goblin_Leecher',300,0,1098,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1666,106,'Goblin_Gambler',300,0,1081,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1648,106,'Goblin_Digger',300,0,1039,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1456,106,'Gambilox_Wanderling',0,128,0,0,0,53,53,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (35,6973,106,'Old_Quadav',0,128,3226,0,0,0,NULL);
@@ -8045,6 +10232,7 @@ INSERT INTO `mob_groups` VALUES (40,3148,106,'Pixie',0,128,2001,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (41,936,106,'Deathly_Stinger',0,128,0,0,0,0,NULL);
 
 -- Voidwalker
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (42,6999,106,'Yilbegan',86400,0,3185,90000,5000,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (43,7004,106,'Blobdingnag',7200,0,3181,39100,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (44,7005,106,'Septic_Boil',0,128,0,1400,0,0,'WOTG');
@@ -8052,6 +10240,15 @@ INSERT INTO `mob_groups` VALUES (45,7003,106,'Shoggoth',3600,0,3171,13000,0,0,'W
 INSERT INTO `mob_groups` VALUES (46,7002,106,'Lamprey_Lord',3600,0,3170,11000,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (47,7001,106,'Ground_Guzzler',300,0,0,3000,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (48,7000,106,'Globster',300,0,0,5100,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (42,6999,106,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (43,7004,106,'Blobdingnag',7200,0,3181,39100,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (44,7005,106,'Septic_Boil',0,128,0,1400,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (45,7003,106,'Shoggoth',3600,0,3171,13000,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (46,7002,106,'Lamprey_Lord',3600,0,3170,11000,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (47,7001,106,'Ground_Guzzler',300,0,0,3000,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (48,7000,106,'Globster',300,0,0,5100,0,80,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 INSERT INTO `mob_groups` VALUES (49,4687,106,'Sallow_Seymour',0,128,0,0,9999,0,NULL);
 INSERT INTO `mob_groups` VALUES (50,0,106,'Tatenashi_Armor',0,128,0,0,0,0,NULL);
@@ -8087,6 +10284,7 @@ INSERT INTO `mob_groups` VALUES (3,6771,107,'Land_Crab_fished',0,128,481,0,0,0,N
 INSERT INTO `mob_groups` VALUES (4,2722,107,'Mole_Crab',0,128,93,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,3102,107,'Passage_Crab',0,128,93,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,551,107,'Bubbly_Bernie',0,128,2848,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,2000,107,'Huge_Hornet',60,0,1334,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,4053,107,'Tunnel_Worm',60,0,2496,0,0,0,NULL);
@@ -8138,11 +10336,65 @@ INSERT INTO `mob_groups` VALUES (53,0,107,'Slime',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (54,0,107,'She-Slime',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (55,0,107,'Metal_Slime',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (56,6830,107,'Bounding_Belinda',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,551,107,'Bubbly_Bernie',0,128,2848,0,0,9,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,2000,107,'Huge_Hornet',60,0,1334,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,4053,107,'Tunnel_Worm',60,0,2496,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1038,107,'Ding_Bats',180,2,82,0,0,1,4,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,2547,107,'Maneating_Hornet',180,0,584,0,0,2,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3780,107,'Stone_Eater',180,0,428,0,0,1,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3058,107,'Ornery_Sheep',300,0,1958,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1737,107,'Goblin_Thug',300,0,1169,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1364,107,'Fledermaus',180,2,461,0,0,3,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,441,107,'Black_Wolf',300,1,287,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1744,107,'Goblin_Weaver',300,0,1182,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,645,107,'Carnero',0,32,421,335,0,11,12,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6543,107,'Enchanted_Bones_war',300,1,769,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1214,107,'Enchanted_Bones_blm',300,1,769,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3381,107,'Rock_Lizard',300,0,2120,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,4277,107,'Walking_Sapling',180,0,2603,0,0,2,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,4266,107,'Vulture',180,0,207,0,0,2,7,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,4477,107,'Young_Quadav',300,0,2789,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,107,107,'Amethyst_Quadav',300,0,67,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,103,107,'Amber_Quadav',300,0,58,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1659,107,'Goblin_Fisher',300,0,1051,0,0,3,4,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,3611,107,'Shrapnel',300,8,216,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,5419,107,'Tococo',0,128,2939,146,0,4,5,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (29,2384,107,'Leaping_Lizzy',0,32,1504,230,0,10,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,2372,107,'Land_Crab',180,0,481,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1648,107,'Goblin_Digger',300,0,1039,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,3148,107,'Pixie',0,128,2001,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1829,107,'Grylio',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,4688,107,'Bhishani',0,128,0,0,9999,99,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,0,107,'Wayward_Worm',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,0,107,'Tatenashi_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,0,107,'Hizamaru_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,0,107,'Ubuginu_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,0,107,'Hachiryu_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,0,107,'Omodaka_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,579,107,'Bull_[Herd1]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,821,107,'Cow_[Herd1]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,611,107,'Calf_[Herd1]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,580,107,'Bull_[Herd2]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,822,107,'Cow_[Herd2]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,612,107,'Calf_[Herd2]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,581,107,'Bull_[Herd3]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,823,107,'Cow_[Herd3]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,613,107,'Calf_[Herd3]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,3241,107,'Pyracmon',0,128,2047,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,4381,107,'Wraith_Bat',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,0,107,'Astral_Box',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,0,107,'Slime',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,0,107,'She-Slime',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,0,107,'Metal_Slime',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,6830,107,'Bounding_Belinda',0,128,0,0,0,0,0,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Konschtat_Highlands (Zone 108)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,2679,108,'Mist_Lizard',300,0,1701,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,3792,108,'Strolling_Sapling',300,0,2346,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,3378,108,'Rock_Eater',300,0,428,0,0,0,NULL);
@@ -8188,6 +10440,53 @@ INSERT INTO `mob_groups` VALUES (40,7019,108,'Tammuz',3600,0,3179,18510,0,0,'WOT
 INSERT INTO `mob_groups` VALUES (41,7018,108,'Chesma',3600,0,3178,14700,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (42,7017,108,'Void_Hare',300,0,0,4900,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (43,7016,108,'Prickly_Sheep',300,0,0,5300,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (1,2679,108,'Mist_Lizard',300,0,1701,0,0,10,12,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,3792,108,'Strolling_Sapling',300,0,2346,0,0,7,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,3378,108,'Rock_Eater',300,0,428,0,0,7,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,1737,108,'Goblin_Thug',300,0,1169,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,1635,108,'Goblin_Ambusher',300,0,1017,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,1744,108,'Goblin_Weaver',300,0,1182,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1643,108,'Goblin_Butcher',300,0,1032,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,5544,108,'Ghillie_Dhu',0,128,2954,600,250,16,18,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (9,4477,108,'Young_Quadav',300,0,2789,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,2986,108,'Onyx_Quadav',300,0,1863,0,0,10,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,107,108,'Amethyst_Quadav',300,0,67,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,103,108,'Amber_Quadav',300,0,58,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,2003,108,'Huge_Wasp',300,0,1336,0,0,7,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1514,108,'Ghost',300,1,956,0,0,15,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,4226,108,'Veteran_Quadav',300,0,1863,0,0,10,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1808,108,'Greater_Quadav',300,0,1234,0,0,10,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3647,108,'Skeleton_Warrior',300,1,769,0,0,10,12,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,3646,108,'Skeleton_Sorcerer',300,1,769,0,0,11,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3912,108,'Thunder_Elemental',300,4,2410,0,0,18,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3170,108,'Poltergeist',300,0,0,0,0,18,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,1812,108,'Grenade',300,8,569,0,0,15,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,2473,108,'Mad_Sheep',300,0,368,0,0,11,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,4359,108,'Wolf_Zombie',300,1,226,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1738,108,'Goblin_Tinkerer',300,0,1032,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1160,108,'Earth_Elemental',300,4,733,0,0,18,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,5545,108,'Highlander_Lizard',1200,0,2955,950,0,27,28,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (27,3785,108,'Stray_Mary',0,32,2343,590,0,19,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,3995,108,'Tremor_Ram',660,0,2466,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,3316,108,'Rampaging_Ram',0,32,2074,2080,0,27,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,3766,108,'Steelfleece_Baldarich',0,32,2329,20500,0,55,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,6658,108,'Goblin_Digger',300,0,1039,0,0,11,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1636,108,'Goblin_Archaeologist',0,128,1021,0,0,30,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1407,108,'Forger',0,128,897,0,0,33,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1899,108,'Haty',0,128,253,895,0,14,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,390,108,'Bendigeit_Vran',0,128,253,825,0,14,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,3148,108,'Pixie',0,128,2001,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,3911,108,'Thunderhead',0,128,0,0,0,1,1,0,NULL);
+
+-- Voidwalker
+INSERT INTO `mob_groups` VALUES (38,6999,108,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (39,7020,108,'Dawon',7200,0,3184,24700,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (40,7019,108,'Tammuz',3600,0,3179,18510,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (41,7018,108,'Chesma',3600,0,3178,14700,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (42,7017,108,'Void_Hare',300,0,0,4900,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (43,7016,108,'Prickly_Sheep',300,0,0,5300,0,80,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 INSERT INTO `mob_groups` VALUES (44,5163,108,'Gwynn_ap_Nudd',0,128,0,0,9999,0,NULL);
 INSERT INTO `mob_groups` VALUES (45,0,108,'Wayward_Worm',0,128,0,0,0,0,NULL);
@@ -8209,6 +10508,7 @@ INSERT INTO `mob_groups` VALUES (2,3753,109,'Stag_Crab',0,128,93,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,3821,109,'Swamp_Pugil',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,5133,109,'Thread_Leech_fished',0,128,895,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,5733,109,'Snipper',300,0,482,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,1445,109,'Gadfly',300,0,923,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,486,109,'Bog_Bunny',300,0,326,0,0,0,NULL);
@@ -8262,6 +10562,61 @@ INSERT INTO `mob_groups` VALUES (54,2639,109,'Metaquadav_Red_Mage',0,128,0,0,0,0
 INSERT INTO `mob_groups` VALUES (55,2640,109,'Metaquadav_Thief',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (56,2638,109,'Metaquadav_Paladin',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (57,2637,109,'Metaquadav_Dark_Knight',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,5733,109,'Snipper',300,0,482,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,1445,109,'Gadfly',300,0,923,0,0,18,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,486,109,'Bog_Bunny',300,0,326,0,0,13,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,2877,109,'Night_Bats',300,2,82,0,0,13,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,433,109,'Black_Bat',300,2,461,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,487,109,'Bog_Dog',300,1,328,0,0,18,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3901,109,'Thread_Leech',300,0,2405,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,2373,109,'Land_Pugil',300,0,279,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,485,109,'Bogy',300,1,322,0,0,25,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,4309,109,'Water_Elemental',300,4,2629,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1756,109,'Goobbue',300,0,1198,0,0,22,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,2493,109,'Malboro',300,0,2918,0,0,25,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,2965,109,'Old_Quadav',300,0,1847,0,0,20,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4226,109,'Veteran_Quadav',300,0,1235,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1808,109,'Greater_Quadav',300,0,1235,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,791,109,'Copper_Quadav',300,0,512,0,0,20,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,525,109,'Brass_Quadav',300,0,350,0,0,20,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,2986,109,'Onyx_Quadav',300,0,1864,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1517,109,'Ghoul_war',300,1,960,0,0,18,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,6574,109,'Zombie_blm',300,1,2809,0,0,16,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,3912,109,'Thunder_Elemental',300,4,2410,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,646,109,'Carnivorous_Crawler',300,0,256,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,4314,109,'Water_Wasp',300,0,584,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,4832,109,'NiZho_Bladebender',0,32,3022,0,0,43,45,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (29,2155,109,'Jolly_Green',0,32,1409,1030,0,27,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1690,109,'Goblin_Mugger',300,0,1117,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1635,109,'Goblin_Ambusher',300,0,1017,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1683,109,'Goblin_Leecher',300,0,1098,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1738,109,'Goblin_Tinkerer',300,0,1032,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1666,109,'Goblin_Gambler',300,0,1081,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1643,109,'Goblin_Butcher',300,0,1032,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,2579,109,'Marsh_Funguar',300,0,1632,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1419,109,'Fox_Fire',300,8,569,0,0,24,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,6831,109,'Toxic_Tamlyn',0,128,3320,0,0,44,44,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (39,460,109,'Bloodpool_Vorax',0,32,301,800,0,24,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,519,109,'BoWho_Warmonger',0,128,2852,2750,0,36,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,6658,109,'Goblin_Digger',300,0,1040,0,0,18,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,1983,109,'Hobgoblin_Warrior',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1984,109,'Hobgoblin_White_Mage',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,1972,109,'Hobgoblin_Black_Mage',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,1979,109,'Hobgoblin_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1980,109,'Hobgoblin_Thief',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,1974,109,'Hobgoblin_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,1978,109,'Hobgoblin_Ranger',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,1971,109,'Hobgoblin_Beastmaster',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,1722,109,'Goblins_Bee',0,128,0,0,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,2641,109,'Metaquadav_Warrior',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,2642,109,'Metaquadav_White_Mage',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,2636,109,'Metaquadav_Black_Mage',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,2639,109,'Metaquadav_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,2640,109,'Metaquadav_Thief',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,2638,109,'Metaquadav_Paladin',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,2637,109,'Metaquadav_Dark_Knight',0,128,0,0,0,35,35,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (58,2965,109,'Old_Quadav_G',0,128,3226,0,0,0,NULL);
@@ -8274,6 +10629,7 @@ INSERT INTO `mob_groups` VALUES (63,3745,109,'Sprite',0,128,2001,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (64,331,109,'Ballistosporer',0,128,0,0,0,0,NULL);
 
 -- Voidwalker
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (65,6999,109,'Yilbegan',86400,0,3185,90000,5000,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (66,7004,109,'Blobdingnag',7200,0,3181,39100,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (67,7005,109,'Septic_Boil',0,128,0,1400,0,0,'WOTG');
@@ -8281,6 +10637,15 @@ INSERT INTO `mob_groups` VALUES (68,7003,109,'Shoggoth',3600,0,3171,13000,0,0,'W
 INSERT INTO `mob_groups` VALUES (69,7002,109,'Lamprey_Lord',3600,0,3170,11000,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (70,7001,109,'Ground_Guzzler',300,0,0,3000,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (71,7000,109,'Globster',300,0,0,5100,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (65,6999,109,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (66,7004,109,'Blobdingnag',7200,0,3181,39100,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (67,7005,109,'Septic_Boil',0,128,0,1400,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (68,7003,109,'Shoggoth',3600,0,3171,13000,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (69,7002,109,'Lamprey_Lord',3600,0,3170,11000,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (70,7001,109,'Ground_Guzzler',300,0,0,3000,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (71,7000,109,'Globster',300,0,0,5100,0,80,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 INSERT INTO `mob_groups` VALUES (72,5312,109,'Murk-veined_Baneberry',0,128,0,0,99999,0,NULL);
 INSERT INTO `mob_groups` VALUES (73,6832,109,'Joyous_Green',0,128,0,0,0,0,NULL);
@@ -8305,6 +10670,7 @@ INSERT INTO `mob_groups` VALUES (3,1991,110,'Horrid_Fluke',0,128,895,0,0,0,NULL)
 INSERT INTO `mob_groups` VALUES (4,5868,110,'Greater_Pugil_fished',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,418,110,'Big_Leech',0,128,79,0,0,0,NULL);
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,3625,110,'Silk_Caterpillar',0,128,2248,700,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,941,110,'Death_Wasp',300,0,584,0,0,0,NULL);
@@ -8400,6 +10766,61 @@ INSERT INTO `mob_groups` VALUES (53,7022,110,'Pruina',300,0,0,4400,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (54,7024,110,'Beorht',300,0,0,4400,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (55,7027,110,'Thunor',300,0,0,4400,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (56,7029,110,'Lacus',300,0,0,4400,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (6,3625,110,'Silk_Caterpillar',0,128,2248,700,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,941,110,'Death_Wasp',300,0,584,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,2735,110,'Moon_Bat',300,2,461,0,0,23,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1757,110,'Goobbue_Farmer',300,0,1200,0,0,28,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,394,110,'Berry_Grub',300,0,256,0,0,25,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,2965,110,'Old_Quadav',300,0,1848,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,791,110,'Copper_Quadav',300,0,361,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,538,110,'Bronze_Quadav',300,0,361,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,525,110,'Brass_Quadav',300,0,351,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3628,110,'Silver_Quadav',300,0,361,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,4506,110,'Zircon_Quadav',300,0,361,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1472,110,'Garnet_Quadav',300,0,935,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4337,110,'Wight_war',300,1,2651,0,0,26,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1341,110,'Fire_Elemental',300,4,831,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2940,110,'Ochu',300,0,1837,0,0,34,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,2649,110,'Midnight_Wings',300,2,82,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1690,110,'Goblin_Mugger',300,0,1117,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1694,110,'Goblin_Pathfinder',300,0,1123,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1722,110,'Goblins_Bee',0,128,0,0,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1683,110,'Goblin_Leecher',300,0,1098,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1665,110,'Goblin_Furrier',300,0,1064,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1666,110,'Goblin_Gambler',300,0,1081,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1715,110,'Goblin_Smithy',300,0,1162,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1710,110,'Goblin_Shaman',300,0,1148,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,2054,110,'Ignis_Fatuus',300,8,569,0,0,34,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,440,110,'Black_Triple_Stars',0,32,286,0,0,26,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,3165,110,'Poison_Leech',300,0,18,0,0,24,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,743,110,'Clipper',300,0,482,0,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,4309,110,'Water_Elemental',300,4,2629,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1267,110,'Evil_Weapon',300,0,0,0,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,6025,110,'Ravenous_Crawler',7200,0,3097,3500,0,42,42,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (37,1266,110,'Evil_Spirit',300,1,264,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,5729,110,'Eldritch_Edge',0,32,2993,5096,0,55,55,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (39,1124,110,'Drooling_Daisy',0,32,712,1400,0,39,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,6658,110,'Goblin_Digger',300,0,1040,0,0,28,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,3630,110,'Simurgh',0,128,2255,51000,0,58,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,3745,110,'Sprite',0,128,2001,0,0,61,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,4107,110,'Urayuli',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,726,110,'Chuglix_Berrypaws',0,128,0,0,0,1,1,0,NULL);
+
+-- Voidwalker
+INSERT INTO `mob_groups` VALUES (45,6999,110,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (46,7032,110,'Verthandi',7200,0,3183,25500,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (47,7031,110,'Urd',3600,0,3175,12900,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (48,7030,110,'Skuld',3600,0,3174,12900,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (49,7021,110,'Aither',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (50,7023,110,'Deorc',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (51,7025,110,'Eorthe',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (52,7028,110,'Puretos',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (53,7022,110,'Pruina',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (54,7024,110,'Beorht',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (55,7027,110,'Thunor',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (56,7029,110,'Lacus',300,0,0,4400,0,80,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 INSERT INTO `mob_groups` VALUES (57,4703,110,'Yatagarasu',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (58,6833,110,'Strix',0,128,0,0,0,0,NULL);
@@ -8422,6 +10843,7 @@ INSERT INTO `mob_groups` VALUES (3,6029,111,'Kraken_fished',0,128,1464,0,0,0,NUL
 INSERT INTO `mob_groups` VALUES (4,204,111,'Apsaras',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,2746,111,'Morgawr',0,128,2183,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,4050,111,'Tundra_Tiger',300,0,2494,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,1694,111,'Goblin_Pathfinder',300,0,1123,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,1733,111,'Goblins_Tiger',0,128,0,0,0,0,NULL);
@@ -8464,6 +10886,50 @@ INSERT INTO `mob_groups` VALUES (44,1575,111,'Gigas_Monk',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (45,1551,111,'Gigas_Beastmaster',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (46,1581,111,'Gigas_Ranger',0,128,0,0,0,0,NULL);
 -- 47 free
+=======
+INSERT INTO `mob_groups` VALUES (6,4050,111,'Tundra_Tiger',300,0,2494,0,0,34,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1694,111,'Goblin_Pathfinder',300,0,1123,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1733,111,'Goblins_Tiger',0,128,0,0,0,28,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1665,111,'Goblin_Furrier',300,0,1064,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1715,111,'Goblin_Smithy',300,0,1162,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1710,111,'Goblin_Shaman',300,0,1148,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,2424,111,'Living_Statue',300,0,192,0,0,37,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,374,111,'Bat_Eye',300,0,245,0,0,40,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,764,111,'Cold_Gigas',300,0,499,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3688,111,'Snow_Gigas',300,0,499,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3368,111,'Rime_Gigas',300,0,499,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1594,111,'Gigass_Tiger',0,128,0,0,0,33,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,3668,111,'Sleet_Gigas',300,0,499,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,913,111,'Dark_Elemental',300,4,568,0,0,44,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2043,111,'Ice_Elemental',300,4,1347,0,0,44,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,6549,111,'Ghast_war',300,0,953,0,0,40,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1511,111,'Ghast_blm',300,0,953,0,0,40,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,2447,111,'Lugat',300,0,264,0,0,39,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,2919,111,'Nue',0,32,1827,0,0,41,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1701,111,'Goblin_Poacher',300,0,1138,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1741,111,'Goblin_Trader',300,0,1179,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1709,111,'Goblin_Robber',300,0,1145,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1705,111,'Goblin_Reaper',300,0,1142,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,3781,111,'Stone_Golem',300,0,505,0,0,40,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,2264,111,'Kirata',0,32,1453,0,0,41,41,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1461,111,'Gargantua',0,32,930,0,0,47,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,5853,111,'Humbaba',0,128,3064,6500,0,62,62,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (33,5313,111,'Calcabrina',5400,0,2937,4550,0,52,55,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (34,1983,111,'Hobgoblin_Warrior',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1984,111,'Hobgoblin_White_Mage',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1972,111,'Hobgoblin_Black_Mage',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1979,111,'Hobgoblin_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1980,111,'Hobgoblin_Thief',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1974,111,'Hobgoblin_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,1978,111,'Hobgoblin_Ranger',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,1971,111,'Hobgoblin_Beastmaster',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,1733,111,'Goblins_Tiger',0,128,0,0,0,40,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1598,111,'Gigas_Warrior',0,128,0,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,1575,111,'Gigas_Monk',0,128,0,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,1551,111,'Gigas_Beastmaster',0,128,0,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1581,111,'Gigas_Ranger',0,128,0,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,1594,111,'Gigass_Tiger',0,128,0,0,0,40,40,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (48,1566,111,'Gigas_Hillrazer',0,128,3226,0,0,0,NULL);
@@ -8473,12 +10939,21 @@ INSERT INTO `mob_groups` VALUES (50,1576,111,'Gigas_Overseer',0,128,3226,0,0,0,N
 INSERT INTO `mob_groups` VALUES (51,3159,111,'Plumbago',0,128,0,0,0,0,NULL);
 
 -- Voidwalker
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (52,6999,111,'Yilbegan',86400,0,3185,90000,5000,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (53,7015,111,'Lord_Ruthven',7200,0,3186,32600,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (54,7014,111,'Feuerunke',3600,0,3177,15500,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (55,7013,111,'Erebus',3600,0,3176,16000,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (56,7012,111,'Gjenganger',300,0,0,4900,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (57,7011,111,'Gorehound',300,0,0,5000,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (52,6999,111,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (53,7015,111,'Lord_Ruthven',7200,0,3186,32600,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (54,7014,111,'Feuerunke',3600,0,3177,15500,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (55,7013,111,'Erebus',3600,0,3176,16000,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (56,7012,111,'Gjenganger',300,0,0,4900,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (57,7011,111,'Gorehound',300,0,0,5000,0,80,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 INSERT INTO `mob_groups` VALUES (58,4708,111,'Kalasutrax',0,128,0,0,9999,0,NULL);
 INSERT INTO `mob_groups` VALUES (59,6834,111,'Largantua',0,128,0,0,0,0,NULL);
@@ -8497,6 +10972,7 @@ INSERT INTO `mob_groups` VALUES (65,0,111,'Excenmille',0,128,0,0,0,0,NULL);
 -- Xarcabard (Zone 112)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,6558,112,'Lost_Soul_war',300,0,1539,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,2442,112,'Lost_Soul_blm',300,0,1539,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1260,112,'Etemmu',300,0,264,0,0,0,NULL);
@@ -8540,6 +11016,51 @@ INSERT INTO `mob_groups` VALUES (40,1575,112,'Gigas_Monk',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (41,1551,112,'Gigas_Beastmaster',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (42,1581,112,'Gigas_Ranger',0,128,0,0,0,0,NULL);
 -- 43 free
+=======
+INSERT INTO `mob_groups` VALUES (1,6558,112,'Lost_Soul_war',300,0,1539,0,0,42,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,2442,112,'Lost_Soul_blm',300,0,1539,0,0,42,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1260,112,'Etemmu',300,0,264,0,0,43,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,1264,112,'Evil_Eye',300,0,794,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,3575,112,'Shadow_Dragon',600,0,0,0,0,52,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,410,112,'Biast',0,128,266,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,2043,112,'Ice_Elemental',300,4,1347,0,0,48,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,868,112,'Cursed_Weapon',300,0,548,0,0,43,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,913,112,'Dark_Elemental',300,4,568,0,0,48,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,991,112,'Demon_Pawn',300,0,621,0,0,48,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,6027,112,'Barbaric_Weapon',0,32,3098,6700,0,73,74,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (12,5851,112,'Timeworn_Warrior',0,32,3062,5000,0,57,58,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (13,1252,112,'Ereshkigal',0,128,788,6000,0,48,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,453,112,'Blizzard_Gigas',300,0,296,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1794,112,'Graupel_Gigas',300,0,296,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1431,112,'Frost_Gigas',300,0,296,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1594,112,'Gigass_Tiger',0,128,0,0,0,38,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1874,112,'Hail_Gigas',300,0,296,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,997,112,'Demon_Wizard',300,0,621,0,0,48,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,988,112,'Demon_Knight',300,0,616,0,0,48,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,5423,112,'Duke_Focalor',0,128,2943,4400,0,51,53,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (22,995,112,'Demon_Warlock',300,0,624,0,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,994,112,'Demons_Elemental',0,128,0,0,0,43,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,3576,112,'Shadow_Eye',0,32,2226,6800,0,48,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,693,112,'Chaos_Elemental',0,128,452,0,0,42,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,510,112,'Boreal_Hound',300,0,0,26000,0,53,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,509,112,'Boreal_Coeurl',300,0,0,26000,0,53,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,511,112,'Boreal_Tiger',300,0,0,26000,0,53,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,2276,112,'Koenigstiger',0,128,0,0,0,63,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1983,112,'Hobgoblin_Warrior',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1984,112,'Hobgoblin_White_Mage',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1972,112,'Hobgoblin_Black_Mage',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1979,112,'Hobgoblin_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1980,112,'Hobgoblin_Thief',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1974,112,'Hobgoblin_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1978,112,'Hobgoblin_Ranger',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1971,112,'Hobgoblin_Beastmaster',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1733,112,'Goblins_Tiger',0,128,0,0,0,43,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1598,112,'Gigas_Warrior',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,1575,112,'Gigas_Monk',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,1551,112,'Gigas_Beastmaster',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,1581,112,'Gigas_Ranger',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1594,112,'Gigass_Tiger',0,128,0,0,0,55,55,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (44,997,112,'Demon_Wizard',0,128,3226,0,0,0,NULL);
@@ -8549,12 +11070,21 @@ INSERT INTO `mob_groups` VALUES (46,981,112,'Demon_Aristocrat',0,128,3226,0,0,0,
 INSERT INTO `mob_groups` VALUES (47,2295,112,'Kulili',0,128,0,0,0,0,NULL);
 
 -- Voidwalker
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (48,6999,112,'Yilbegan',86400,0,3185,90000,5000,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (49,7015,112,'Lord_Ruthven',7200,0,3186,32600,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (50,7014,112,'Feuerunke',3600,0,3177,15500,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (51,7013,112,'Erebus',3600,0,3176,16000,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (52,7012,112,'Gjenganger',300,0,0,4900,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (53,7011,112,'Gorehound',300,0,0,5000,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (48,6999,112,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (49,7015,112,'Lord_Ruthven',7200,0,3186,32600,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (50,7014,112,'Feuerunke',3600,0,3177,15500,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (51,7013,112,'Erebus',3600,0,3176,16000,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (52,7012,112,'Gjenganger',300,0,0,4900,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (53,7011,112,'Gorehound',300,0,0,5000,0,80,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 INSERT INTO `mob_groups` VALUES (54,4857,112,'Beist',0,128,0,0,0,0,NULL);
 
@@ -8568,6 +11098,7 @@ INSERT INTO `mob_groups` VALUES (2,6777,113,'Rock_Crab_fished',0,128,273,0,0,0,N
 INSERT INTO `mob_groups` VALUES (3,6768,113,'Stygian_Pugil_fished',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,6778,113,'Devil_Manta_fished',0,128,0,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,1687,113,'Goblin_Mercenary',300,0,1114,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,5643,113,'Sand_Lizard',300,0,2152,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,378,113,'Beach_Bunny',300,0,247,0,0,0,NULL);
@@ -8602,6 +11133,42 @@ INSERT INTO `mob_groups` VALUES (35,1978,113,'Hobgoblin_Ranger',0,128,0,0,0,0,NU
 INSERT INTO `mob_groups` VALUES (36,1971,113,'Hobgoblin_Beastmaster',0,128,0,0,0,0,NULL);
 -- 37 free
 INSERT INTO `mob_groups` VALUES (38,3777,113,'Stolas',0,128,0,8500,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,1687,113,'Goblin_Mercenary',300,0,1114,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,5643,113,'Sand_Lizard',300,0,2152,0,0,62,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,378,113,'Beach_Bunny',300,0,247,0,0,62,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1711,113,'Goblin_Shepherd',300,0,1156,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1730,113,'Goblins_Rabbit',0,128,0,0,0,48,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1637,113,'Goblin_Bandit',300,0,1022,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1085,113,'Doom_Soldier',300,1,684,0,0,66,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1634,113,'Goblin_Alchemist',300,0,1015,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1083,113,'Doom_Mage',300,1,676,0,0,67,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1341,113,'Fire_Elemental',300,4,831,0,0,67,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,4218,113,'Velociraptor',300,0,600,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1295,113,'Fantasma',300,1,817,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3375,113,'Robber_Crab',300,0,2107,0,0,64,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1235,113,'Enna-enna',300,8,569,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3451,113,'Sand_Cockatrice',300,0,2147,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,5889,113,'Killer_Jonny',0,32,3088,0,0,85,85,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (21,3882,113,'Terror_Pugil',300,0,279,0,0,66,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,71,113,'Air_Elemental',300,4,38,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,5425,113,'Tegmine',7200,0,2945,10500,5000,70,73,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (24,6835,113,'Zmey_Gorynych',3600,0,3289,0,0,78,78,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (25,1806,113,'Greater_Manticore',300,0,1228,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1429,113,'Frostmane',0,32,912,10500,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,2287,113,'Kreutzet',0,128,1466,13000,0,79,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,302,113,'Axesarion_the_Wanderer',0,128,0,7600,0,68,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1983,113,'Hobgoblin_Warrior',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1984,113,'Hobgoblin_White_Mage',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1972,113,'Hobgoblin_Black_Mage',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1979,113,'Hobgoblin_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1980,113,'Hobgoblin_Thief',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1974,113,'Hobgoblin_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1978,113,'Hobgoblin_Ranger',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1971,113,'Hobgoblin_Beastmaster',0,128,0,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1730,113,'Goblins_Rabbit',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,3777,113,'Stolas',0,128,0,8500,0,80,80,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (39,1699,113,'Goblin_Pirate',0,128,3226,0,0,0,NULL);
@@ -8625,6 +11192,7 @@ INSERT INTO `mob_groups` VALUES (3,5865,114,'Ironshell_fished',0,128,93,0,0,0,NU
 INSERT INTO `mob_groups` VALUES (4,6779,114,'Makara_fished',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,1268,114,'Bigclaw_fished',0,128,273,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,1539,114,'Giant_Spider',300,0,973,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,1006,114,'Desert_Dhalmel',300,0,632,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,3450,114,'Sand_Beetle',300,0,2146,0,0,0,NULL);
@@ -8672,6 +11240,55 @@ INSERT INTO `mob_groups` VALUES (49,778,114,'Contantican_Black_Mage',0,128,0,0,0
 INSERT INTO `mob_groups` VALUES (50,779,114,'Contantican_Paladin',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (51,780,114,'Contantican_Ranger',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (52,595,114,'Cactrot_Rapido',0,128,395,9800,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,1539,114,'Giant_Spider',300,0,973,0,0,30,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1006,114,'Desert_Dhalmel',300,0,632,0,0,39,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3450,114,'Sand_Beetle',300,0,2146,0,0,36,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,167,114,'Antican_Auxiliarius',300,0,116,0,0,35,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1035,114,'Diatryma',300,0,651,0,0,47,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1341,114,'Fire_Elemental',300,4,831,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,174,114,'Antican_Funditor',300,0,123,0,0,35,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1239,114,'Flesh_Eater',300,2,438,0,0,37,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3426,114,'Sabotender',300,0,396,0,0,42,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1160,114,'Earth_Elemental',300,4,733,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,5764,114,'Donnergugi',0,32,3048,5500,0,60,60,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (17,173,114,'Antican_Faber',300,0,122,0,0,35,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,170,114,'Antican_Decurio',300,0,119,0,0,44,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,192,114,'Antican_Veles',300,0,117,0,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,168,114,'Antican_Centurio',300,0,117,0,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,6558,114,'Lost_Soul_war',300,1,678,0,0,44,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,2442,114,'Lost_Soul_blm',300,1,678,0,0,44,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,186,114,'Antican_Sagittarius',300,0,121,0,0,44,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,189,114,'Antican_Speculator',300,0,138,0,0,44,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,5891,114,'Sabotender_Corrido',7200,0,3090,9000,0,72,73,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (26,1709,114,'Goblin_Robber',300,0,1145,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,676,114,'Centurio_XII-I',0,128,444,5000,0,56,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1701,114,'Goblin_Poacher',300,0,1138,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1138,114,'Dune_Widow',0,32,720,0,0,45,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1705,114,'Goblin_Reaper',300,0,1142,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1741,114,'Goblin_Trader',300,0,1179,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1732,114,'Goblins_Spider',0,128,0,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,2398,114,'Lesser_Manticore',300,0,633,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,5855,114,'Nandi',0,128,3067,4500,0,48,49,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (35,1084,114,'Doom_Scorpion',300,0,681,0,0,44,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,6658,114,'Goblin_Digger',300,0,1042,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,948,114,'Decurio_I-III',0,128,0,5000,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,4045,114,'Tsuchigumo',0,128,0,0,0,42,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1983,114,'Hobgoblin_Warrior',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,1984,114,'Hobgoblin_White_Mage',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,1972,114,'Hobgoblin_Black_Mage',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,1979,114,'Hobgoblin_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1980,114,'Hobgoblin_Thief',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,1974,114,'Hobgoblin_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,1978,114,'Hobgoblin_Ranger',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1971,114,'Hobgoblin_Beastmaster',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,1732,114,'Goblins_Spider',0,128,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,781,114,'Contantican_Warrior',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,778,114,'Contantican_Black_Mage',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,779,114,'Contantican_Paladin',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,780,114,'Contantican_Ranger',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,595,114,'Cactrot_Rapido',0,128,395,0,0,80,81,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (53,1896,114,'Hastatus_XIII-LXXV',0,128,3226,0,0,0,NULL);
@@ -8701,6 +11318,7 @@ INSERT INTO `mob_groups` VALUES (3,6771,115,'Land_Crab_fished',0,128,481,0,0,0,N
 INSERT INTO `mob_groups` VALUES (4,2769,115,'Mugger_Crab',0,128,481,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,3102,115,'Passage_Crab',0,128,93,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,3924,115,'Tiny_Mandragora',60,0,2419,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,583,115,'Bumblebee',60,0,388,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,3490,115,'Savanna_Rarab',180,0,2846,0,0,0,NULL);
@@ -8724,6 +11342,31 @@ INSERT INTO `mob_groups` VALUES (25,3947,115,'Tom_Tit_Tat',0,32,2427,540,0,0,NUL
 INSERT INTO `mob_groups` VALUES (26,2921,115,'Nunyenunc',0,32,1829,335,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (27,5737,115,'Numbing_Norman',0,128,3000,440,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (28,1648,115,'Goblin_Digger',300,0,1039,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,3924,115,'Tiny_Mandragora',60,0,2419,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,583,115,'Bumblebee',60,0,388,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3490,115,'Savanna_Rarab',180,0,2846,0,0,1,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,3371,115,'River_Crab',180,0,481,0,0,1,3,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,831,115,'Crawler',300,0,530,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,650,115,'Carrion_Crow',180,0,43,0,0,2,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1737,115,'Goblin_Thug',300,0,1169,0,0,3,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1744,115,'Goblin_Weaver',300,0,1182,0,0,3,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1659,115,'Goblin_Fisher',300,0,1051,0,0,3,4,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,2546,115,'Mandragora',300,0,1596,0,0,3,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,4426,115,'Yagudo_Initiate',300,0,2716,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,4405,115,'Yagudo_Acolyte',300,0,2692,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4448,115,'Yagudo_Scribe',300,0,2761,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,332,115,'Balloon',300,8,216,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2472,115,'Mad_Fox',300,1,226,0,0,4,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,2475,115,'Magicked_Bones_war',300,1,769,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,831,115,'Crawler',300,0,3227,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1524,115,'Giant_Bee',180,0,584,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,6562,115,'Magicked_Bones_blm',300,1,769,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,3947,115,'Tom_Tit_Tat',0,32,2427,540,0,9,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,2921,115,'Nunyenunc',0,32,1829,335,0,12,12,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,5737,115,'Numbing_Norman',0,128,3000,440,0,12,13,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (28,1648,115,'Goblin_Digger',300,0,1039,0,0,5,8,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (29,6971,115,'Yagudo_Votary',0,128,3226,0,0,0,NULL);
@@ -8736,12 +11379,21 @@ INSERT INTO `mob_groups` VALUES (34,3148,115,'Pixie',0,128,2001,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (35,327,115,'Bakru',0,128,0,0,0,0,NULL);
 
 -- Voidwalker
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (36,6999,115,'Yilbegan',86400,0,3185,90000,5000,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (37,7010,115,'Orcus',7200,0,3182,39000,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (38,7009,115,'Farruca_Fly',3600,0,3173,18200,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (39,7008,115,'Jyeshtha',3600,0,3172,11917,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (40,7007,115,'Rummager_Beetle',300,0,0,5150,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (41,7006,115,'Raker_Bee',300,0,0,4900,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (36,6999,115,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (37,7010,115,'Orcus',7200,0,3182,39000,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (38,7009,115,'Farruca_Fly',3600,0,3173,18200,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (39,7008,115,'Jyeshtha',3600,0,3172,11917,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (40,7007,115,'Rummager_Beetle',300,0,0,5150,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (41,7006,115,'Raker_Bee',300,0,0,4900,0,80,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 INSERT INTO `mob_groups` VALUES (42,5148,115,'Virvatuli',0,128,0,0,9999,0,NULL);
 INSERT INTO `mob_groups` VALUES (43,0,115,'Tatenashi_Armor',0,128,0,0,0,0,NULL);
@@ -8783,6 +11435,7 @@ INSERT INTO `mob_groups` VALUES (3,2768,116,'Mud_Pugil',0,128,975,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,6769,116,'Pug_Pugil_fished',0,128,463,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,1336,116,'Fighting_Pugil',0,128,279,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,3924,116,'Tiny_Mandragora',60,0,2419,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,583,116,'Bumblebee',60,0,388,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,3490,116,'Savanna_Rarab',180,0,2171,0,0,0,NULL);
@@ -8829,6 +11482,54 @@ INSERT INTO `mob_groups` VALUES (48,0,116,'Slime',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (49,0,116,'She-Slime',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (50,0,116,'Metal_Slime',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (51,4851,116,'Prickly_Pitriv',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,3924,116,'Tiny_Mandragora',60,0,2419,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,583,116,'Bumblebee',60,0,388,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3490,116,'Savanna_Rarab',180,0,2171,0,0,1,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,831,116,'Crawler',300,0,530,0,0,3,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,650,116,'Carrion_Crow',180,0,43,0,0,2,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,4426,116,'Yagudo_Initiate',300,0,2716,0,0,1,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,4405,116,'Yagudo_Acolyte',300,0,2692,0,0,1,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,4448,116,'Yagudo_Scribe',300,0,2761,0,0,1,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,2472,116,'Mad_Fox',300,1,226,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,2475,116,'Magicked_Bones_war',300,1,769,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3587,116,'Sharp-Eared_Ropipi',0,32,2231,290,0,10,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1737,116,'Goblin_Thug',300,0,1169,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1744,116,'Goblin_Weaver',300,0,1182,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3371,116,'River_Crab',180,0,2102,0,0,2,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2546,116,'Mandragora',180,0,1596,0,0,3,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,1524,116,'Giant_Bee',180,0,584,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,332,116,'Balloon',300,8,216,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1659,116,'Goblin_Fisher',300,0,1051,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,3734,116,'Spiny_Spipi',0,32,2308,560,0,9,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,4529,116,'Duke_Decapod',0,128,2988,200,125,8,8,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (26,1648,116,'Goblin_Digger',300,0,1039,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,3148,116,'Pixie',0,128,2001,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,489,116,'Bolster',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,4709,116,'Rw_Nw_Prt_M_Hrw',0,128,0,0,5000,95,97,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,0,116,'Wayward_Worm',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,0,116,'Tatenashi_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,0,116,'Hizamaru_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,0,116,'Ubuginu_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,0,116,'Hachiryu_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,0,116,'Omodaka_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,579,116,'Bull_[Herd1]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,821,116,'Cow_[Herd1]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,611,116,'Calf_[Herd1]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,580,116,'Bull_[Herd2]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,822,116,'Cow_[Herd2]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,612,116,'Calf_[Herd2]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,581,116,'Bull_[Herd3]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,823,116,'Cow_[Herd3]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,613,116,'Calf_[Herd3]',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,3241,116,'Pyracmon',0,128,2047,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,4381,116,'Wraith_Bat',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,0,116,'Astral_Box',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,0,116,'Slime',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,0,116,'She-Slime',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,0,116,'Metal_Slime',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,4851,116,'Prickly_Pitriv',0,128,0,0,0,80,80,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- The Cardian's Duty
 INSERT INTO `mob_groups` VALUES (52,0,116,'Yagudo_Vicar',0,128,0,0,0,0,NULL);
@@ -8843,6 +11544,7 @@ INSERT INTO `mob_groups` VALUES (57,6562,116,'Magicked_Bones_blm',300,1,769,0,0,
 -- Tahrongi_Canyon (Zone 117)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,626,117,'Canyon_Rarab',300,0,407,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,3240,117,'Pygmaioi',300,0,2046,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,3792,117,'Strolling_Sapling',300,0,2347,0,0,0,NULL);
@@ -8886,6 +11588,51 @@ INSERT INTO `mob_groups` VALUES (38,7019,117,'Tammuz',3600,0,3179,18510,0,0,'WOT
 INSERT INTO `mob_groups` VALUES (39,7018,117,'Chesma',3600,0,3178,14700,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (40,7017,117,'Void_Hare',300,0,0,4900,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (41,7016,117,'Prickly_Sheep',300,0,0,5300,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (1,626,117,'Canyon_Rarab',300,0,407,0,0,7,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,3240,117,'Pygmaioi',300,0,2046,0,0,7,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,3792,117,'Strolling_Sapling',300,0,2347,0,0,7,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,5079,117,'Akbaba',300,0,43,0,0,9,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,3647,117,'Skeleton_Warrior',300,1,769,0,0,10,12,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3646,117,'Skeleton_Sorcerer',300,1,769,0,0,11,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1514,117,'Ghost',300,1,956,0,0,15,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,4570,117,'Habrok',0,128,2976,600,0,16,18,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (9,2228,117,'Killer_Bee',300,0,584,0,0,8,12,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,624,117,'Canyon_Crawler',300,0,256,0,0,11,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1737,117,'Goblin_Thug',300,0,1169,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1635,117,'Goblin_Ambusher',300,0,1017,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1744,117,'Goblin_Weaver',300,0,1182,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1738,117,'Goblin_Tinkerer',300,0,1032,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1643,117,'Goblin_Butcher',300,0,1032,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,71,117,'Air_Elemental',300,4,38,0,0,18,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,4341,117,'Wild_Dhalmel',300,0,2655,0,0,14,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,342,117,'Barghest',300,1,226,0,0,8,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3550,117,'Serpopard_Ishtar',0,32,2204,620,0,19,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,4426,117,'Yagudo_Initiate',300,0,2716,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,4432,117,'Yagudo_Mendicant',300,0,2731,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,4454,117,'Yagudos_Elemental',0,128,0,0,0,8,9,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,4405,117,'Yagudo_Acolyte',300,0,2692,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,4448,117,'Yagudo_Scribe',300,0,2761,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,4441,117,'Yagudo_Piper',300,0,2743,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,4439,117,'Yagudo_Persecutor',300,0,2731,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1160,117,'Earth_Elemental',300,4,733,0,0,18,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1812,117,'Grenade',300,8,569,0,0,15,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,3170,117,'Poltergeist',300,0,0,0,0,18,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,4571,117,'Herbage_Hunter',0,32,2983,1320,0,29,29,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (31,6658,117,'Goblin_Digger',300,0,1039,0,0,11,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1636,117,'Goblin_Archaeologist',0,128,1021,0,0,30,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,4466,117,'Yara_Ma_Yha_Who',0,128,2779,950,0,14,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,3148,117,'Pixie',0,128,2001,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,92,117,'Allocamelus',0,128,0,0,0,1,1,0,NULL);
+
+-- Voidwalker
+INSERT INTO `mob_groups` VALUES (36,6999,117,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (37,7020,117,'Dawon',7200,0,3184,24700,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (38,7019,117,'Tammuz',3600,0,3179,18510,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (39,7018,117,'Chesma',3600,0,3178,14700,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (40,7017,117,'Void_Hare',300,0,0,4900,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (41,7016,117,'Prickly_Sheep',300,0,0,5300,0,80,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 INSERT INTO `mob_groups` VALUES (42,4735,117,'Smierc',0,128,0,0,9999,0,NULL);
 INSERT INTO `mob_groups` VALUES (43,0,117,'Wayward_Worm',0,128,0,0,0,0,NULL);
@@ -8908,6 +11655,7 @@ INSERT INTO `mob_groups` VALUES (3,3682,118,'Snipper_fished',0,128,482,0,0,0,NUL
 INSERT INTO `mob_groups` VALUES (4,6780,118,'Shoal_Pugil_fished',0,128,248,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,6765,118,'Clipper_fished',0,128,481,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,3830,118,'Sylvestre',300,0,2369,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,2652,118,'Mighty_Rarab',300,0,1670,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,4523,118,'Zu',300,0,43,0,0,0,NULL);
@@ -8948,6 +11696,48 @@ INSERT INTO `mob_groups` VALUES (42,3890,118,'Theoyagudo_Ninja',0,128,0,0,0,0,NU
 INSERT INTO `mob_groups` VALUES (43,3892,118,'Theoyagudo_Summoner',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (44,4454,118,'Yagudos_Elemental',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (45,4453,118,'Yagudos_Avatar',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,3830,118,'Sylvestre',300,0,2369,0,0,15,19,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,2652,118,'Mighty_Rarab',300,0,1670,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,4523,118,'Zu',300,0,43,0,0,20,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1635,118,'Goblin_Ambusher',300,0,1017,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1738,118,'Goblin_Tinkerer',300,0,1032,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1643,118,'Goblin_Butcher',300,0,1032,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,4516,118,'Zombie_war',300,1,2809,0,0,18,22,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1518,118,'Ghoul_blm',300,1,960,0,0,20,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,4345,118,'Will-o-the-Wisp',300,8,569,0,0,25,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,485,118,'Bogy',300,1,322,0,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,578,118,'Bull_Dhalmel',300,0,385,0,0,20,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1690,118,'Goblin_Mugger',300,0,1117,0,0,22,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1683,118,'Goblin_Leecher',300,0,1098,0,0,22,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1666,118,'Goblin_Gambler',300,0,1081,0,0,22,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,71,118,'Air_Elemental',300,4,38,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3165,118,'Poison_Leech',300,0,2011,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,5741,118,'Wake_Warder_Wanda',0,128,3004,1030,0,22,23,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (23,4309,118,'Water_Elemental',960,4,2629,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,646,118,'Carnivorous_Crawler',300,0,256,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1919,118,'Helldiver',0,32,1292,1180,0,29,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,552,118,'Buburimboo',0,32,369,820,0,30,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,6658,118,'Goblin_Digger',300,0,1040,0,0,19,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1983,118,'Hobgoblin_Warrior',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1984,118,'Hobgoblin_White_Mage',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1972,118,'Hobgoblin_Black_Mage',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1979,118,'Hobgoblin_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1980,118,'Hobgoblin_Thief',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1974,118,'Hobgoblin_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1978,118,'Hobgoblin_Ranger',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1971,118,'Hobgoblin_Beastmaster',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1730,118,'Goblins_Rabbit',0,128,0,0,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,3889,118,'Theoyagudo_Monk',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,3893,118,'Theoyagudo_White_Mage',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,3888,118,'Theoyagudo_Black_Mage',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,3887,118,'Theoyagudo_Bard',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,3891,118,'Theoyagudo_Samurai',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,3890,118,'Theoyagudo_Ninja',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,3892,118,'Theoyagudo_Summoner',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,4454,118,'Yagudos_Elemental',0,128,0,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,4453,118,'Yagudos_Avatar',0,128,0,0,0,28,30,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (46,1718,118,'Goblin_Swordmaker',0,128,3226,0,0,0,NULL);
@@ -8956,6 +11746,7 @@ INSERT INTO `mob_groups` VALUES (48,1665,118,'Goblin_Furrier',0,128,3226,0,0,0,N
 INSERT INTO `mob_groups` VALUES (49,1710,118,'Goblin_Shaman',0,128,3226,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (50,1672,118,'Goblin_Guide',0,128,3226,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (51,3148,118,'Pixie',0,128,2001,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (52,2213,118,'Ketos',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (53,4734,118,'Botulus_Rex',0,128,0,0,9999,0,NULL);
@@ -8964,11 +11755,22 @@ INSERT INTO `mob_groups` VALUES (55,5344,118,'Backoo',0,128,3140,2700,0,0,'WOTG'
 INSERT INTO `mob_groups` VALUES (56,3608,118,'Shoal_Pugil',300,0,248,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (57,5733,118,'Snipper',300,0,482,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (58,4853,118,'Abyssdiver',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (51,3148,118,'Pixie',0,128,2001,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,2213,118,'Ketos',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,4734,118,'Botulus_Rex',0,128,0,0,9999,94,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,1642,118,'Goblin_Bounty_Hunter',300,0,1030,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,5344,118,'Backoo',0,128,3140,2700,0,37,37,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (56,3608,118,'Shoal_Pugil',300,0,248,0,0,24,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,5733,118,'Snipper',300,0,482,0,0,18,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,4853,118,'Abyssdiver',0,128,0,0,0,0,0,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Meriphataud_Mountains (Zone 119)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,6356,119,'Wandering_Sapling',300,0,2618,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,2163,119,'Jubjub',300,0,43,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1956,119,'Hill_Lizard',300,0,1317,0,0,0,NULL);
@@ -9025,6 +11827,64 @@ INSERT INTO `mob_groups` VALUES (53,3890,119,'Theoyagudo_Ninja',0,128,0,0,0,0,NU
 INSERT INTO `mob_groups` VALUES (54,3892,119,'Theoyagudo_Summoner',0,128,0,0,0,0,NULL);
 -- 55 free
 INSERT INTO `mob_groups` VALUES (56,4453,119,'Yagudos_Avatar',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,6356,119,'Wandering_Sapling',300,0,2618,0,0,13,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,2163,119,'Jubjub',300,0,43,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1956,119,'Hill_Lizard',300,0,1317,0,0,19,22,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,2877,119,'Night_Bats',300,2,82,0,0,13,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,433,119,'Black_Bat',300,2,461,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,4345,119,'Will-o-the-Wisp',300,8,569,0,0,24,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,3497,119,'Scavenging_Hound',300,1,226,0,0,18,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,485,119,'Bogy',300,1,322,0,0,25,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,303,119,'Axe_Beak',300,0,201,0,0,25,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1160,119,'Earth_Elemental',300,4,733,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1690,119,'Goblin_Mugger',300,0,1117,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1635,119,'Goblin_Ambusher',300,0,1017,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1683,119,'Goblin_Leecher',300,0,1098,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1738,119,'Goblin_Tinkerer',300,0,1032,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1666,119,'Goblin_Gambler',300,0,1081,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1643,119,'Goblin_Butcher',300,0,1032,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,4516,119,'Zombie_war',300,1,2809,0,0,16,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6574,119,'Zombie_blm',300,1,2809,0,0,16,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,5727,119,'Chonchon',3600,0,2992,3154,0,42,42,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (20,3324,119,'Raptor',300,0,557,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,4459,119,'Yagudo_Votary',300,0,2774,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,4432,119,'Yagudo_Mendicant',300,0,2732,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,4454,119,'Yagudos_Elemental',0,128,0,0,0,9,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,4456,119,'Yagudo_Theologist',300,0,2770,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,4441,119,'Yagudo_Piper',300,0,2744,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,4444,119,'Yagudo_Priest',300,0,2749,0,0,21,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,4439,119,'Yagudo_Persecutor',300,0,2732,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1341,119,'Fire_Elemental',300,4,831,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,5771,119,'Naa_Zeku_the_Unwaiting',0,32,3055,3800,0,49,49,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (30,890,119,'Daggerclaw_Dracos',0,32,558,0,0,27,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,4287,119,'Waraxe_Beak',0,128,2621,14800,0,55,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,483,119,'Boggart',300,0,319,0,0,25,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,827,119,'Crane_Fly',300,0,524,0,0,18,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,3752,119,'Stag_Beetle',300,0,2319,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,759,119,'Coeurl',300,0,496,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,788,119,'Coo_Keja_the_Unseen',0,128,508,0,0,37,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,4575,119,'Patripatan',0,32,3017,0,0,27,30,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (38,6658,119,'Goblin_Digger',300,0,1040,0,0,18,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1983,119,'Hobgoblin_Warrior',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,1984,119,'Hobgoblin_White_Mage',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,1972,119,'Hobgoblin_Black_Mage',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,1979,119,'Hobgoblin_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1980,119,'Hobgoblin_Thief',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,1974,119,'Hobgoblin_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,1978,119,'Hobgoblin_Ranger',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1971,119,'Hobgoblin_Beastmaster',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,1725,119,'Goblins_Dragonfly',0,128,0,0,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,3889,119,'Theoyagudo_Monk',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,3893,119,'Theoyagudo_White_Mage',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,3888,119,'Theoyagudo_Black_Mage',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,3887,119,'Theoyagudo_Bard',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,3891,119,'Theoyagudo_Samurai',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,3890,119,'Theoyagudo_Ninja',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,3892,119,'Theoyagudo_Summoner',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,4454,119,'Yagudos_Elemental',0,128,0,0,0,28,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,4453,119,'Yagudos_Avatar',0,128,0,0,0,28,28,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (57,4459,119,'Yagudo_Votary_G',0,128,3226,0,0,0,NULL);
@@ -9037,12 +11897,21 @@ INSERT INTO `mob_groups` VALUES (62,3745,119,'Sprite',0,128,2001,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (63,4044,119,'Tsaagan',0,128,0,0,0,0,NULL);
 
 -- Voidwalker
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (64,6999,119,'Yilbegan',86400,0,3185,90000,5000,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (65,7010,119,'Orcus',7200,0,3182,39000,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (66,7009,119,'Farruca_Fly',3600,0,3173,18200,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (67,7008,119,'Jyeshtha',3600,0,3172,11917,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (68,7007,119,'Rummager_Beetle',300,0,0,5150,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (69,7006,119,'Raker_Bee',300,0,0,4900,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (64,6999,119,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (65,7010,119,'Orcus',7200,0,3182,39000,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (66,7009,119,'Farruca_Fly',3600,0,3173,18200,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (67,7008,119,'Jyeshtha',3600,0,3172,11917,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (68,7007,119,'Rummager_Beetle',300,0,0,5150,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (69,7006,119,'Raker_Bee',300,0,0,4900,0,80,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 INSERT INTO `mob_groups` VALUES (70,5189,119,'Lord_Asag',0,128,0,0,25000,0,NULL);
 INSERT INTO `mob_groups` VALUES (71,6839,119,'Warblade_Beak',0,128,0,0,0,0,NULL);
@@ -9067,6 +11936,7 @@ INSERT INTO `mob_groups` VALUES (3,5868,120,'Greater_Pugil_fished',0,128,147,0,0
 INSERT INTO `mob_groups` VALUES (4,5864,120,'Cutter_fished',0,128,93,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,6029,120,'Kraken_fished',0,128,1464,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,1956,120,'Hill_Lizard',300,0,1314,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,2649,120,'Midnight_Wings',300,2,82,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,2735,120,'Moon_Bat',300,2,461,0,0,0,NULL);
@@ -9133,6 +12003,74 @@ INSERT INTO `mob_groups` VALUES (65,0,120,'Omodaka_Armor',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (66,1642,120,'Goblin_Bounty_Hunter',300,0,1030,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (67,6570,120,'Wight_blm',300,1,2651,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (68,6583,120,'Bashe',0,32,3142,3300,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (6,1956,120,'Hill_Lizard',300,0,1314,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,2649,120,'Midnight_Wings',300,2,82,0,0,20,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,2735,120,'Moon_Bat',300,2,461,0,0,23,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,690,120,'Champaign_Coeurl',300,0,449,0,0,30,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,4459,120,'Yagudo_Votary',300,0,2771,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,4423,120,'Yagudo_Herald',300,0,2709,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,4456,120,'Yagudo_Theologist',300,0,2771,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,4416,120,'Yagudo_Drummer',300,0,2705,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,4437,120,'Yagudo_Oracle',300,0,2736,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,4454,120,'Yagudos_Elemental',0,128,0,0,0,23,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,4444,120,'Yagudo_Priest',300,0,2750,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,4428,120,'Yagudo_Interrogator',300,0,2722,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4337,120,'Wight_war',300,1,2651,0,0,26,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2054,120,'Ignis_Fatuus',300,8,569,0,0,34,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3831,120,'Tabar_Beak',300,0,2370,0,0,34,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,1690,120,'Goblin_Mugger',300,0,1117,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1694,120,'Goblin_Pathfinder',300,0,1123,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1723,120,'Goblins_Beetle',0,128,0,0,0,23,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1683,120,'Goblin_Leecher',300,0,1098,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1665,120,'Goblin_Furrier',300,0,1064,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1666,120,'Goblin_Gambler',300,0,1081,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1715,120,'Goblin_Smithy',300,0,1162,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1710,120,'Goblin_Shaman',300,0,1148,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1160,120,'Earth_Elemental',300,4,733,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,3424,120,'Sabertooth_Tiger',300,0,2136,0,0,28,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,2966,120,'Old_Sabertooth',0,128,0,0,0,20,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,3485,120,'Sauromugue_Skink',300,0,2935,0,0,28,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,5873,120,'Thunderclaw_Thuban',5400,0,3079,4000,0,47,48,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (34,931,120,'Deadly_Dodo',0,32,578,0,0,39,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,3912,120,'Thunder_Elemental',300,4,2410,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1065,120,'Diving_Beetle',300,0,670,0,0,25,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1267,120,'Evil_Weapon',300,0,0,0,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,5730,120,'Blighting_Brand',0,32,2994,4900,4900,54,55,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (39,1266,120,'Evil_Spirit',300,1,264,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,6658,120,'Goblin_Digger',300,0,1040,0,0,28,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,3376,120,'Roc',0,128,2112,42000,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,741,120,'Climbpix_Highrise',0,128,478,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,3745,120,'Sprite',0,128,2001,0,0,61,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,328,120,'Balam-Agab',0,128,0,0,0,30,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,1119,120,'Dribblix_Greasemaw',0,128,0,0,0,30,36,0,NULL);
+
+-- Voidwalker
+INSERT INTO `mob_groups` VALUES (46,6999,120,'Yilbegan',86400,0,3185,90000,5000,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (47,7032,120,'Verthandi',7200,0,3183,25500,0,85,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (48,7031,120,'Urd',3600,0,3175,12900,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (49,7030,120,'Skuld',3600,0,3174,12900,0,82,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (50,7021,120,'Aither',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (51,7023,120,'Deorc',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (52,7025,120,'Eorthe',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (53,7028,120,'Puretos',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (54,7022,120,'Pruina',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (55,7024,120,'Beorht',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (56,7027,120,'Thunor',300,0,0,4400,0,80,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (57,7029,120,'Lacus',300,0,0,4400,0,80,80,0,'ABYSSEA');
+
+INSERT INTO `mob_groups` VALUES (58,5149,120,'Goji',0,128,0,0,0,92,94,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,6840,120,'Arke',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,0,120,'Wayward_Worm',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,0,120,'Tatenashi_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (62,0,120,'Hizamaru_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (63,0,120,'Ubuginu_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (64,0,120,'Hachiryu_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (65,0,120,'Omodaka_Armor',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (66,1642,120,'Goblin_Bounty_Hunter',300,0,1030,0,0,30,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (67,6570,120,'Wight_blm',300,1,2651,0,0,26,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (68,6583,120,'Bashe',0,32,3142,3300,0,54,55,0,'WOTG');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- The_Sanctuary_of_ZiTah (Zone 121)
@@ -9144,6 +12082,7 @@ INSERT INTO `mob_groups` VALUES (2,6765,121,'Clipper_fished',0,128,93,0,0,0,NULL
 INSERT INTO `mob_groups` VALUES (3,1268,121,'Bigclaw_fished',0,128,273,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,204,121,'Apsaras',0,128,147,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,1832,121,'Guardian_Treant',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,1080,121,'Doomed_Pilgrims',0,128,0,17000,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,1690,121,'Goblin_Mugger',300,0,1117,0,0,0,NULL);
@@ -9187,6 +12126,51 @@ INSERT INTO `mob_groups` VALUES (44,1978,121,'Hobgoblin_Ranger',0,128,0,0,0,0,NU
 INSERT INTO `mob_groups` VALUES (45,1971,121,'Hobgoblin_Beastmaster',0,128,0,0,0,0,NULL);
 -- 46 free
 INSERT INTO `mob_groups` VALUES (47,1811,121,'Greenman',0,128,0,9000,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,1832,121,'Guardian_Treant',0,128,0,0,0,33,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,1080,121,'Doomed_Pilgrims',0,128,0,17000,0,68,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1690,121,'Goblin_Mugger',300,0,1117,0,0,25,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1666,121,'Goblin_Gambler',300,0,1081,0,0,25,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,120,121,'Ancient_Bat',300,2,386,0,0,26,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1683,121,'Goblin_Leecher',300,0,1098,0,0,25,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1715,121,'Goblin_Smithy',300,0,1162,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1665,121,'Goblin_Furrier',300,0,1064,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,2953,121,'Ogrefly',300,0,571,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,2397,121,'Lesser_Gaylas',300,2,1511,0,0,39,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1203,121,'Elusive_Edwin',7200,0,759,3200,0,46,47,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (16,1758,121,'Goobbue_Gardener',300,0,1201,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3358,121,'Revenant',300,0,2092,0,0,45,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1760,121,'Goobbue_Parasite',300,0,17,0,0,42,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3379,121,'Rock_Golem',300,0,565,0,0,49,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,4572,121,'Huwasi',7200,0,3014,6500,0,64,65,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (21,3232,121,'Puroboros',300,8,569,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,2203,121,'Keeper_of_Halidom',0,32,1428,6300,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,6669,121,'Goblin_Robber',300,0,1146,0,0,42,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,4309,121,'Water_Elemental',300,4,2629,0,0,48,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1741,121,'Goblin_Trader',300,0,1181,0,0,42,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,6397,121,'Goblins_Leech',0,128,0,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,3912,121,'Thunder_Elemental',300,4,2410,0,0,48,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,2585,121,'Master_Coeurl',300,0,1639,0,0,44,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1926,121,'Hell_Hound',300,1,226,0,0,46,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1701,121,'Goblin_Poacher',300,0,1140,0,0,42,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1705,121,'Goblin_Reaper',300,0,1142,0,0,42,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,3398,121,'Rot_Prowler',300,1,2122,0,0,49,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,2442,121,'Lost_Soul_blm',300,1,677,0,0,51,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,6841,121,'Bastet',7200,0,3293,6000,6000,62,62,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (35,2796,121,'Myxomycete',300,0,1770,0,0,41,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,2898,121,'Noble_Mold',0,128,1821,4674,4600,49,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,2108,121,'Isonade',0,128,0,6100,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1983,121,'Hobgoblin_Warrior',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1984,121,'Hobgoblin_White_Mage',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,1972,121,'Hobgoblin_Black_Mage',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,1979,121,'Hobgoblin_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,1980,121,'Hobgoblin_Thief',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1974,121,'Hobgoblin_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,1978,121,'Hobgoblin_Ranger',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,1971,121,'Hobgoblin_Beastmaster',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,6397,121,'Goblins_Leech',0,128,0,0,0,40,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,1811,121,'Greenman',0,128,0,9000,0,80,81,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (48,1654,121,'Goblin_Enchanter',0,128,3226,0,0,0,NULL);
@@ -9195,6 +12179,7 @@ INSERT INTO `mob_groups` VALUES (50,1641,121,'Goblin_Bouncer',0,128,3226,0,0,0,N
 INSERT INTO `mob_groups` VALUES (51,1705,121,'Goblin_Reaper_G',0,128,3226,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (52,1651,121,'Goblin_Doyen',0,128,3226,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (53,3411,121,'Ruebezahl',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (54,6842,121,'Skeleton_Scuffler',0,128,0,0,0,0,'ASA');
 INSERT INTO `mob_groups` VALUES (55,4728,121,'Blest_Bones',0,128,0,0,0,0,'ASA');
@@ -9202,11 +12187,21 @@ INSERT INTO `mob_groups` VALUES (56,4730,121,'Holey_Horror',0,128,0,0,0,0,'ASA')
 INSERT INTO `mob_groups` VALUES (57,4732,121,'Cath_Palug',0,128,0,0,9999,0,NULL);
 INSERT INTO `mob_groups` VALUES (58,4731,121,'Grwnan',0,128,0,0,9999,0,NULL);
 INSERT INTO `mob_groups` VALUES (59,4854,121,'Keeper_of_Heiligtum',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (53,3411,121,'Ruebezahl',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,6842,121,'Skeleton_Scuffler',0,128,0,0,0,58,58,0,'ASA');
+INSERT INTO `mob_groups` VALUES (55,4728,121,'Blest_Bones',0,128,0,0,0,59,59,0,'ASA');
+INSERT INTO `mob_groups` VALUES (56,4730,121,'Holey_Horror',0,128,0,0,0,60,60,0,'ASA');
+INSERT INTO `mob_groups` VALUES (57,4732,121,'Cath_Palug',0,128,0,0,9999,94,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,4731,121,'Grwnan',0,128,0,0,9999,90,91,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,4854,121,'Keeper_of_Heiligtum',0,128,0,0,0,0,0,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- RoMaeve (Zone 122)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,2717,122,'Mokkurkalfi',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,2231,122,'Killing_Weapon',300,0,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,2974,122,'Ominous_Weapon',300,0,0,0,0,0,NULL);
@@ -9234,6 +12229,35 @@ INSERT INTO `mob_groups` VALUES (24,4722,122,'Lode_Golem',0,128,0,0,0,0,'ASA');
 INSERT INTO `mob_groups` VALUES (25,4723,122,'Fired_Urn',0,128,0,0,0,0,'ASA');
 INSERT INTO `mob_groups` VALUES (26,6843,122,'Douma_Weapon',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (27,6844,122,'Katashiro_Weapon',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,2717,122,'Mokkurkalfi',0,128,0,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,2231,122,'Killing_Weapon',300,0,0,0,0,60,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,2974,122,'Ominous_Weapon',300,0,0,0,0,61,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,867,122,'Cursed_Puppet',300,0,547,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,623,122,'Cannonball',300,8,216,0,0,66,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,4309,122,'Water_Elemental',300,4,2629,0,0,67,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,2476,122,'Magic_Flagon',300,0,1565,0,0,64,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3912,122,'Thunder_Elemental',300,4,2410,0,0,67,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2873,122,'Nightmare_Vase',0,32,1806,8400,0,70,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,199,122,'Apocalyptic_Weapon',300,0,0,0,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,2077,122,'Infernal_Weapon',300,0,0,9600,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,5426,122,'Martinet',7200,0,2946,0,0,72,74,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (13,2793,122,'Mythril_Golem',300,0,565,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,906,122,'Darksteel_Golem',300,0,565,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3420,122,'Rogue_Receptacle',0,32,3086,7000,0,67,68,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (16,5842,122,'Nargun',7200,0,3321,11000,0,77,79,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (17,1194,122,'Eldhrimnir',0,128,0,8000,8000,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,3603,122,'Shikigami_Weapon',76500,0,2237,14000,0,77,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2117,122,'Jackpot',0,128,0,0,0,1,1,0,NULL); -- TODO: capture level from retail
+INSERT INTO `mob_groups` VALUES (20,4727,122,'Mimic_King',0,128,0,0,9999,93,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,4726,122,'Mimic_Jester',0,128,0,0,9999,90,91,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,4725,122,'Mimic_Mage',0,128,0,0,9999,90,91,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,4724,122,'Steely_Weapon',0,128,0,0,0,68,68,0,'ASA');
+INSERT INTO `mob_groups` VALUES (24,4722,122,'Lode_Golem',0,128,0,0,0,70,70,0,'ASA');
+INSERT INTO `mob_groups` VALUES (25,4723,122,'Fired_Urn',0,128,0,0,0,69,69,0,'ASA');
+INSERT INTO `mob_groups` VALUES (26,6843,122,'Douma_Weapon',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,6844,122,'Katashiro_Weapon',0,128,0,0,0,0,0,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Yuhtunga_Jungle (Zone 123)
@@ -9244,6 +12268,7 @@ INSERT INTO `mob_groups` VALUES (1,5865,123,'Ironshell_fished',0,128,93,0,0,0,NU
 INSERT INTO `mob_groups` VALUES (2,1268,123,'Bigclaw_fished',0,128,2930,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,7313,123,'Bloodsucker_fished',0,128,174,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (4,3925,123,'Tipha',0,128,0,5500,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,657,123,'Carthi',0,128,0,5500,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,4482,123,'Yuhtunga_Mandragora',300,0,2793,0,0,0,NULL);
@@ -9287,6 +12312,51 @@ INSERT INTO `mob_groups` VALUES (43,972,123,'Demishagin_White_Mage',0,128,0,0,0,
 INSERT INTO `mob_groups` VALUES (44,969,123,'Demisahagin_Bard',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (45,970,123,'Demisahagin_Dragoon',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (46,3442,123,'Sahagins_Wyvern',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (4,3925,123,'Tipha',0,128,0,5500,0,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,657,123,'Carthi',0,128,0,5500,0,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,4482,123,'Yuhtunga_Mandragora',300,0,2793,0,0,29,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1715,123,'Goblin_Smithy',300,0,1162,0,0,32,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,2110,123,'Ivory_Lizard',300,0,1382,0,0,32,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,5736,123,'Koropokkur',3600,0,2999,2500,0,36,38,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (10,6307,123,'Death_Jacket',300,0,584,0,0,33,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,4476,123,'Young_Opo-opo',300,0,2783,0,0,34,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,7034,123,'Soldier_Crawler',300,0,2022,0,0,37,41,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1709,123,'Goblin_Robber',300,0,1145,0,0,42,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1701,123,'Goblin_Poacher',300,0,1138,0,0,42,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,2379,123,'Lava_Bomb',300,8,569,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3073,123,'Overgrown_Rose',300,0,2922,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1665,123,'Goblin_Furrier',300,0,1064,0,0,32,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1341,123,'Fire_Elemental',300,4,831,0,0,48,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2677,123,'Mischievous_Micholas',0,32,1699,5400,0,53,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,4309,123,'Water_Elemental',300,4,2629,0,0,48,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,833,123,'Creek_Sahagin',300,0,532,0,0,34,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,3373,123,'River_Sahagin',300,0,2105,0,0,34,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,3788,123,'Stream_Sahagin',300,0,2344,0,0,34,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,2647,123,'Meww_the_Turtlerider',0,128,1666,4500,10000,47,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,6845,123,'Pyuu_the_Spatemaker',0,128,3258,8700,10000,73,73,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (26,2491,123,'Makara',300,0,279,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,3393,123,'Rose_Garden',0,128,2123,5000,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,4252,123,'Voluptuous_Vilma',0,128,2589,5300,0,52,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,2168,123,'Jungle_Coeurl',300,0,1420,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,6846,123,'Bayawak',0,128,1349,7500,0,67,70,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (31,1705,123,'Goblin_Reaper',300,0,1142,0,0,42,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,6659,123,'Goblin_Digger',300,0,1040,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1983,123,'Hobgoblin_Warrior',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1984,123,'Hobgoblin_White_Mage',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1972,123,'Hobgoblin_Black_Mage',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1979,123,'Hobgoblin_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1980,123,'Hobgoblin_Thief',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1974,123,'Hobgoblin_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1978,123,'Hobgoblin_Ranger',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,1971,123,'Hobgoblin_Beastmaster',0,128,0,0,0,40,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,6303,123,'Goblins_Bee',0,128,0,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,971,123,'Demisahagin_Monk',0,128,0,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,972,123,'Demishagin_White_Mage',0,128,0,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,969,123,'Demisahagin_Bard',0,128,0,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,970,123,'Demisahagin_Dragoon',0,128,0,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,3442,123,'Sahagins_Wyvern',0,128,0,0,0,38,40,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (47,541,123,'Brook_Sahagin',0,128,3226,0,0,0,NULL);
@@ -9316,6 +12386,7 @@ INSERT INTO `mob_groups` VALUES (2,6765,124,'Clipper_fished',0,128,552,0,0,0,NUL
 INSERT INTO `mob_groups` VALUES (3,4220,124,'Vepar',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,6779,124,'Makara_fished',0,128,147,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,4470,124,'Yhoator_Mandragora',300,0,2781,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,4334,124,'White_Lizard',300,0,2649,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,1715,124,'Goblin_Smithy',300,0,1162,0,0,0,NULL);
@@ -9370,6 +12441,62 @@ INSERT INTO `mob_groups` VALUES (55,2900,124,'Noctonberry_Ninja',0,128,0,0,0,0,N
 INSERT INTO `mob_groups` VALUES (56,2901,124,'Noctonberry_Summoner',0,128,0,0,0,0,NULL);
 -- 57 free
 INSERT INTO `mob_groups` VALUES (58,3970,124,'Tonberrys_Avatar',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,4470,124,'Yhoator_Mandragora',300,0,2781,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,4334,124,'White_Lizard',300,0,2649,0,0,36,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1715,124,'Goblin_Smithy',300,0,1162,0,0,35,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1694,124,'Goblin_Pathfinder',300,0,1123,0,0,35,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,6303,124,'Goblins_Bee',0,128,0,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,4471,124,'Yhoator_Wasp',300,0,584,0,0,37,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1710,124,'Goblin_Shaman',300,0,1148,0,0,35,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,136,124,'Anemone',300,0,91,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1641,124,'Goblin_Bouncer',300,0,1027,0,0,51,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1677,124,'Goblin_Hunter',300,0,1092,0,0,51,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,4375,124,'Worker_Crawler',300,0,2022,0,0,43,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1709,124,'Goblin_Robber',300,0,1145,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1741,124,'Goblin_Trader',300,0,1179,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6303,124,'Goblins_Bee',0,128,0,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2585,124,'Master_Coeurl',300,0,1639,0,0,47,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,4361,124,'Woodland_Sage',0,128,2666,7000,0,60,61,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,5123,124,'Big_Jaw',300,0,279,0,0,43,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,4309,124,'Water_Elemental',300,4,2629,0,0,53,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1705,124,'Goblin_Reaper',300,0,1142,0,0,41,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,4476,124,'Young_Opo-opo',300,0,2784,0,0,40,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,5856,124,'Powderer_Penny',0,128,3068,3500,0,49,49,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (26,1701,124,'Goblin_Poacher',300,0,1138,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,5858,124,'Acolnahuacatl',7200,0,3070,7700,0,67,68,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (28,3951,124,'Tonberry_Creeper',300,0,2431,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,3958,124,'Tonberry_Hexer',300,0,2437,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1341,124,'Fire_Elemental',300,4,831,0,0,53,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,3966,124,'Tonberry_Shadower',300,0,2445,0,0,61,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,5857,124,'Hoar-knuckled_Rimberry',0,32,3069,7250,0,73,73,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (33,3960,124,'Tonberry_Jinxer',300,0,2438,0,0,61,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,3950,124,'Tonberry_Chopper',300,0,2430,0,0,61,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,3956,124,'Tonberry_Harasser',300,0,2435,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,3971,124,'Tonberrys_Elemental',0,128,0,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,423,124,'Bisque-heeled_Sunberry',0,128,280,6000,0,58,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,3232,124,'Puroboros',300,8,569,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,532,124,'Bright-handed_Kunberry',0,128,358,5400,0,55,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,6659,124,'Goblin_Digger',300,0,1042,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,2186,124,'Kappa_Akuso',0,128,0,5800,0,63,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,2188,124,'Kappa_Bonze',0,128,0,4600,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,2187,124,'Kappa_Biwa',0,128,0,4600,0,61,61,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,1983,124,'Hobgoblin_Warrior',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,1984,124,'Hobgoblin_White_Mage',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1972,124,'Hobgoblin_Black_Mage',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,1979,124,'Hobgoblin_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,1980,124,'Hobgoblin_Thief',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,1974,124,'Hobgoblin_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,1978,124,'Hobgoblin_Ranger',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,1971,124,'Hobgoblin_Beastmaster',0,128,0,0,0,50,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,6303,124,'Goblins_Bee',0,128,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,2899,124,'Noctonberry_Black_Mage',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,2902,124,'Noctonberry_Thief',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,2900,124,'Noctonberry_Ninja',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,2901,124,'Noctonberry_Summoner',0,128,0,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,3971,124,'Tonberrys_Elemental',0,128,0,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,3970,124,'Tonberrys_Avatar',0,128,0,0,0,45,45,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (59,3951,124,'Tonberry_Creeper_G',0,128,3226,0,0,0,NULL);
@@ -9393,6 +12520,7 @@ INSERT INTO `mob_groups` VALUES (2,204,125,'Apsaras',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1268,125,'Bigclaw_fished',0,128,2930,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,6776,125,'Razorjaw_Pugil_fished',0,128,147,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,1009,125,'Desert_Spider',300,0,635,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,1006,125,'Desert_Dhalmel',300,0,632,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,1010,125,'Desert_Worm',300,2,438,0,0,0,NULL);
@@ -9430,6 +12558,45 @@ INSERT INTO `mob_groups` VALUES (38,6850,125,'Picolaton',0,32,3225,6900,0,0,'WOT
 INSERT INTO `mob_groups` VALUES (39,6851,125,'Sabotender_Campeador',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (40,6852,125,'Sabotender_Mercenario',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (41,6853,125,'King_Uropygid',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,1009,125,'Desert_Spider',300,0,635,0,0,40,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,1006,125,'Desert_Dhalmel',300,0,632,0,0,44,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1010,125,'Desert_Worm',300,2,438,0,0,43,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,172,125,'Antican_Essedarius',300,0,121,0,0,41,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1160,125,'Earth_Elemental',300,4,733,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,596,125,'Cactuar',300,0,396,0,0,48,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,4048,125,'Tulwar_Scorpion',300,0,2492,0,0,53,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1004,125,'Desert_Beetle',300,0,670,0,0,47,51,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,185,125,'Antican_Retiarius',300,0,134,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,187,125,'Antican_Secutor',300,0,117,0,0,54,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,177,125,'Antican_Lanista',300,0,126,0,0,54,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1007,125,'Desert_Manticore',300,0,633,0,0,53,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,176,125,'Antican_Hoplomachus',300,0,125,0,0,54,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1341,125,'Fire_Elemental',300,4,831,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3133,125,'Phorusrhacos',300,0,1991,0,0,57,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,171,125,'Antican_Eques',300,0,119,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,670,125,'Celphie',0,32,441,2000,0,47,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1287,125,'Fallen_Knight',300,1,810,0,0,50,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,5862,125,'Calchas',0,32,3074,9000,0,74,75,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (24,597,125,'Cactuar_Cantautor',0,32,398,6000,0,55,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,2407,125,'Lich',300,1,678,0,0,49,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,2262,125,'King_Vinegarroon',0,128,1451,25000,0,80,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1745,125,'Goblin_Welldigger',300,0,1188,0,0,51,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1641,125,'Goblin_Bouncer',300,0,1027,0,0,51,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1654,125,'Goblin_Enchanter',300,0,1047,0,0,51,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1677,125,'Goblin_Hunter',300,0,1092,0,0,51,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,6658,125,'Goblin_Digger',300,0,1042,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,3430,125,'Sabotender_Enamorado',0,128,0,15000,0,62,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1165,125,'Eastern_Sphinx',0,128,0,6400,0,62,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,4324,125,'Western_Sphinx',0,128,0,6400,0,62,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,2487,125,'Maharaja',0,128,0,9000,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,2731,125,'Monarca_de_Altepa',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,6849,125,'Dahu',0,128,3322,5800,0,57,57,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (38,6850,125,'Picolaton',0,32,3225,6900,0,61,64,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (39,6851,125,'Sabotender_Campeador',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,6852,125,'Sabotender_Mercenario',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,6853,125,'King_Uropygid',0,128,0,0,0,0,0,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Qufim_Island (Zone 126)
@@ -9442,6 +12609,7 @@ INSERT INTO `mob_groups` VALUES (3,3518,126,'Sea_Bishop',0,128,2183,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,4220,126,'Vepar',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,6030,126,'Kraken_fished_NM',0,128,1465,1580,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,3537,126,'Seeker_Bats',300,0,82,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,900,126,'Dancing_Weapon',300,0,563,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,2374,126,'Land_Worm',300,0,428,0,0,0,NULL);
@@ -9480,6 +12648,46 @@ INSERT INTO `mob_groups` VALUES (40,1533,126,'Giant_Monk',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (41,1523,126,'Giant_Beastmaster',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (42,1529,126,'Giant_High_Ranger',0,128,0,0,0,0,NULL);
 -- 43 free
+=======
+INSERT INTO `mob_groups` VALUES (6,3537,126,'Seeker_Bats',300,0,82,0,0,25,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,900,126,'Dancing_Weapon',300,0,563,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,2374,126,'Land_Worm',300,0,428,0,0,25,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,743,126,'Clipper',300,0,93,0,0,25,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,909,126,'Dark_Bats',300,2,82,0,0,25,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1625,126,'Glow_Bat',300,2,461,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1536,126,'Giant_Ranger',300,0,971,0,0,28,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1521,126,'Giant_Ascetic',300,0,964,0,0,28,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1540,126,'Giant_Trapper',300,0,964,0,0,28,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1591,126,'Gigass_Leech',0,128,0,0,0,21,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1530,126,'Giant_Hunter',300,0,968,0,0,28,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,4337,126,'Wight_war',300,1,2652,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6570,126,'Wight_blm',300,1,2652,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2413,126,'Light_Elemental',300,4,1521,0,0,35,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1807,126,'Greater_Pugil',300,0,248,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,338,126,'Banshee',300,1,222,0,0,31,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,3912,126,'Thunder_Elemental',300,4,2410,0,0,35,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,5848,126,'Slippery_Sucker',0,32,3059,3500,0,42,42,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (24,40,126,'Acrophies',300,0,18,0,0,32,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,6854,126,'Atkorkamuy',1800,0,3295,0,0,73,73,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (26,2286,126,'Kraken',1800,0,504,0,0,37,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,4004,126,'Trickster_Kinetix',0,32,2471,0,0,35,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,6024,126,'Qoofim',3600,0,3096,4000,0,47,48,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (29,120,126,'Ancient_Bat',300,2,461,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1983,126,'Hobgoblin_Warrior',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1984,126,'Hobgoblin_White_Mage',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1972,126,'Hobgoblin_Black_Mage',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1979,126,'Hobgoblin_Red_Mage',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1980,126,'Hobgoblin_Thief',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1974,126,'Hobgoblin_Dark_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1978,126,'Hobgoblin_Ranger',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1971,126,'Hobgoblin_Beastmaster',0,128,0,0,0,30,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1728,126,'Goblins_Leech',0,128,0,0,0,30,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,1541,126,'Giant_Warrior',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,1533,126,'Giant_Monk',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,1523,126,'Giant_Beastmaster',0,128,0,0,0,35,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,1529,126,'Giant_High_Ranger',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1591,126,'Gigass_Leech',0,128,0,0,0,30,30,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- garrison
 INSERT INTO `mob_groups` VALUES (44,1536,126,'Giant_Ranger_G',0,128,3226,0,0,0,NULL);
@@ -10327,6 +13535,7 @@ INSERT INTO `mob_groups` VALUES (145,7296,137,'Savage_Ruszor',300,0,2135,0,0,0,N
 -- Castle_Zvahl_Baileys_[S] (Zone 138)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,2041,138,'Icefall',960,0,1346,4700,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,996,138,'Demon_Warrior',960,0,611,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,913,138,'Dark_Elemental',960,4,568,0,0,0,NULL);
@@ -10490,6 +13699,171 @@ INSERT INTO `mob_groups` VALUES (160,7191,138,'Demon_Corrupter',960,0,611,0,0,0,
 INSERT INTO `mob_groups` VALUES (161,7192,138,'Demon_Entomber',960,0,611,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (162,7193,138,'Demon_Condemner',960,0,611,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (163,7194,138,'Demon_Suppressor',960,0,611,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,2041,138,'Icefall',960,0,1346,4700,0,79,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,996,138,'Demon_Warrior',960,0,611,0,0,80,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,913,138,'Dark_Elemental',0,4,568,0,0,79,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,2043,138,'Ice_Elemental',0,4,1347,0,0,79,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,990,138,'Demon_Magus',960,0,611,0,999,80,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,987,138,'Demon_Justiciar',960,0,611,0,999,80,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,994,138,'Demons_Elemental',0,128,0,0,999,75,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,983,138,'Demon_Befouler',960,0,611,0,999,80,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,5234,138,'Errand_Imp',960,0,1002,0,5000,79,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1045,138,'Dire_Gargouille',960,0,664,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,6275,138,'Orcish_Bowshooter',960,0,0,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,6293,138,'Orcish_Augur',960,0,1871,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,6290,138,'Orcish_Champion',960,0,1062,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,6292,138,'Orcish_Protector',960,0,1062,0,0,76,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,6294,138,'Orcish_Dragonbrander',960,0,1062,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,6285,138,'Orcish_Veteran',960,0,1922,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,6295,138,'Orcish_Warlord',960,0,1062,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,5553,138,'Adaman_Quadav',960,0,22,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,6251,138,'Gold_Quadav',960,0,22,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,6255,138,'Magnes_Quadav',960,0,1574,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,6256,138,'Star_Ruby_Quadav',960,0,934,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,4430,138,'Yagudo_Knight_Templar',960,0,2725,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,4417,138,'Yagudo_Eradicator',960,0,2725,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,5493,138,'Yagudo_Chanter',960,0,2703,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,4442,138,'Yagudo_Prelate',960,0,2747,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,6246,138,'Iron_Quadav',960,0,22,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,6253,138,'Vajra_Quadav',960,0,0,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,5481,138,'Yagudo_Sentinel',960,0,2764,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,6233,138,'Ancient_Quadav',960,0,22,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,5478,138,'Yagudo_High_Priest',960,0,2713,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,2950,138,'Ogler',960,0,579,0,9999,81,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,5235,138,'Shadowguard_Demon',0,128,0,14500,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,6609,138,'Deathwreaker_Demon',960,0,258,0,0,85,87,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,5221,138,'Demon_Corrupter',960,0,611,0,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,5222,138,'Demon_Entomber',960,0,611,0,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,5223,138,'Demon_Condemner',960,0,611,0,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,5225,138,'Soulsearer_Demon',960,0,3328,0,0,85,88,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (38,5224,138,'Demon_Suppressor',960,0,611,0,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,6610,138,'Woebringer_Demon',960,0,258,0,0,85,88,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (40,6611,138,'Foredoomer_Demon',960,0,258,0,0,85,88,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (41,6607,138,'Doom_Lens',960,0,579,0,9000,84,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,994,138,'Demons_Elemental',0,128,0,0,999,80,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,6712,138,'Zvahl_Fortalice',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,260,138,'Ashmea_B_Greinner',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,3495,138,'Scarlet_Boar_Esquire',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1321,138,'Feldrautte_I_Rouhent',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,2909,138,'Norvallen_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,4481,138,'Yrvaulair_S_Cousseraux',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,3405,138,'Royal_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,2445,138,'Ludwig',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,7,138,'2nd_Legionnaire',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,1198,138,'Elivira',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,1,138,'1st_Gold_Musketeer',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,2300,138,'Kurt',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,13,138,'8th_Iron_Musketeer',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,4515,138,'Zolku-Azolku',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,2406,138,'Libran_Caster',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,2405,138,'Lhu_Mhakaracca',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,3239,138,'Pya',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,2306,138,'Kyo',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,3243,138,'Python_Mercenary',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (62,1875,138,'Haja_Zhwan',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (63,4339,138,'Wildcat_Volunteer',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (64,1752,138,'Gold_Badger_Esquire',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (65,11,138,'4th_Legionnaire',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (66,3139,138,'Piscean_Caster',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (67,91,138,'Allied_Mantelet',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (68,2799,138,'Nail_Bomb',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (69,90,138,'Allied_Belfry',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (70,3511,138,'Scylla_Brigade_Officer',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (71,89,138,'Allied_Armored_Belfry',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (72,3509,138,'Scylla_Brigade_Elite',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (73,3510,138,'Scylla_Brigade_Healer',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (74,935,138,'Deathlord_Rojgnoj',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (75,3730,138,'Spinebeak_Neckchopper',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (76,2127,138,'Jagidbods_Warmachine',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (77,6677,138,'Jagidbod_of_Clan_Reaper',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (78,737,138,'Clan_Reaper_Grunt',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (79,96,138,'Alpha_Gnole_Anders',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (80,132,138,'Anderss_Guard',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (81,2734,138,'Moonfang_Warrior',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (82,6681,138,'DeVyu_Headhunter',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (83,381,138,'Beadeaux_Vanguard',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (84,6680,138,'BiGho_Headtaker',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (85,3293,138,'Qulun_Heavyshell',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (86,1779,138,'GoBhu_Herohunter',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (87,1780,138,'GoBhus_Elite_Raider',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (88,2776,138,'Muu_Buxu_the_Elusive',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (89,1056,138,'Divine_Assassin',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (90,953,138,'Dee_Xalmo_the_Grim',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (91,1055,138,'Divine_Ascetic',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (92,2198,138,'Kazan_the_Peerless',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (93,3158,138,'Plenilune_Ronin',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (94,3569,138,'Shadowhorn',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (95,3570,138,'Shadowhorn_Stormer',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (96,3565,138,'Shadowhand',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (97,3566,138,'Shadowhand_Cuirassier',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (98,3563,138,'Shadowfang',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (99,3564,138,'Shadowfang_Void',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (100,6608,138,'Shadoweye',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (101,3562,138,'Shadoweye_Gnat',0,128,0,0,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (102,0,138,'Shadowclaw',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (103,0,138,'Shadowclaw_Devastator',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (104,3568,138,'Shadowhind_Machinator',0,128,0,0,0,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (105,776,138,'Confederate_Mantelet',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (106,2100,138,'Iron_Bomb',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (107,775,138,'Confederate_Belfry',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (108,93,138,'Allotaur',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (109,3621,138,'Siege_Turret',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (110,3644,138,'Skeleton_Escort',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (111,1333,138,'Fiendish_Leechkeeper',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (112,6880,138,'Fortification',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (113,3366,138,'Rikoh_Wahcondalo',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (114,2179,138,'Kagetora',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (115,896,138,'Dalzakk',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (116,2949,138,'Oggbi',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (117,3312,138,'Rainemard',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (118,6823,138,'Maat',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (119,960,138,'Degenhard',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (120,311,138,'Azima',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (121,725,138,'Choh_Moui',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (122,6312,138,'Chigoe',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (123,312,138,'Azo',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (124,4118,138,'Vahi',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (125,3391,138,'Rongo-Nango',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (126,2391,138,'Lerren',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (127,2137,138,'Jajaro',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (128,3176,138,'Popochu',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (129,3096,138,'Papako',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (130,2730,138,'Momowa',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (131,4081,138,'Ulla',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (132,2226,138,'Kilhwch',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (133,84,138,'Alfons',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (134,37,138,'Achtelle',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (135,526,138,'Bravo',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (136,1141,138,'Duskraven',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (137,1143,138,'Dusk_Raider',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (138,227,138,'Areuhat',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (139,2946,138,'Odzmanouk',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (140,502,138,'Boodlix',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (141,1681,138,'Goblin_Lansquenet',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (142,3926,138,'Titania',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (143,1279,138,'Faerie',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (144,320,138,'Babban_Ny_Mheillea',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (145,18,138,'Abenzio',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (146,549,138,'Bryher',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (147,616,138,'Camlin',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (148,903,138,'Darach',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (149,3310,138,'Raigegue_R_dOraguille',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (150,126,138,'Ancient_Royal_Knight',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (151,1262,138,'Eurytos',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (152,1574,138,'Gigas_Mercenary',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (153,3184,138,'Poroggo_Prince',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (154,3186,138,'Poroggo_Servant',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (155,2180,138,'Kaiser_Behemoth',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (156,1324,138,'Ferreous_Coffin',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (157,2403,138,'Lewenhart',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (158,291,138,'Auroral_Alicorn',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (159,7185,138,'Eurytos',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (160,7191,138,'Demon_Corrupter',960,0,611,0,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (161,7192,138,'Demon_Entomber',960,0,611,0,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (162,7193,138,'Demon_Condemner',960,0,611,0,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (163,7194,138,'Demon_Suppressor',960,0,611,0,0,82,83,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Horlais_Peak (Zone 139)
@@ -10606,6 +13980,7 @@ INSERT INTO `mob_groups` VALUES (2,6766,141,'Giant_Pugil_fished',0,128,147,0,0,0
 INSERT INTO `mob_groups` VALUES (3,3220,141,'Puffer_Pugil',0,128,975,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,6764,141,'Land_Pugil_fished',0,128,975,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,3013,141,'Orcish_Fodder',480,0,1905,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,3022,141,'Orcish_Mesmerizer',480,0,1925,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,3016,141,'Orcish_Grappler',480,0,1914,0,0,0,NULL);
@@ -10624,6 +13999,26 @@ INSERT INTO `mob_groups` VALUES (19,697,141,'Chariotbuster_Byakzak',0,128,455,13
 INSERT INTO `mob_groups` VALUES (20,5845,141,'Kegpaunch_Doshgnosh',3600,0,3028,800,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (21,3004,141,'Orcish_Cursemaker',600,0,1887,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (22,3032,141,'Orcish_Serjeant',600,0,1936,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,3013,141,'Orcish_Fodder',480,0,1905,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3022,141,'Orcish_Mesmerizer',480,0,1925,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,3016,141,'Orcish_Grappler',480,0,1914,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3721,141,'Spectacled_Bats',480,2,82,0,0,6,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,6454,141,'Cheiroptera',480,2,461,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,3012,141,'Orcish_Flamethrower',480,0,0,0,0,16,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,2009,141,'Hundredscar_Hajwaj',0,32,1338,0,0,11,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3017,141,'Orcish_Grunt',480,0,1918,0,0,11,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,3033,141,'Orcish_Stonechucker',480,0,1940,0,0,11,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3023,141,'Orcish_Neckchopper',480,0,1918,0,0,11,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3009,141,'Orcish_Fighter',480,0,1898,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3545,141,'Sentry_Lizard',480,0,2199,0,0,11,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3028,141,'Orcish_Panzer',3600,0,0,760,0,20,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,3009,141,'Orcish_Fighter',0,128,1898,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,697,141,'Chariotbuster_Byakzak',0,128,455,1350,0,23,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,5845,141,'Kegpaunch_Doshgnosh',3600,0,3028,800,0,22,22,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (21,3004,141,'Orcish_Cursemaker',600,0,1887,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,3032,141,'Orcish_Serjeant',600,0,1936,0,0,21,23,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Yughott_Grotto (Zone 142)
@@ -10650,6 +14045,7 @@ INSERT INTO `mob_groups` VALUES (2,794,143,'Coral_Crab',0,128,481,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,3753,143,'Stag_Crab',0,128,93,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,3682,143,'Snipper_fished',0,128,0,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,4477,143,'Young_Quadav',480,0,2790,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,107,143,'Amethyst_Quadav',480,0,69,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,103,143,'Amber_Quadav',480,0,59,0,0,0,NULL);
@@ -10672,6 +14068,30 @@ INSERT INTO `mob_groups` VALUES (23,525,143,'Brass_Quadav',600,0,352,0,0,0,NULL)
 INSERT INTO `mob_groups` VALUES (24,2916,143,'NoMho_Crimsonarmor',86400,0,2839,880,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (25,2897,143,'NiGhu_Nestfender',0,128,2825,5500,3000,0,NULL);
 INSERT INTO `mob_groups` VALUES (26,6725,143,'Incensed_Pineapple',0,128,0,0,0,0,NULL); -- TODO: capture level from retail
+=======
+INSERT INTO `mob_groups` VALUES (5,4477,143,'Young_Quadav',480,0,2790,0,0,3,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,107,143,'Amethyst_Quadav',480,0,69,0,0,3,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,103,143,'Amber_Quadav',480,0,59,0,0,3,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3143,143,'Pit_Hare',480,0,309,0,0,2,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,663,143,'Cave_Funguar',480,0,435,0,0,9,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,5420,143,'QuVho_Deathhurler',3600,0,2940,480,0,17,17,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (11,4226,143,'Veteran_Quadav',480,0,2581,0,0,11,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1808,143,'Greater_Quadav',480,0,1236,0,0,11,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,2986,143,'Onyx_Quadav',480,0,1865,0,0,11,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,790,143,'Copper_Beetle',480,0,510,0,0,9,12,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,2674,143,'Mine_Scorpion',480,0,1698,0,0,14,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,590,143,'BuGhi_Howlblade',0,32,2837,0,0,12,12,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,4511,143,'ZiGhi_Boneeater',0,32,2838,625,0,15,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,3300,143,'Rabid_Rat',480,0,309,0,0,11,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3500,143,'Scimitar_Scorpion',480,0,2181,0,0,19,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2965,143,'Old_Quadav',600,0,1849,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,791,143,'Copper_Quadav',600,0,514,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,5774,143,'BeHya_Hundredwall',0,32,3058,775,0,30,30,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (23,525,143,'Brass_Quadav',600,0,352,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,2916,143,'NoMho_Crimsonarmor',86400,0,2839,880,0,22,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,2897,143,'NiGhu_Nestfender',0,128,2825,0,0,58,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,6725,143,'Incensed_Pineapple',0,128,0,0,0,0,0,0,NULL); -- TODO: capture level from retail
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- Cornelia's Call to Action
 INSERT INTO `mob_groups` VALUES (27,0,143,'Mind-warped_Scorpion',0,128,0,0,0,0,NULL); -- TODO: capture level from retail
@@ -10760,6 +14180,7 @@ INSERT INTO `mob_groups` VALUES (2,6769,145,'Pug_Pugil_fished',0,128,463,0,0,0,N
 INSERT INTO `mob_groups` VALUES (3,3220,145,'Puffer_Pugil',0,128,975,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,6764,145,'Land_Pugil_fished',0,128,975,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,1277,145,'Eyy_Mon_the_Ironbreaker',300,0,803,310,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,4502,145,'Zhuu_Buxu_the_Silent',300,0,2854,300,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,4426,145,'Yagudo_Initiate',480,0,2718,0,0,0,NULL);
@@ -10783,6 +14204,31 @@ INSERT INTO `mob_groups` VALUES (24,4456,145,'Yagudo_Theologist',600,0,2772,0,0,
 INSERT INTO `mob_groups` VALUES (25,4444,145,'Yagudo_Priest',600,0,2751,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (26,4267,145,'Vuu_Puqu_the_Beguiler',0,32,2596,960,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (27,4113,145,'Vaa_Huja_the_Erudite',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,1277,145,'Eyy_Mon_the_Ironbreaker',900,0,803,310,0,16,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,4502,145,'Zhuu_Buxu_the_Silent',300,0,2854,300,0,16,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,4426,145,'Yagudo_Initiate',300,0,2718,0,0,3,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,4405,145,'Yagudo_Acolyte',300,0,2693,0,0,3,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,4448,145,'Yagudo_Scribe',300,0,2763,0,0,3,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1543,145,'Giddeus_Bee',300,0,584,0,0,2,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1544,145,'Giddeus_Pugil',300,0,975,0,0,2,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1047,145,'Dirt_Eater',300,0,428,0,0,3,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,4432,145,'Yagudo_Mendicant',300,0,2733,0,0,11,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,4454,145,'Yagudos_Elemental',0,128,0,0,0,4,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,4441,145,'Yagudo_Piper',300,0,2745,0,0,11,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,4439,145,'Yagudo_Persecutor',300,0,2741,0,0,11,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,6071,145,'Digger_Wasp',300,0,584,0,0,11,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,2170,145,'Juu_Duzu_the_Whirlwind',0,32,1421,520,0,13,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1535,145,'Giant_Pugil',300,0,463,0,0,9,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,5850,145,'Quu_Xijo_the_Illusory',3600,0,3061,900,0,24,25,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (21,4459,145,'Yagudo_Votary',780,0,2776,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1159,145,'Earth_Eater',300,0,428,0,0,10,12,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1988,145,'Hoo_Mjuu_the_Torrent',0,32,1329,850,0,16,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,4456,145,'Yagudo_Theologist',660,0,2772,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,4444,145,'Yagudo_Priest',660,0,2751,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,4267,145,'Vuu_Puqu_the_Beguiler',0,32,2596,960,0,21,22,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,4113,145,'Vaa_Huja_the_Erudite',0,128,0,0,0,45,45,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- Zhuu Buxu's Gambit
 INSERT INTO `mob_groups` VALUES (28,0,145,'Yagudo_Lookout',0,128,0,0,0,0,NULL);
@@ -11022,6 +14468,7 @@ INSERT INTO `mob_groups` VALUES (26,0,150,'Orcish_Bewitcher',0,128,0,0,0,0,NULL)
 -- Castle_Oztroja (Zone 151)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,4459,151,'Yagudo_Votary',780,0,2775,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,355,151,'Bastion_Bats',780,0,82,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,4456,151,'Yagudo_Theologist',780,0,2773,0,0,0,NULL);
@@ -11068,6 +14515,54 @@ INSERT INTO `mob_groups` VALUES (43,2664,151,'Mimic',0,128,1679,0,0,0,NULL);
 -- 44 free
 -- 45 free
 -- 46 free
+=======
+INSERT INTO `mob_groups` VALUES (1,4459,151,'Yagudo_Votary',780,0,2775,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,355,151,'Bastion_Bats',780,0,82,0,0,18,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,4456,151,'Yagudo_Theologist',780,0,2773,0,0,22,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,4444,151,'Yagudo_Priest',780,0,2752,0,0,23,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,4576,151,'Saa_Doyi_the_Fervid',3600,0,3018,0,0,37,39,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (6,4423,151,'Yagudo_Herald',780,0,2710,0,0,32,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,4437,151,'Yagudo_Oracle',780,0,2737,0,0,34,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,4454,151,'Yagudos_Elemental',0,128,0,0,0,25,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,4428,151,'Yagudo_Interrogator',780,0,2723,0,0,35,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,2602,151,'Meat_Maggot',780,0,1649,0,0,29,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1341,151,'Fire_Elemental',960,4,831,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1160,151,'Earth_Elemental',960,4,734,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,4416,151,'Yagudo_Drummer',780,0,2706,0,0,33,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,872,151,'Cutter',780,0,552,0,0,29,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,2607,151,'Mee_Deggi_the_Punisher',0,32,1652,2400,0,35,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,2737,151,'Moo_Ouzi_the_Swiftblade',0,32,1730,0,0,30,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3298,151,'Quu_Domi_the_Gallant',0,32,2069,2300,0,35,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,582,151,'Bulwark_Bat',780,0,386,0,0,29,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,4461,151,'Yagudo_Zealot',960,0,2778,0,0,42,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,4445,151,'Yagudo_Prior',960,0,2754,0,0,45,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,4573,151,'Lii_Jixa_the_Somnolist',3600,0,3015,0,0,43,43,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (22,4413,151,'Yagudo_Conquistador',960,0,2701,0,0,43,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,4431,151,'Yagudo_Lutenist',960,0,2726,0,0,42,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,4450,151,'Yagudo_Sentinel',960,0,2765,0,0,51,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,4404,151,'Yagudo_Abbot',960,0,2689,0,0,53,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,4410,151,'Yagudo_Chanter',960,0,2698,0,0,53,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,4427,151,'Yagudo_Inquisitor',960,0,2720,0,0,54,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,4402,151,'Yaa_Haqa_the_Profane',0,32,2685,0,0,43,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,2987,151,'Ooze',960,0,1868,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,4438,151,'Yagudo_Parasite',960,0,2832,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,4418,151,'Yagudo_Flagellant',960,0,2833,0,0,62,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,5494,151,'Yagudo_Prelate',960,0,2748,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,4412,151,'Yagudo_Conductor',960,0,2834,0,0,63,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,4407,151,'Yagudo_Assassin',960,0,2695,0,0,64,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,4425,151,'Yagudo_High_Priest',1440,0,2714,4500,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,4455,151,'Yagudo_Templar',1440,0,2768,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,4408,151,'Yagudo_Avatar',0,128,2696,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,4453,151,'Yagudos_Avatar',0,128,0,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,4072,151,'Tzee_Xicu_the_Manifest',0,128,2511,42000,42000,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,2016,151,'Huu_Xalmo_the_Savage',0,128,1341,30000,0,63,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,2944,151,'Odontotyrannus',0,128,1838,0,0,52,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,4434,151,'Yagudo_Muralist',0,128,0,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,2664,151,'Mimic',0,128,1679,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,4418,151,'Yagudo_Flagellant',960,0,2833,0,0,70,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,5494,151,'Yagudo_Prelate',960,0,2748,0,0,70,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,4412,151,'Yagudo_Conductor',960,0,2834,0,0,70,71,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Altar_Room (Zone 152)
@@ -11093,6 +14588,7 @@ INSERT INTO `mob_groups` VALUES (2,6768,153,'Stygian_Pugil_fished',0,128,2355,0,
 INSERT INTO `mob_groups` VALUES (3,6782,153,'Bouncing_Ball_fished',0,128,342,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,6783,153,'Demonic_Pugil_fished',0,128,147,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,343,153,'Bark_Spider',300,0,227,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,937,153,'Death_Cap',300,0,582,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,1201,153,'Ellyllon',0,32,2890,3600,0,0,NULL);
@@ -11129,6 +14625,44 @@ INSERT INTO `mob_groups` VALUES (37,5159,153,'Modron',0,128,0,0,9999,0,NULL);
 INSERT INTO `mob_groups` VALUES (38,5160,153,'Modrons_Druid',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (39,6876,153,'Ayapec',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (40,6877,153,'Hidhaegg',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,343,153,'Bark_Spider',960,0,227,0,0,60,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,937,153,'Death_Cap',960,0,582,0,0,60,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1201,153,'Ellyllon',0,32,2890,3600,0,65,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,2762,153,'Mourioche',960,0,1746,0,0,62,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2754,153,'Moss_Eater',960,0,1742,0,0,62,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,2272,153,'Knight_Crawler',960,0,1456,0,0,62,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,2962,153,'Old_Goobbue',960,0,3228,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3375,153,'Robber_Crab',960,0,2109,0,0,62,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,4309,153,'Water_Elemental',960,4,2629,0,0,69,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,206,153,'Aquarius',0,32,149,6100,3000,69,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3912,153,'Thunder_Elemental',960,4,2410,0,0,69,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,4103,153,'Unut',0,32,2524,7400,0,69,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,2745,153,'Morbol_Menace',960,0,1738,0,0,67,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1191,153,'Elder_Goobbue',960,0,3012,0,0,74,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2282,153,'Korrigan',960,0,3229,0,0,72,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3649,153,'Skimmer',960,0,571,0,0,72,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3768,153,'Steelshell',960,0,2330,0,0,73,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,3200,153,'Processionaire',960,0,2022,0,0,72,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,920,153,'Darter',960,0,571,0,0,75,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,469,153,'Blood_Ball',960,0,0,0,0,75,78,0,NULL); -- Removed drop pool, FFXIDB shows zero drops for mob (http://ffxidb.com/zones/153/blood-ball)
+INSERT INTO `mob_groups` VALUES (25,4578,153,'Mourning_Crawler',300,0,3007,0,0,103,105,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (26,4577,153,'Snaggletooth_Peapuk',300,0,2814,0,0,102,105,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (27,6369,153,'Viseclaw',300,0,3197,0,0,102,105,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (28,123,153,'Ancient_Goobbue',86400,0,3141,15000,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,515,153,'Boyahda_Sapling',960,0,2912,0,0,74,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,344,153,'Bark_Tarantula',960,0,228,0,0,75,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,978,153,'Demonic_Rose',960,0,609,0,0,75,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,2393,153,'Leshonki',0,32,3039,5000,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,4253,153,'Voluptuous_Vivian',0,32,2831,13000,0,80,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,2664,153,'Mimic',0,128,1680,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,60,153,'Agas',0,128,0,10000,10000,65,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,386,153,'Beet_Leafhopper',0,128,0,11000,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,5159,153,'Modron',0,128,0,0,9999,94,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,5160,153,'Modrons_Druid',0,128,0,0,0,92,93,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,6876,153,'Ayapec',0,128,0,0,0,125,125,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,6877,153,'Hidhaegg',0,128,0,0,0,135,135,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- Star Onion Fortune
 INSERT INTO `mob_groups` VALUES (41,0,153,'Templar_Crawler',0,128,0,0,0,0,NULL);
@@ -11385,6 +14919,7 @@ INSERT INTO `mob_groups` VALUES (36,6564,157,'Scythe_Victim_blm',0,128,0,8000,80
 -- Upper_Delkfutts_Tower (Zone 158)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,1233,158,'Enkelados',0,32,772,3050,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,1590,158,'Gigass_Bats',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1595,158,'Gigas_Torturer',300,0,980,0,0,0,NULL);
@@ -11411,6 +14946,34 @@ INSERT INTO `mob_groups` VALUES (23,6427,158,'Incubus_Bats',300,0,234,0,0,0,NULL
 INSERT INTO `mob_groups` VALUES (24,87,158,'Alkyoneus',0,128,50,11670,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (25,5428,158,'Autarch',1800,0,2949,0,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (26,1589,158,'Gigass_Bat',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,1233,158,'Enkelados',0,32,772,0,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,1590,158,'Gigass_Bats',0,128,0,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1595,158,'Gigas_Torturer',300,0,980,0,0,34,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,1552,158,'Gigas_Bonecutter',300,0,980,0,0,34,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,1588,158,'Gigas_Stonemason',300,0,980,0,0,34,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,1585,158,'Gigas_Spirekeeper',300,0,980,0,0,34,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,3912,158,'Thunder_Elemental',300,4,2410,0,0,35,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,2413,158,'Light_Elemental',300,4,1521,0,0,35,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2663,158,'Mimas',900,0,1674,1320,0,36,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,2483,158,'Magic_Urn',300,0,1570,0,0,34,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3188,158,'Porphyrion',600,0,2018,0,0,36,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,974,158,'Demonic_Doll',300,0,192,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,3085,158,'Pallas',0,128,1975,10000,0,72,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1589,158,'Gigass_Bat',0,128,0,0,0,53,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,6600,158,'Magic_Pot',300,0,1569,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,6456,158,'Dire_Bat',300,0,234,0,0,64,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,2161,158,'Jotunn_Wallkeeper',300,0,1413,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,2158,158,'Jotunn_Gatekeeper',300,0,1411,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2159,158,'Jotunn_Hallkeeper',300,0,1412,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2162,158,'Jotunn_Wildkeeper',300,0,1414,0,0,65,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,6510,158,'Phasma',300,0,1997,0,0,67,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,2111,158,'Ixtab',0,32,1383,0,0,71,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,6427,158,'Incubus_Bats',300,0,234,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,87,158,'Alkyoneus',0,128,50,11500,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,5428,158,'Autarch',1800,0,2949,0,0,83,85,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (26,1589,158,'Gigass_Bat',0,128,0,0,0,65,65,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Temple_of_Uggalepih (Zone 159)
@@ -11520,6 +15083,7 @@ INSERT INTO `mob_groups` VALUES (39,6882,160,'Azrael',0,128,0,0,0,0,NULL);
 -- Castle_Zvahl_Baileys (Zone 161)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,1264,161,'Evil_Eye',960,0,794,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,991,161,'Demon_Pawn',960,0,622,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,913,161,'Dark_Elemental',960,4,568,0,0,0,NULL);
@@ -11574,6 +15138,62 @@ INSERT INTO `mob_groups` VALUES (51,982,161,'Demon_Banneret',0,128,0,0,0,0,NULL)
 INSERT INTO `mob_groups` VALUES (52,992,161,'Demon_Secretary',0,128,0,0,0,0,NULL);
 -- 53 free
 -- 54 free
+=======
+INSERT INTO `mob_groups` VALUES (1,1264,161,'Evil_Eye',960,0,794,0,0,46,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,991,161,'Demon_Pawn',960,0,622,0,0,48,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,913,161,'Dark_Elemental',960,4,568,0,0,48,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,2043,161,'Ice_Elemental',960,4,1347,0,0,48,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,988,161,'Demon_Knight',960,0,617,0,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,997,161,'Demon_Wizard',960,0,622,0,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,2414,161,'Likho',0,128,1522,7000,0,67,68,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (8,1701,161,'Goblin_Poacher',960,0,1139,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1741,161,'Goblin_Trader',960,0,1180,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1721,161,'Goblins_Bats',0,128,0,0,0,40,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1709,161,'Goblin_Robber',960,0,1147,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1705,161,'Goblin_Reaper',960,0,1141,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,2997,161,'Orcish_Bowshooter',960,0,1876,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3014,161,'Orcish_Footsoldier',960,0,1908,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3015,161,'Orcish_Gladiator',960,0,1912,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3039,161,'Orcish_Trooper',960,0,1946,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,995,161,'Demon_Warlock',960,0,625,0,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,994,161,'Demons_Elemental',0,128,623,0,0,49,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1192,161,'Elder_Quadav',960,0,755,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2102,161,'Iron_Quadav',960,0,754,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3731,161,'Spinel_Quadav',960,0,2307,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1207,161,'Emerald_Quadav',960,0,763,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,4461,161,'Yagudo_Zealot',960,0,2765,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,4413,161,'Yagudo_Conquistador',960,0,2702,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,4431,161,'Yagudo_Lutenist',960,0,2727,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,4445,161,'Yagudo_Prior',960,0,2755,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,2738,161,'Morbid_Eye',960,0,1731,0,0,52,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,985,161,'Demon_Commander',960,0,613,0,0,57,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,986,161,'Demon_General',960,0,614,0,0,57,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,984,161,'Demon_Chancellor',960,0,612,0,0,57,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,989,161,'Demon_Magistrate',960,0,618,0,0,57,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,472,161,'Blood_Demon',960,0,310,0,0,64,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1081,161,'Doom_Demon',960,0,674,0,0,64,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,226,161,'Arch_Demon',960,0,163,0,0,64,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,22,161,'Abyssal_Demon',960,0,4,0,0,64,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,5890,161,'Marquis_Naberius',3600,0,3089,6000,0,63,64,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (37,5763,161,'Marquis_Sabnock',0,32,3047,9500,0,73,75,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (38,65,161,'Ahriman',960,0,32,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,6612,161,'Dread_Demon',960,0,705,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,6614,161,'Judicator_Demon',960,0,1416,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,6634,161,'Stygian_Demon',960,0,2352,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,2568,161,'Marquis_Allocen',0,128,1622,4500,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,6613,161,'Gore_Demon',960,0,1206,0,0,71,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,2569,161,'Marquis_Amon',0,128,1623,3500,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,1134,161,'Duke_Haborym',0,128,716,4400,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1786,161,'Grand_Duke_Batym',0,128,1213,4000,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,993,161,'Demons_Avatar',0,128,0,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,917,161,'Dark_Spark',0,128,0,8600,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,2664,161,'Mimic',0,128,1683,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,2571,161,'Marquis_Andrealphus',0,128,0,0,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,982,161,'Demon_Banneret',0,128,0,0,0,61,61,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,992,161,'Demon_Secretary',0,128,0,0,0,61,61,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,994,161,'Demons_Elemental',0,128,623,0,0,43,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,994,161,'Demons_Elemental',0,128,623,0,0,60,64,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Castle_Zvahl_Keep (Zone 162)
@@ -11830,6 +15450,7 @@ INSERT INTO `mob_groups` VALUES (28,4249,165,'Volker',0,128,0,1300,0,1,NULL); --
 -- Ranguemont_Pass (Zone 166)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,4349,166,'Wind_Bats',300,0,82,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,443,166,'Blade_Bat',300,0,461,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,6412,166,'Oil_Slick',300,0,15,0,0,0,NULL);
@@ -11861,6 +15482,39 @@ INSERT INTO `mob_groups` VALUES (28,4041,166,'Tros',0,128,0,3000,2000,0,NULL);
 INSERT INTO `mob_groups` VALUES (29,2633,166,'Metallic_Slime',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (30,0,166,'Arcus_Blades',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (31,6883,166,'Hyakume',0,32,0,0,0,0,'WOTG');
+=======
+INSERT INTO `mob_groups` VALUES (1,4349,166,'Wind_Bats',480,0,82,0,0,3,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,443,166,'Blade_Bat',480,0,461,0,0,4,7,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,6412,166,'Oil_Slick',480,0,15,0,0,7,9,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,1737,166,'Goblin_Thug',900,0,1170,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,1744,166,'Goblin_Weaver',900,0,1183,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,1690,166,'Goblin_Mugger',960,0,1119,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1683,166,'Goblin_Leecher',960,0,1099,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1666,166,'Goblin_Gambler',960,0,1079,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,3537,166,'Seeker_Bats',960,0,82,0,0,25,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,2987,166,'Ooze',960,0,1190,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,666,166,'Cave_Scorpion',660,0,436,0,0,30,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3776,166,'Stirge',960,0,401,0,0,30,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,5849,166,'Gloom_Eye',0,32,3060,8600,0,73,74,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (14,3838,166,'Taisai',960,0,2374,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3839,166,'Taisaijin',0,128,2375,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1537,166,'Giant_Scorpion',780,0,972,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,374,166,'Bat_Eye',780,0,246,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1912,166,'Hecteyes',960,0,1288,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,4574,166,'Mucoid_Mass',6000,0,3016,0,0,45,48,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (20,6606,166,'Hovering_Oculus',300,0,3196,0,0,87,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (21,6459,166,'Bilesucker',300,0,461,0,0,87,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (22,6657,166,'Goblin_Hoodoo',300,0,1149,0,0,86,90,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (23,6662,166,'Goblin_Artificer',300,0,1163,0,0,88,90,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (24,6655,166,'Goblin_Tanner',300,0,1065,0,0,88,90,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (25,6668,166,'Goblin_Chaser',300,0,1124,0,0,88,90,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (26,1721,166,'Goblins_Bats',0,128,0,0,0,83,84,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (27,1267,166,'Evil_Weapon',660,0,799,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,4041,166,'Tros',0,128,0,0,0,44,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,2633,166,'Metallic_Slime',0,128,0,0,0,29,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,0,166,'Arcus_Blades',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,6883,166,'Hyakume',0,32,0,0,0,0,0,0,'WOTG');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- Curilla Unleashed
 INSERT INTO `mob_groups` VALUES (32,0,166,'Harnessed_Smilodon',0,128,0,0,0,0,NULL);
@@ -11874,6 +15528,7 @@ INSERT INTO `mob_groups` VALUES (1,6770,167,'Bloodsucker_fished',0,128,174,0,0,0
 INSERT INTO `mob_groups` VALUES (2,6785,167,'Acid_Grease_fished',0,128,15,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,6784,167,'Mousse_fished',0,128,15,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (4,1440,167,'Funnel_Bats',300,0,234,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,1911,167,'Hecatomb_Hound',300,0,933,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,4321,167,'Werebat',300,0,234,0,0,0,NULL);
@@ -11897,6 +15552,31 @@ INSERT INTO `mob_groups` VALUES (23,2548,167,'Manes',0,32,2879,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (24,5138,167,'Bloodsucker_NM',3600,0,2892,3400,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (25,482,167,'Bodach',0,128,0,7500,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (26,6723,167,'Garbage_Gel',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (4,1440,167,'Funnel_Bats',300,0,234,0,0,52,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,1911,167,'Hecatomb_Hound',300,0,933,0,0,56,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,4321,167,'Werebat',300,0,234,0,0,55,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1900,167,'Haunt',300,0,1280,0,0,60,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,6526,167,'Garm',300,0,933,0,0,64,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,908,167,'Dark_Aspic',300,0,1407,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,2764,167,'Mousse',300,0,1407,0,0,58,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3557,167,'Sewer_Syrup',0,32,2209,11230,0,64,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3597,167,'Shii',0,32,2236,10000,0,70,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1118,167,'Drexerion_the_Condemned',0,128,707,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3125,167,'Phanduron_the_Condemned',0,128,1992,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,6475,167,'Blind_Bat',300,0,2165,0,0,94,99,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (16,6411,167,'Panna_Cotta',300,0,1972,0,0,95,96,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (17,6509,167,'Nachtmahr',300,0,2164,0,0,96,97,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (18,6527,167,'Dabilla',300,0,2878,0,0,94,97,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (19,6582,167,'Wurdalak',300,0,2882,0,0,97,99,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (20,233,167,'Arioch',0,32,2388,0,0,56,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,6393,167,'Bloodsucker',300,0,174,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1505,167,'Gespenst',300,0,950,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,2548,167,'Manes',0,32,2879,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,5138,167,'Bloodsucker_NM',3600,0,2892,3400,0,70,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,482,167,'Bodach',0,128,0,7500,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,6723,167,'Garbage_Gel',0,128,0,0,0,122,122,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- Curilla Unleashed
 INSERT INTO `mob_groups` VALUES (27,0,167,'Trion',0,128,0,0,0,0,NULL);
@@ -11948,6 +15628,7 @@ INSERT INTO `mob_groups` VALUES (3,6777,169,'Rock_Crab_fished',0,128,273,0,0,0,N
 INSERT INTO `mob_groups` VALUES (4,6770,169,'Bloodsucker_fished',0,128,18,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,6784,169,'Mousse_fished',0,128,1751,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,617,169,'Canal_Bats',300,0,1512,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,5130,169,'Hell_Bat',300,0,386,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,413,169,'Bigclaw',300,0,274,0,0,0,NULL);
@@ -11985,6 +15666,45 @@ INSERT INTO `mob_groups` VALUES (39,6540,169,'Doom_Soldier',300,0,685,0,0,0,NULL
 INSERT INTO `mob_groups` VALUES (40,5757,169,'Brazen_Bones',28800,0,2868,20000,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (41,3755,169,'Starmite',300,0,2325,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (42,2664,169,'Mimic',0,128,1684,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,617,169,'Canal_Bats',300,0,1512,0,0,45,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,5130,169,'Hell_Bat',300,0,386,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,413,169,'Bigclaw',300,0,274,0,0,49,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1287,169,'Fallen_Knight',300,0,683,0,0,52,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,2407,169,'Lich',300,0,958,0,0,54,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,908,169,'Dark_Aspic',300,0,567,0,0,53,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,6394,169,'Bloodsucker',300,0,18,0,0,54,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1606,169,'Girtab',420,0,1001,0,0,58,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,2482,169,'Magic_Sludge',0,128,0,0,0,64,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3496,169,'Scavenger_Crab',300,0,2177,0,0,60,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1366,169,'Fleshcraver',300,0,845,0,0,60,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,2667,169,'Mindcraver',300,0,1695,0,0,60,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,3396,169,'Rotten_Sod',300,0,2124,0,0,58,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,2491,169,'Makara',300,0,279,0,0,49,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,514,169,'Bouncing_Ball',300,0,344,0,0,64,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,5859,169,'Canal_Moocher',0,32,3071,9500,0,73,74,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (22,3803,169,'Stygian_Pugil',300,0,3336,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,2982,169,'Oni_Carcass',86400,0,1860,32700,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,619,169,'Blackwater_Pugil',300,0,3204,0,0,96,98,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (25,6366,169,'Plunderer_Crab',300,0,3200,0,0,95,98,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (26,2764,169,'Mousse',300,0,1751,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,5552,169,'Konjac',0,32,3040,0,0,78,78,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (28,6426,169,'Deviling_Bats',300,0,3198,0,0,95,97,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (29,6541,169,'Sodden_Bones',300,0,3203,0,0,95,98,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (30,6534,169,'Drowned_Bones',300,0,3199,0,0,95,98,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (31,6073,169,'Starborer',300,0,3108,0,0,95,97,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (32,6335,169,'Rapier_Scorpion',300,0,3202,0,0,95,99,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (33,2070,169,'Impish_Bats',300,0,1361,0,0,58,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1958,169,'Hinge_Oil',900,0,0,5800,0,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,6377,169,'Poroggo_Excavator',300,0,3201,0,0,97,99,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (36,6378,169,'Flume_Toad',300,0,3205,0,0,94,96,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (37,6456,169,'Dire_Bat',300,0,663,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,6539,169,'Doom_Mage',300,0,679,0,0,65,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,6540,169,'Doom_Soldier',300,0,685,0,0,65,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,5757,169,'Brazen_Bones',28800,0,2868,20000,0,85,85,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (41,3755,169,'Starmite',300,0,2325,0,0,65,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,2664,169,'Mimic',0,128,1684,0,0,60,60,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Full_Moon_Fountain (Zone 170)
@@ -12159,12 +15879,21 @@ INSERT INTO `mob_groups` VALUES (122,7167,171,'Goblin_Lansquenet',0,128,0,0,0,0,
 -- Zeruhn_Mines (Zone 172)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,1038,172,'Ding_Bats',300,0,654,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,6420,172,'Burrower_Worm',300,0,2501,0,0,0,'ABYSSEA');
 INSERT INTO `mob_groups` VALUES (3,6469,172,'Colliery_Bat',300,0,654,0,0,0,'ABYSSEA');
 INSERT INTO `mob_groups` VALUES (4,6365,172,'Soot_Crab',300,0,2104,0,0,0,'ABYSSEA');
 INSERT INTO `mob_groups` VALUES (5,3371,172,'River_Crab',300,0,2103,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,6399,172,'Veindigger_Leech',300,0,963,0,0,0,'ABYSSEA');
+=======
+INSERT INTO `mob_groups` VALUES (1,1038,172,'Ding_Bats',300,0,654,0,0,1,3,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,6420,172,'Burrower_Worm',300,0,2501,0,0,75,79,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (3,6469,172,'Colliery_Bat',300,0,654,0,0,75,80,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (4,6365,172,'Soot_Crab',300,0,2104,0,0,75,78,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (5,3371,172,'River_Crab',300,0,2103,0,0,2,4,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,6399,172,'Veindigger_Leech',300,0,963,0,0,75,80,0,'ABYSSEA');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- The Gloom Phantom's Approach
 INSERT INTO `mob_groups` VALUES (7,0,172,'Gloom_Phantom',0,128,0,0,0,0,NULL); -- TODO: capture level from retail
@@ -12184,6 +15913,7 @@ INSERT INTO `mob_groups` VALUES (1,3682,173,'Snipper_fished',0,128,93,0,0,0,NULL
 INSERT INTO `mob_groups` VALUES (2,5868,173,'Greater_Pugil_fished',0,128,279,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,6029,173,'Kraken_fished',0,128,1464,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (4,2374,173,'Land_Worm',300,0,438,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,3537,173,'Seeker_Bats',300,0,399,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,3901,173,'Thread_Leech',300,0,343,0,0,0,NULL);
@@ -12212,6 +15942,36 @@ INSERT INTO `mob_groups` VALUES (28,2283,173,'Korroloka_Leech',0,128,0,250,0,0,N
 INSERT INTO `mob_groups` VALUES (29,2748,173,'Morion_Worm',0,128,1739,2100,2100,0,NULL);
 INSERT INTO `mob_groups` VALUES (30,2633,173,'Metallic_Slime',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (31,1642,173,'Goblin_Bounty_Hunter',300,0,1030,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (4,2374,173,'Land_Worm',300,0,438,0,0,20,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,3537,173,'Seeker_Bats',300,0,399,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3901,173,'Thread_Leech',300,0,343,0,0,28,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,2002,173,'Huge_Spider',300,0,1335,0,0,28,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,771,173,'Combat',300,0,386,0,0,27,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2146,173,'Jelly',300,0,1407,0,0,23,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,3912,173,'Thunder_Elemental',780,4,2410,0,0,32,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3523,173,'Sea_Monk',300,0,504,0,0,32,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1807,173,'Greater_Pugil',300,0,279,0,0,25,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,743,173,'Clipper',300,0,483,0,0,29,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,4309,173,'Water_Elemental',780,4,2629,0,0,32,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,639,173,'Cargo_Crab_Colin',0,32,416,2100,0,34,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,2141,173,'Jammer_Leech',1800,0,0,0,0,60,60,0,NULL); -- 10-30 minutes random timer
+INSERT INTO `mob_groups` VALUES (17,1282,173,'Falcatus_Aranei',0,32,808,3500,0,32,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4816,173,'Lacerator',300,0,0,0,0,87,91,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (19,6404,173,'Spool_Leech',300,0,79,0,0,87,91,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (20,485,173,'Bogy',300,0,323,0,0,30,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,898,173,'Dame_Blanche',0,32,561,1800,0,37,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1588,173,'Gigas_Stonemason',300,0,988,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1586,173,'Gigas_Stonecarrier',300,0,988,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1587,173,'Gigas_Stonegrinder',300,0,988,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1563,173,'Gigas_Foreman',300,0,988,0,0,35,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1593,173,'Gigass_Spider',0,128,0,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,4831,173,'Thoon',3600,0,3020,3000,0,43,45,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (28,2283,173,'Korroloka_Leech',0,128,0,250,0,32,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,2748,173,'Morion_Worm',0,128,1739,2000,2000,30,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,2633,173,'Metallic_Slime',0,128,0,0,0,24,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1642,173,'Goblin_Bounty_Hunter',300,0,1030,0,0,10,10,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- The Destiny Destroyers
 INSERT INTO `mob_groups` VALUES (32,0,173,'Gloom_Phantom',0,128,0,0,0,0,NULL);
@@ -12227,6 +15987,7 @@ INSERT INTO `mob_groups` VALUES (1,6781,174,'Scavenger_Crab_fished',0,128,2178,0
 INSERT INTO `mob_groups` VALUES (2,6768,174,'Stygian_Pugil_fished',0,128,2356,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,6778,174,'Devil_Manta_fished',0,128,644,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (4,1763,174,'Gordovs_Ghost',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,1003,174,'Dervos_Ghost',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,1609,174,'Gizerls_Ghost',0,128,0,0,0,0,NULL);
@@ -12268,6 +16029,49 @@ INSERT INTO `mob_groups` VALUES (41,5181,174,'Koura',0,128,0,0,9999,0,NULL);
 INSERT INTO `mob_groups` VALUES (42,5182,174,'Pekapeka',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (43,5183,174,'Moki',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (44,6884,174,'Specter_Worm',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (4,1763,174,'Gordovs_Ghost',0,128,0,0,0,68,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,1003,174,'Dervos_Ghost',0,128,0,0,0,68,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,1609,174,'Gizerls_Ghost',0,128,0,0,0,68,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,3456,174,'Sand_Lizard',300,0,2153,0,0,61,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3375,174,'Robber_Crab',300,0,2110,0,0,60,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1900,174,'Haunt',1200,0,1281,0,0,63,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,668,174,'Cave_Worm',300,0,439,0,0,60,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1341,174,'Fire_Elemental',300,4,831,0,0,67,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,71,174,'Air_Elemental',300,4,38,0,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,3433,174,'Sabotender_Sediendo',300,0,2141,0,0,64,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3432,174,'Sabotender_Mariachi',0,32,2140,8000,0,68,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3342,174,'Recluse_Spider',300,0,2084,0,0,63,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,105,174,'Amemet',0,32,62,11500,0,65,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1039,174,'Diplopod',960,0,656,0,0,68,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,3079,174,'Ovinnik',300,0,1969,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1801,174,'Greater_Cockatrice',300,0,201,0,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2314,174,'Ladon',300,0,1477,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3115,174,'Pelican',0,32,1988,0,0,80,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,6417,174,'Kuftal_Delver',300,0,3192,0,0,99,102,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (23,3677,174,'Machairodus',300,0,1560,0,0,99,103,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (24,962,174,'Deinonychus',300,0,601,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1687,174,'Goblin_Mercenary',300,0,1115,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1634,174,'Goblin_Alchemist',300,0,1014,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1637,174,'Goblin_Bandit',300,0,1022,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1734,174,'Goblin_Tamer',300,0,1168,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1732,174,'Goblins_Spider',0,128,0,0,0,53,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,463,174,'Bloodthirster_Madkix',0,32,305,9700,0,70,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,2292,174,'Kuftal_Digger',300,0,1467,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,4478,174,'Yowie',0,32,2791,12500,0,69,71,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,207,174,'Arachne',0,32,150,8700,0,67,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,2664,174,'Mimic',0,128,1685,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,620,174,'Cancer',0,128,403,6200,0,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,3375,174,'Robber_Crab',0,128,2110,0,0,60,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,3129,174,'Phantom_Worm',0,128,1994,7500,7500,70,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1841,174,'Guivre',0,128,1252,22000,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,2214,174,'Kettenkaefer',0,128,0,10500,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,5180,174,'Tangaroa',0,128,0,0,50000,96,97,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,5181,174,'Koura',0,128,0,0,9999,92,93,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,5182,174,'Pekapeka',0,128,0,0,0,92,93,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,5183,174,'Moki',0,128,0,0,0,92,93,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,6884,174,'Specter_Worm',0,128,0,0,0,0,0,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- The_Eldieme_Necropolis_[S] (Zone 175)
@@ -12502,6 +16306,7 @@ INSERT INTO `mob_groups` VALUES (19,4717,177,'Trna',0,128,0,0,5000,0,NULL);
 -- The_Shrine_of_RuAvitau (Zone 178)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,290,178,'Aura_Weapon',300,0,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,288,178,'Aura_Pot',300,0,193,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,2043,178,'Ice_Elemental',300,0,1347,0,0,0,NULL);
@@ -12539,6 +16344,45 @@ INSERT INTO `mob_groups` VALUES (34,4715,178,'Bai_Hu',0,128,0,0,5000,0,NULL);
 INSERT INTO `mob_groups` VALUES (35,4714,178,'Qing_Long',0,128,0,0,5000,0,NULL);
 INSERT INTO `mob_groups` VALUES (36,4713,178,'Zhu_Que',0,128,0,0,5000,0,NULL);
 INSERT INTO `mob_groups` VALUES (37,4712,178,'Xuan_Wu',0,128,0,0,5000,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,290,178,'Aura_Weapon',300,0,0,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,288,178,'Aura_Pot',300,0,193,0,0,75,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,2043,178,'Ice_Elemental',300,0,1347,0,0,73,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,286,178,'Aura_Butler',300,0,192,0,0,77,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,1341,178,'Fire_Elemental',300,0,831,0,0,73,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,1306,178,'Faust',10800,0,2821,16000,0,83,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,955,178,'Defender',300,0,0,500,0,71,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,287,178,'Aura_Gear',0,128,192,0,0,76,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2755,178,'Mother_Globe',10800,0,2820,12000,0,83,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,3667,178,'Slave_Globe',0,128,0,600,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,289,178,'Aura_Statue',300,0,2824,0,0,81,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,4082,178,'Ullikummi',0,128,2822,16000,0,85,87,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,946,178,'Decorative_Weapon',300,0,0,0,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3912,178,'Thunder_Elemental',300,0,2410,0,0,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,4309,178,'Water_Elemental',300,0,2629,0,0,73,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,71,178,'Air_Elemental',300,0,38,0,0,71,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1160,178,'Earth_Elemental',300,0,733,0,0,71,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,913,178,'Dark_Elemental',300,0,568,0,0,73,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,323,178,'Baelfyr',300,0,0,0,0,104,106,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (20,1487,178,'Gefyrst',300,0,0,0,0,104,106,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (21,4099,178,'Ungeweder',300,0,0,0,0,104,106,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (22,593,178,'Byrgen',300,0,0,0,999,104,106,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (23,6595,178,'Aura_Sculpture',300,0,3107,0,0,104,106,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,2971,178,'Olla_Pequena',0,128,0,5000,0,82,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,2970,178,'Olla_Media',0,128,0,5200,0,84,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,2969,178,'Olla_Grande',0,128,2823,5300,0,85,85,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,2265,178,'Kirin',0,128,2819,60000,60000,92,92,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,4670,178,'Genbu_pet',0,128,0,10000,10000,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,4671,178,'Seiryu_pet',0,128,0,11000,11000,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,4672,178,'Byakko_pet',0,128,0,10500,10500,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,4673,178,'Suzaku_pet',0,128,0,10000,10000,82,84,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,2266,178,'Kirins_Avatar',0,128,0,0,0,78,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,4716,178,'Qilin',0,128,0,0,5000,100,101,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,4715,178,'Bai_Hu',0,128,0,0,5000,98,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,4714,178,'Qing_Long',0,128,0,0,5000,98,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,4713,178,'Zhu_Que',0,128,0,0,5000,98,99,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,4712,178,'Xuan_Wu',0,128,0,0,5000,98,99,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Stellar_Fulcrum (Zone 179)
@@ -12719,6 +16563,7 @@ INSERT INTO `mob_groups` VALUES (11288,5811,183,'Auspicious_Entity_Earth',0,128,
 -- Lower_Delkfutts_Tower (Zone 184)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,1248,184,'Epialtes',0,32,787,1950,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,1526,184,'Giant_Gatekeeper',300,0,964,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1528,184,'Giant_Guard',300,0,964,0,0,0,NULL);
@@ -12749,6 +16594,38 @@ INSERT INTO `mob_groups` VALUES (27,3055,184,'Orna',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (28,1379,184,'Fomorian_Spear',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (29,2058,184,'Illusory_Pot',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (30,5162,184,'Akvan',0,128,0,0,9999,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,1248,184,'Epialtes',0,32,787,0,0,28,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,1526,184,'Giant_Gatekeeper',300,0,964,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1528,184,'Giant_Guard',300,0,964,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,1538,184,'Giant_Sentry',300,0,964,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,1589,184,'Gigass_Bat',0,128,0,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,1531,184,'Giant_Lobber',300,0,968,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,6436,184,'Seeker_Bats',300,0,82,0,0,25,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,6450,184,'Ancient_Bat',300,0,461,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,6504,184,'Bogy',300,0,324,0,0,30,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1690,184,'Goblin_Mugger',300,0,1119,0,0,27,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1683,184,'Goblin_Leecher',300,0,1099,0,0,27,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1666,184,'Goblin_Gambler',300,0,0,0,0,27,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,694,184,'Chaos_Idol',300,0,192,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,5427,184,'Tyrant',5400,0,2948,0,0,40,42,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (15,1564,184,'Gigas_Hallwatcher',300,0,980,0,0,34,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1579,184,'Gigas_Punisher',300,0,980,0,0,34,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1554,184,'Gigas_Butcher',300,0,0,0,0,34,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1590,184,'Gigass_Bats',0,128,0,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1582,184,'Gigas_Sculptor',300,0,980,0,0,34,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3912,184,'Thunder_Elemental',300,4,2410,0,0,35,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,2413,184,'Light_Elemental',300,4,1521,0,0,35,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,2483,184,'Magic_Urn',300,0,1571,0,0,34,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1961,184,'Hippolytos',0,32,787,0,0,28,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,2480,184,'Magic_Pot',300,0,606,0,0,28,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1261,184,'Eurymedon',0,32,787,0,0,30,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1049,184,'Disaster_Idol',0,128,0,4300,10000,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,3055,184,'Orna',0,128,0,0,0,40,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1379,184,'Fomorian_Spear',0,128,0,0,0,32,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,2058,184,'Illusory_Pot',0,128,0,0,0,45,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,5162,184,'Akvan',0,128,0,0,9999,94,95,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Dynamis-San_dOria (Zone 185)
@@ -13062,6 +16939,7 @@ INSERT INTO `mob_groups` VALUES (98,7257,188,'Vanguard_Pathfinder',300,0,2563,40
 -- King_Ranperres_Tomb (Zone 190)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,1038,190,'Ding_Bats',300,2,655,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,656,190,'Carrion_Worm',300,0,428,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1737,190,'Goblin_Thug',300,0,1170,0,0,0,NULL);
@@ -13112,6 +16990,58 @@ INSERT INTO `mob_groups` VALUES (47,6889,190,'Arcus_Blades',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (48,7058,190,'Locus_Hati',60,0,1278,305000,0,0,'ROV');
 INSERT INTO `mob_groups` VALUES (50,7059,190,'Locus_Spartoi_Sorcerer',60,0,2301,311800,0,0,'ROV');
 INSERT INTO `mob_groups` VALUES (49,7060,190,'Locus_Spartoi_Warrior',60,0,2125,311800,0,0,'ROV');
+=======
+INSERT INTO `mob_groups` VALUES (1,1038,190,'Ding_Bats',300,2,655,0,0,2,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,656,190,'Carrion_Worm',300,0,428,0,0,2,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1737,190,'Goblin_Thug',300,0,1170,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,2763,190,'Mouse_Bat',300,0,386,0,0,3,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,1744,190,'Goblin_Weaver',300,0,1183,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3780,190,'Stone_Eater',300,0,2340,0,0,5,7,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1214,190,'Enchanted_Bones_blm',300,1,769,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3739,190,'Spook',360,1,2840,220,0,11,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,4349,190,'Wind_Bats',300,0,82,0,0,9,11,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1635,190,'Goblin_Ambusher',300,0,1019,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1738,190,'Goblin_Tinkerer',300,0,1175,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1643,190,'Goblin_Butcher',300,0,1033,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1796,190,'Grave_Bat',300,0,1221,0,0,11,13,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3378,190,'Rock_Eater',300,0,2116,0,0,14,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1670,190,'Goblin_Gruel',23400,0,1087,0,0,18,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,2797,190,'Nachzehrer_war',300,0,1771,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,5769,190,'Gwyllgi',0,32,3053,1500,0,31,34,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (18,3942,190,'Tomb_Bat',300,0,2423,0,0,17,19,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,857,190,'Crypt_Ghost',0,128,544,490,0,20,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3152,190,'Plague_Bats',300,2,2002,0,0,15,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,5726,190,'Ankou',3600,0,2989,650,650,21,21,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (22,4569,190,'Barbastelle',0,128,2971,550,0,16,19,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (23,1690,190,'Goblin_Mugger',300,0,1118,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1683,190,'Goblin_Leecher',300,0,1100,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1666,190,'Goblin_Gambler',300,0,1083,0,0,21,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,3946,190,'Locus_Tomb_Worm',60,0,428,293000,0,131,133,0,'ROV');
+INSERT INTO `mob_groups` VALUES (27,6460,190,'Locus_Dire_Bat',60,0,461,300000,0,133,135,0,'ROV');
+INSERT INTO `mob_groups` VALUES (28,6801,190,'Locus_Cutlass_Scorpion',60,0,549,305000,0,135,137,0,'ROV');
+INSERT INTO `mob_groups` VALUES (29,6391,190,'Locus_Thousand_Eyes',60,0,2402,305000,0,135,137,0,'ROV');
+INSERT INTO `mob_groups` VALUES (30,1898,190,'Hati',300,0,1278,0,0,135,137,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,3720,190,'Spartoi_Warrior',300,0,2125,0,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,3719,190,'Spartoi_Sorcerer',300,0,2301,0,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,2388,190,'Locus_Lemures',60,0,1506,0,0,80,82,0,'ROV');
+INSERT INTO `mob_groups` VALUES (34,709,190,'Cherry_Sapling',0,128,462,3700,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,671,190,'Cemetery_Cherry',0,128,442,40750,10000,72,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,244,190,'Locus_Armet_Beetle',60,0,670,302500,0,134,136,0,'ROV');
+INSERT INTO `mob_groups` VALUES (37,4261,190,'Vrtra',0,128,2592,100000,100000,95,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,3124,190,'Pey',0,128,0,0,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,2105,190,'Iruci',0,128,0,0,0,76,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,70,190,'Airi',0,128,0,0,0,81,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,799,190,'Corrupted_Yorgos',0,128,0,7250,0,64,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,797,190,'Corrupted_Soffeil',0,128,0,0,0,63,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,798,190,'Corrupted_Ulbrig',0,128,0,0,0,63,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,5164,190,'Hahava',0,128,0,0,9999,94,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,6543,190,'Enchanted_Bones_war',300,1,769,0,0,4,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,6563,190,'Nachzehrer_blm',300,0,1771,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,6889,190,'Arcus_Blades',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,7058,190,'Locus_Hati',60,0,1278,305000,0,136,137,0,'ROV');
+INSERT INTO `mob_groups` VALUES (50,7059,190,'Locus_Spartoi_Sorcerer',60,0,2301,311800,0,135,137,0,'ROV');
+INSERT INTO `mob_groups` VALUES (49,7060,190,'Locus_Spartoi_Warrior',60,0,2125,311800,0,135,137,0,'ROV');
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Dangruf_Wadi (Zone 191)
@@ -13123,6 +17053,7 @@ INSERT INTO `mob_groups` VALUES (2,7300,191,'Coral_Crab',0,128,481,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,6786,191,'Wadi_Leech_fished',0,128,2599,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,5133,191,'Thread_Leech_fished',0,128,79,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,1508,191,'Geyser_Lizard',0,128,952,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,3381,191,'Rock_Lizard',300,0,2120,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,1737,191,'Goblin_Thug',300,0,1170,0,0,0,NULL);
@@ -13153,11 +17084,44 @@ INSERT INTO `mob_groups` VALUES (31,724,191,'Chocoboleech',0,128,470,965,0,0,NUL
 INSERT INTO `mob_groups` VALUES (32,5528,191,'Fire_Elemental',0,128,831,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (33,4273,191,'Wadi_Leech',0,128,2599,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (34,6890,191,'Celaeno',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,1508,191,'Geyser_Lizard',0,128,952,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3381,191,'Rock_Lizard',300,0,2120,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1737,191,'Goblin_Thug',300,0,1170,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1744,191,'Goblin_Weaver',300,0,1183,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1965,191,'Hoarder_Hare',300,0,309,0,0,6,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,4830,191,'Teporingo',0,32,3019,630,0,20,20,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (11,1635,191,'Goblin_Ambusher',300,0,1020,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1738,191,'Goblin_Tinkerer',300,0,1176,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1643,191,'Goblin_Butcher',300,0,1034,0,0,12,16,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,4272,191,'Wadi_Hare',300,0,2598,0,0,11,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,3764,191,'Steam_Lizard',300,0,2327,0,0,16,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1659,191,'Goblin_Fisher',300,0,1052,0,0,5,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3780,191,'Stone_Eater',300,0,2341,0,0,3,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4271,191,'Wadi_Crab',300,0,2597,0,0,7,9,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,6666,191,'Goblin_Brigand',300,0,1119,0,0,86,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (20,6671,191,'Goblin_Headsman',300,0,1035,0,0,86,90,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (21,6664,191,'Goblin_Healer',300,0,2881,0,0,86,90,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (22,6415,191,'Witchetty_Grub',300,0,3357,0,0,86,90,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (23,6398,191,'Couloir_Leech',300,0,2599,0,0,87,88,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (24,5354,191,'Prim_Pika',300,0,2026,0,0,86,90,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (25,5352,191,'Natty_Gibbon',300,0,3188,0,0,90,93,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (26,6367,191,'Trimmer',300,0,2490,0,0,90,92,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (27,5644,191,'Fume_Lizard',300,0,922,0,0,86,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (28,6670,191,'Goblin_Conjurer',300,0,3187,0,0,86,91,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (29,6660,191,'Goblin_Bladesmith',300,0,1026,0,0,86,91,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (30,6665,191,'Goblin_Bushwhacker',300,0,1031,0,0,90,91,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (31,724,191,'Chocoboleech',0,128,470,965,0,24,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,5528,191,'Fire_Elemental',0,128,831,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,4273,191,'Wadi_Leech',0,128,2599,0,0,11,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,6890,191,'Celaeno',0,128,0,0,0,100,100,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Inner_Horutoto_Ruins (Zone 192)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,372,192,'Battue_Bats',300,0,244,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,1737,192,'Goblin_Thug',300,0,1170,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,443,192,'Blade_Bat',300,0,461,0,0,0,NULL);
@@ -13186,6 +17150,36 @@ INSERT INTO `mob_groups` VALUES (25,4567,192,'Nocuous_Weapon',0,32,1497,550,0,0,
 INSERT INTO `mob_groups` VALUES (26,4319,192,'Wendigo_war',300,0,2638,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (27,4320,192,'Wendigo_blm',300,0,2640,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (28,7072,192,'Magicked_Bones_dagger',0,128,2867,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,372,192,'Battue_Bats',300,0,244,0,0,1,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,1737,192,'Goblin_Thug',300,0,1170,0,0,1,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,443,192,'Blade_Bat',300,0,461,0,0,4,6,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,1744,192,'Goblin_Weaver',300,0,1183,0,0,1,7,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,2475,192,'Magicked_Bones_club',0,128,2867,0,0,3,8,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,4915,192,'Troika_Bats',300,0,244,0,0,78,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (7,6077,192,'Deathwatch_Beetle',300,0,670,0,0,79,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (8,6667,192,'Goblin_Flesher',300,0,1035,0,0,79,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (9,6663,192,'Goblin_Metallurgist',300,0,1035,0,0,78,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (10,6654,192,'Goblin_Lurcher',300,0,1170,0,0,78,84,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (11,6530,192,'Skinnymalinks',300,0,678,0,0,81,84,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (12,6535,192,'Skinnymajinx',300,0,769,0,0,81,84,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (13,6461,192,'Covin_Bat',300,0,461,0,0,81,83,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (14,6656,192,'Goblin_Trailblazer',300,0,1018,0,0,78,82,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (15,455,192,'Blob',300,0,297,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,2498,192,'Maltha',3600,0,1584,850,0,22,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,332,192,'Balloon',300,0,217,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1690,192,'Goblin_Mugger',300,0,1120,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1683,192,'Goblin_Leecher',300,0,1101,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1666,192,'Goblin_Gambler',300,0,1084,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,369,192,'Battle_Bat',300,0,239,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,3669,192,'Slendlix_Spindlethumb',0,32,2273,900,0,33,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,4345,192,'Will-o-the-Wisp',300,0,569,0,0,22,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,483,192,'Boggart',300,0,319,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,4567,192,'Nocuous_Weapon',0,32,1497,550,0,25,27,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (26,4319,192,'Wendigo_war',300,0,2638,0,0,25,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,4320,192,'Wendigo_blm',300,0,2640,0,0,25,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,7072,192,'Magicked_Bones_dagger',0,128,2867,0,0,3,8,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Ordelles_Caves (Zone 193)
@@ -13197,6 +17191,7 @@ INSERT INTO `mob_groups` VALUES (2,5133,193,'Thread_Leech_fished',0,128,79,0,0,0
 INSERT INTO `mob_groups` VALUES (3,5134,193,'Poison_Leech_fished',0,128,79,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,6787,193,'Rancid_Ooze_fished',0,128,15,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,3775,193,'Stink_Bats',720,0,81,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,5141,193,'Snipper',720,0,482,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,471,193,'Blood_Bunny',720,0,309,0,0,0,NULL);
@@ -13248,11 +17243,65 @@ INSERT INTO `mob_groups` VALUES (52,5168,193,'Krabimanjaro',0,128,0,0,9999,0,NUL
 INSERT INTO `mob_groups` VALUES (53,252,193,'Aroma_Leech',0,128,0,2330,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (54,6403,193,'Thread_Leech',720,0,79,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (55,5134,193,'Poison_Leech',720,0,18,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,3775,193,'Stink_Bats',720,0,81,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,5141,193,'Snipper',720,0,482,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,471,193,'Blood_Bunny',720,0,309,0,0,17,19,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1738,193,'Goblin_Tinkerer',720,0,1035,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1643,193,'Goblin_Butcher',720,0,1035,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1635,193,'Goblin_Ambusher',720,0,1018,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1985,193,'Hognosed_Bat',720,0,461,0,0,17,20,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3754,193,'Stalking_Sapling',720,0,2324,0,0,18,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,6343,193,'Fly_Agaric',720,0,853,0,0,21,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,5895,193,'Donggu',0,32,3095,3500,0,42,44,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (15,1690,193,'Goblin_Mugger',720,0,1119,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1683,193,'Goblin_Leecher',720,0,1099,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,1666,193,'Goblin_Gambler',720,0,1082,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,5356,193,'Buds_Bunny',300,0,326,0,0,83,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (19,6395,193,'Bilis_Leech',300,0,2599,0,0,83,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (20,1139,193,'Dung_Beetle',720,0,670,0,0,23,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,4256,193,'Vorpal_Bunny',300,0,326,0,0,23,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,6408,193,'Jelly',600,0,1190,0,0,26,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,5170,193,'Agar_Agar',0,32,3036,6000,0,64,66,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (24,6352,193,'Swagger_Spruce',300,0,3358,0,0,86,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (25,6074,193,'Targe_Beetle',300,0,670,0,0,83,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (26,6345,193,'Shrieker',600,0,2243,0,0,24,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,4345,193,'Will-o-the-Wisp',720,0,569,0,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,743,193,'Clipper',720,0,453,0,0,26,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,6076,193,'Goliath_Beetle',720,0,1196,0,0,29,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,3537,193,'Seeker_Bats',720,0,81,0,0,23,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,120,193,'Ancient_Bat',720,0,461,0,0,26,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,3795,193,'Stroper_Chyme',300,0,2349,0,0,33,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1694,193,'Goblin_Pathfinder',720,0,1125,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1721,193,'Goblins_Bats',0,128,0,0,0,24,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1665,193,'Goblin_Furrier',720,0,1066,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1715,193,'Goblin_Smithy',720,0,1164,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1710,193,'Goblin_Shaman',720,0,1150,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,3662,193,'Slash_Pine',300,0,2916,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,3794,193,'Stroper',300,0,2348,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,2742,193,'Morbolger',0,128,1736,2900,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,2808,193,'Napalm',300,0,1775,0,0,31,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,71,193,'Air_Elemental',720,4,39,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,4309,193,'Water_Elemental',720,4,2630,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,5169,193,'Bombast',5400,0,3223,3050,5000,42,44,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (45,3169,193,'Polevik',0,128,0,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1501,193,'Gerwitzs_Axe',0,128,947,7500,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,1504,193,'Gerwitzs_Sword',0,128,948,3000,3000,52,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,1503,193,'Gerwitzs_Soul',0,128,0,5600,5600,54,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,2817,193,'Necroplasm',0,128,0,0,0,37,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,5534,193,'Air_Elemental',0,128,39,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,2633,193,'Metallic_Slime',0,128,0,0,0,34,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,5168,193,'Krabimanjaro',0,128,0,0,9999,95,96,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,252,193,'Aroma_Leech',0,128,0,0,0,44,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,6403,193,'Thread_Leech',720,0,79,0,0,18,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,5134,193,'Poison_Leech',720,0,18,0,0,25,27,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Outer_Horutoto_Ruins (Zone 194)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,1635,194,'Goblin_Ambusher',300,0,1018,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,1738,194,'Goblin_Tinkerer',300,0,1035,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1643,194,'Goblin_Butcher',300,0,1035,0,0,0,NULL);
@@ -13322,11 +17371,83 @@ INSERT INTO `mob_groups` VALUES (66,5529,194,'Thunder_Elemental',300,4,2410,0,0,
 INSERT INTO `mob_groups` VALUES (67,870,194,'Custom_Cardian',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (68,1518,194,'Ghoul_blm',300,0,961,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (69,6724,194,'Voidwrought',0,128,0,0,0,0,NULL); -- TODO: capture level from retail
+=======
+INSERT INTO `mob_groups` VALUES (1,1635,194,'Goblin_Ambusher',300,0,1018,0,0,10,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,1738,194,'Goblin_Tinkerer',300,0,1035,0,0,10,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1643,194,'Goblin_Butcher',300,0,1035,0,0,10,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,6438,194,'Stink_Bats',300,0,241,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,1011,194,'Desmodont',0,32,637,0,0,26,27,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (6,3395,194,'Rotten_Jam',300,0,297,0,0,12,15,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,5874,194,'Legalox_Heftyhind',1200,0,3080,1800,0,32,33,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (8,6429,194,'Fetor_Bats',300,0,82,0,0,81,83,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (9,6413,194,'Fuligo',300,0,1190,0,0,84,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (10,439,194,'Black_Slime',300,0,15,0,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1517,194,'Ghoul_war',300,0,961,0,0,23,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,771,194,'Combat',300,0,3372,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,4568,194,'Ah_Puch',0,32,2836,0,0,29,30,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (14,6462,194,'Thorn_Bat',300,0,461,0,0,82,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (15,4061,194,'Two_of_Cups',300,0,2506,0,0,1,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,4059,194,'Two_of_Batons',300,0,2504,0,0,1,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,4062,194,'Two_of_Swords',300,0,2507,0,0,1,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4060,194,'Two_of_Coins',300,0,2505,0,0,1,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3905,194,'Three_of_Cups',300,0,2408,0,0,5,9,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3903,194,'Three_of_Batons',300,0,2406,0,0,5,9,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3906,194,'Three_of_Swords',300,0,2409,0,0,5,9,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,3904,194,'Three_of_Coins',300,0,2407,0,0,5,9,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1417,194,'Four_of_Cups',300,0,902,0,0,10,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1415,194,'Four_of_Batons',300,0,300,0,0,10,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1418,194,'Four_of_Swords',300,0,903,0,0,10,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1416,194,'Four_of_Coins',300,0,901,0,0,10,14,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1352,194,'Five_of_Cups',300,0,838,0,0,15,19,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1350,194,'Five_of_Batons',300,0,836,0,0,15,19,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1353,194,'Five_of_Swords',300,0,839,0,0,15,19,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,1351,194,'Five_of_Coins',300,0,837,0,0,15,19,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,3639,194,'Six_of_Cups',300,0,2262,0,0,20,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,3637,194,'Six_of_Batons',300,0,2260,0,0,20,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,3640,194,'Six_of_Swords',300,0,2263,0,0,20,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,3638,194,'Six_of_Coins',300,0,2261,0,0,20,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1185,194,'Eight_of_Cups',300,0,749,0,0,30,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1183,194,'Eight_of_Batons',300,0,747,0,0,30,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1186,194,'Eight_of_Swords',300,0,750,0,0,30,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1184,194,'Eight_of_Coins',300,0,748,0,0,30,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,900,194,'Dancing_Weapon',300,0,0,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,3555,194,'Seven_of_Cups',300,0,2207,0,0,25,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,3553,194,'Seven_of_Batons',300,0,2205,0,0,25,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,3556,194,'Seven_of_Swords',300,0,2208,0,0,25,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,3554,194,'Seven_of_Coins',300,0,2206,0,0,25,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,2883,194,'Nine_of_Batons',300,0,1811,0,0,35,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,2885,194,'Nine_of_Cups',300,0,1813,0,0,35,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,2886,194,'Nine_of_Swords',300,0,1814,0,0,35,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,2884,194,'Nine_of_Coins',300,0,1812,0,0,35,39,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,3878,194,'Ten_of_Cups',300,0,2392,0,0,40,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,3876,194,'Ten_of_Batons',300,0,2390,0,0,40,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,3879,194,'Ten_of_Swords',300,0,2393,0,0,40,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,3877,194,'Ten_of_Coins',300,0,2391,0,0,40,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,6584,194,'Balloon',300,0,220,0,0,8,10,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,495,194,'Bomb_King',0,128,333,1050,0,16,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,1090,194,'Doppelganger_Gog',0,128,691,650,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,1089,194,'Doppelganger_Dio',0,128,690,750,0,23,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,372,194,'Battue_Bats',300,0,244,0,0,1,5,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,1737,194,'Goblin_Thug',300,0,1170,0,0,1,7,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,1744,194,'Goblin_Weaver',300,0,1183,0,0,1,7,0,NULL);
+INSERT INTO `mob_groups` VALUES (59,443,194,'Blade_Bat',300,0,461,0,0,4,7,0,NULL);
+INSERT INTO `mob_groups` VALUES (60,2120,194,'Jack_of_Cups',0,128,1386,0,0,62,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (61,2118,194,'Jack_of_Batons',0,128,1384,0,0,62,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (62,2121,194,'Jack_of_Swords',0,128,1387,0,0,62,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (63,2119,194,'Jack_of_Coins',0,128,1385,0,0,62,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (64,3286,194,'Queen_of_Swords',0,128,2065,0,0,72,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (65,3284,194,'Queen_of_Coins',0,128,2063,0,0,72,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (66,5529,194,'Thunder_Elemental',300,4,2410,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (67,870,194,'Custom_Cardian',0,128,0,0,0,1,1,0,NULL);
+INSERT INTO `mob_groups` VALUES (68,1518,194,'Ghoul_blm',300,0,961,0,0,23,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (69,6724,194,'Voidwrought',0,128,0,0,0,0,0,0,NULL); -- TODO: capture level from retail
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- The_Eldieme_Necropolis (Zone 195)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,2408,195,'Lich_C_Magnus',0,128,2869,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,3655,195,'Skull_of_Gluttony',0,128,2871,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,3656,195,'Skull_of_Greed',0,128,2872,0,0,0,NULL);
@@ -13385,6 +17506,66 @@ INSERT INTO `mob_groups` VALUES (55,5535,195,'Ice_Elemental',0,128,1347,0,0,0,NU
 INSERT INTO `mob_groups` VALUES (56,2802,195,'Namorodo',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (57,5179,195,'Gasha-1stform',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (58,6561,195,'Lost_Soul_war',300,0,769,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,2408,195,'Lich_C_Magnus',0,128,2869,0,0,58,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,3655,195,'Skull_of_Gluttony',0,128,2871,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,3656,195,'Skull_of_Greed',0,128,2872,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,3659,195,'Skull_of_Sloth',0,128,2875,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,3657,195,'Skull_of_Lust',0,128,2873,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3658,195,'Skull_of_Pride',0,128,2874,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,3654,195,'Skull_of_Envy',0,128,2870,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3660,195,'Skull_of_Wrath',0,128,2876,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2559,195,'Marchosias',960,0,226,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,6560,195,'Lost_Soul_blm',960,0,769,0,0,42,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,3559,195,'Shade_war',960,0,2883,0,0,46,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,5402,195,'Shade_rng',960,0,2883,0,0,46,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,5401,195,'Shade_thf',960,0,2883,0,5000,46,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,5400,195,'Shade_drk',960,0,2883,0,0,46,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,6531,195,'Hellbound_Warrior',300,0,0,0,0,91,95,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (16,6536,195,'Hellbound_Warlock',300,0,769,0,0,91,95,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (17,6511,195,'Revenant',960,0,2093,0,0,44,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1926,195,'Hell_Hound',960,0,226,0,0,46,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,136,195,'Anemone',960,0,92,0,0,45,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1481,195,'Gazer',960,0,942,0,0,41,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,6589,195,'Puroboros',960,0,2042,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,2770,195,'Mummy',960,0,1753,0,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,2407,195,'Lich',960,0,1518,0,0,51,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,473,195,'Blood_Soul',960,0,312,0,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,2176,195,'Ka_war',960,0,2884,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,5405,195,'Ka_blm',960,0,2884,0,5000,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,5406,195,'Ka_rng',960,0,2884,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,5407,195,'Ka_thf',960,0,2884,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,3945,195,'Tomb_Wolf',960,0,2887,0,0,53,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,876,195,'Cwn_Cyrff',0,32,2886,0,0,68,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,6512,195,'Utukku',960,0,2529,0,0,55,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,6171,195,'Nekros_Hound',960,0,1297,0,0,93,95,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (33,918,195,'Dark_Stalker_war',960,0,554,0,0,57,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,5410,195,'Dark_Stalker_blm',960,0,554,0,5000,57,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,5412,195,'Dark_Stalker_thf',960,0,570,0,0,57,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,5411,195,'Dark_Stalker_rng',960,0,554,0,0,57,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,310,195,'Azer',960,0,3360,0,0,51,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,6545,195,'Fallen_Knight',960,0,811,0,0,54,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,2043,195,'Ice_Elemental',960,4,1347,0,0,52,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,1160,195,'Earth_Elemental',960,4,733,0,0,52,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,6508,195,'Haunt',960,0,1282,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,3944,195,'Tomb_Warrior',960,0,2425,0,0,60,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,3943,195,'Tomb_Mage',960,0,2424,0,0,60,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,3741,195,'Spriggan_war',960,0,2311,0,0,64,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,5415,195,'Spriggan_blm',960,0,2311,0,5000,64,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,5416,195,'Spriggan_thf',960,0,2311,0,0,64,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,5414,195,'Spriggan_rng',960,0,2311,0,0,64,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,4484,195,'Yum_Kimil',0,128,0,0,0,54,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (49,1075,195,'Dog_Guardian',0,128,0,0,0,52,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (50,3081,195,'Owl_Guardian',0,128,0,0,0,52,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (51,3799,195,'Sturm',0,128,0,12500,0,62,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (52,3834,195,'Taifun',0,128,0,3000,0,58,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (53,4038,195,'Trombe',0,128,0,3000,0,58,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (54,2664,195,'Mimic',0,128,1688,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (55,5535,195,'Ice_Elemental',0,128,1347,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (56,2802,195,'Namorodo',0,128,0,0,0,61,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (57,5179,195,'Gasha-1stform',0,128,0,0,0,94,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (58,6561,195,'Lost_Soul_war',960,0,769,0,0,42,46,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Gusgen_Mines (Zone 196)
@@ -13396,6 +17577,7 @@ INSERT INTO `mob_groups` VALUES (2,5868,196,'Greater_Pugil_fished',0,128,1232,0,
 INSERT INTO `mob_groups` VALUES (3,6789,196,'Ooze_fished',0,128,15,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,2774,196,'Mush',0,128,15,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (5,452,196,'Blind_Moby',0,128,295,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,3680,196,'Smothered_Schmidt',0,128,181,2050,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,845,196,'Crushed_Krause',0,128,538,2050,0,0,NULL);
@@ -13438,11 +17620,56 @@ INSERT INTO `mob_groups` VALUES (43,5311,196,'Lorbulcrud',0,128,0,0,99999,0,NULL
 INSERT INTO `mob_groups` VALUES (44,6552,196,'Ghoul_blm',300,0,962,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (45,6570,196,'Wight_blm',300,0,2653,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (46,1807,196,'Greater_Pugil',300,0,1232,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (5,452,196,'Blind_Moby',0,128,295,0,0,25,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3680,196,'Smothered_Schmidt',0,128,181,2050,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,845,196,'Crushed_Krause',0,128,538,2050,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,3226,196,'Pulverized_Pfeffer',0,128,2040,2050,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,585,196,'Burned_Bergmann',0,128,391,2050,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,4378,196,'Wounded_Wurfel',0,128,2674,2050,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,267,196,'Asphyxiated_Amsel',0,128,182,2050,0,36,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,6565,196,'Skeleton_Warrior',300,0,769,0,0,15,17,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1376,196,'Fly_Agaric',300,0,854,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,6551,196,'Ghoul_war',300,0,962,0,0,20,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,335,196,'Bandersnatch',300,0,219,0,0,21,24,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,3050,196,'Ore_Eater',300,0,428,0,0,23,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,6590,196,'Spunkie',300,0,2315,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,485,196,'Bogy',300,0,325,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,4319,196,'Wendigo_war',300,0,2639,0,0,26,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3435,196,'Sadfly',300,0,926,0,0,27,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,2146,196,'Jelly',300,0,15,0,0,27,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,6572,196,'Wight_war',300,0,2653,0,0,30,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,6532,196,'Accursed_Soldier',300,0,678,0,0,85,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (24,6537,196,'Accursed_Sorcerer',300,0,769,0,0,85,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (25,6802,196,'Madfly',300,0,923,0,0,85,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (26,6416,196,'Rockmill',300,0,428,0,0,85,89,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (27,6528,196,'Mauthe_Doog',300,0,1643,0,0,28,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,2783,196,'Myconid',300,0,1760,0,0,30,32,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1329,196,'Feu_Follet',300,0,827,0,0,35,38,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,3912,196,'Thunder_Elemental',300,4,2412,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,1160,196,'Earth_Elemental',300,4,735,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,2165,196,'Juggler_Hecatomb',86400,0,1417,6950,0,46,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,3320,196,'Rancid_Ooze',300,0,2075,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,4943,196,'Gallinipper',300,0,926,0,0,32,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,113,196,'Amphisbaena',300,0,74,0,0,28,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,6502,196,'Banshee',300,0,224,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,6550,196,'Ghast_blm',300,0,955,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,1412,196,'Foul_Meat',64800,0,899,1850,0,43,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,4284,196,'Wandering_Ghost',0,128,2615,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,3218,196,'Pudding',0,128,0,0,0,34,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,5530,196,'Earth_Elemental',0,128,733,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,251,196,'Aroma_Fly',0,128,0,0,0,44,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,5311,196,'Lorbulcrud',0,128,0,0,99999,90,92,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,6552,196,'Ghoul_blm',300,0,962,0,0,20,27,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,6570,196,'Wight_blm',300,0,2653,0,0,30,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,1807,196,'Greater_Pugil',300,0,1232,0,0,29,31,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Crawlers_Nest (Zone 197)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,1830,197,'Guardian_Crawler',0,128,1244,2100,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,1123,197,'Drone_Crawler',0,128,711,2560,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,3281,197,'Queen_Crawler',0,128,1641,3720,0,0,NULL);
@@ -13483,11 +17710,54 @@ INSERT INTO `mob_groups` VALUES (37,1113,197,'Dreadbug',0,128,703,5750,0,0,NULL)
 INSERT INTO `mob_groups` VALUES (38,2664,197,'Mimic',0,128,1689,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (39,5532,197,'Water_Elemental',0,128,2629,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (40,4704,197,'Mellonia',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,1830,197,'Guardian_Crawler',0,128,1244,2100,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,1123,197,'Drone_Crawler',0,128,711,2560,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,3281,197,'Queen_Crawler',0,128,1641,3720,0,64,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,2586,197,'Matron_Crawler',0,128,1641,3800,0,64,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,297,197,'Awd_Goggie',0,128,197,4170,0,68,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,6316,197,'Worker_Crawler',300,0,256,0,0,40,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,6305,197,'Death_Jacket',300,0,586,0,0,40,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,2598,197,'Maze_Lizard',300,0,1645,0,0,41,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2229,197,'Killer_Mushroom',300,0,1439,0,0,45,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1084,197,'Doom_Scorpion',300,0,682,0,0,45,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,661,197,'Caveberry',300,0,433,0,0,42,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,2835,197,'Nest_Beetle',300,0,1778,0,0,45,47,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,3697,197,'Soldier_Crawler',300,0,256,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1990,197,'Hornfly',300,0,1330,0,0,50,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1271,197,'Exoray',300,0,800,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,5839,197,'King_Crawler',300,0,3008,0,0,91,96,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3335,197,'Vespo',300,0,584,0,0,92,96,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6325,197,'Dancing_Jewel',300,0,923,0,0,93,96,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,6344,197,'Olid_Funguar',300,0,1440,0,0,93,96,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1341,197,'Fire_Elemental',300,4,832,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,4309,197,'Water_Elemental',300,4,2631,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,447,197,'Blazer_Beetle',300,0,292,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,5854,197,'Dynast_Beetle',0,128,3065,5500,0,56,56,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (24,6075,197,'Helm_Beetle',300,0,1298,0,0,59,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,6318,197,'Knight_Crawler',300,0,1457,0,0,60,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,3232,197,'Puroboros',3600,0,2043,0,0,45,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,6720,197,'Labyrinth_Lizard',300,0,1474,0,0,49,51,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,4354,197,'Witch_Hazel',300,0,3361,0,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,3707,197,'Soul_Stinger',300,0,2295,0,0,48,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,6332,197,'Mushussu',300,0,1756,0,0,53,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,7035,197,'Rumble_Crawler',300,0,2132,0,0,53,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,4322,197,'Wespe',300,0,2644,0,0,55,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,979,197,'Demonic_Tiphia',0,32,610,10000,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1099,197,'Dragonfly',300,0,697,0,0,55,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,832,197,'Crawler_Hunter',300,0,531,0,0,60,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,4705,197,'Aqrabuamelu',7200,0,2947,7500,0,72,75,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (37,1113,197,'Dreadbug',0,128,703,5000,0,52,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,2664,197,'Mimic',0,128,1689,0,0,55,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,5532,197,'Water_Elemental',0,128,2629,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,4704,197,'Mellonia',0,128,0,0,0,94,95,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Maze_of_Shakhrami (Zone 198)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,2046,198,'Ichorous_Ire',0,128,1348,1200,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,1635,198,'Goblin_Ambusher',300,0,1018,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1738,198,'Goblin_Tinkerer',300,0,1035,0,0,0,NULL);
@@ -13533,11 +17803,59 @@ INSERT INTO `mob_groups` VALUES (42,4675,198,'Lost_Soul_NM',0,128,0,5650,0,0,NUL
 INSERT INTO `mob_groups` VALUES (43,5161,198,'Ogbunabali',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (44,250,198,'Aroma_Crawler',0,128,0,3410,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (45,6570,198,'Wight_blm',300,0,2654,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,2046,198,'Ichorous_Ire',0,128,1348,1200,0,35,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,1635,198,'Goblin_Ambusher',300,0,1018,0,0,16,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1738,198,'Goblin_Tinkerer',300,0,1035,0,0,16,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,1643,198,'Goblin_Butcher',300,0,1035,0,0,16,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,2599,198,'Maze_Maker',300,0,428,0,0,18,21,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,3775,198,'Stink_Bats',300,0,82,0,0,15,18,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,6455,198,'Combat',300,0,461,0,0,20,23,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,6313,198,'Carnivorous_Crawler',300,0,423,0,0,22,25,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,5770,198,'Trembler_Tabitha',0,32,3054,1300,0,55,55,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (10,2600,198,'Maze_Scorpion',300,0,1647,0,0,25,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1690,198,'Goblin_Mugger',300,0,1119,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1683,198,'Goblin_Leecher',300,0,1099,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1666,198,'Goblin_Gambler',300,0,1082,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,6551,198,'Ghoul_war',300,0,959,0,0,22,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,6568,198,'Wendigo_blm',300,0,3254,0,0,24,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,6408,198,'Jelly',300,0,1190,0,0,26,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3165,198,'Poison_Leech',300,0,18,0,0,24,28,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,6401,198,'Bleeder_Leech',300,0,18,0,0,83,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (19,71,198,'Air_Elemental',300,4,40,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,1160,198,'Earth_Elemental',300,4,736,0,0,33,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,6437,198,'Chaser_Bats',300,0,82,0,0,83,85,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (22,6314,198,'Crypterpillar',300,0,422,0,0,86,88,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (23,6451,198,'Warren_Bat',300,0,461,0,0,86,88,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (24,120,198,'Ancient_Bat',300,0,461,0,0,26,29,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,3537,198,'Seeker_Bats',300,0,82,0,0,23,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,5893,198,'Gloombound_Lurker',5400,0,3092,3700,0,47,48,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (27,28,198,'Abyss_Worm',300,0,8,0,0,27,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,4337,198,'Wight_war',300,0,2654,0,0,32,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,2313,198,'Labyrinth_Scorpion',300,0,1476,0,0,30,33,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,3211,198,'Protozoan',300,0,2027,0,0,29,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,5894,198,'Lesath',3600,0,3093,3230,0,43,44,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (32,658,198,'Caterchipillar',300,0,430,0,0,29,31,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1694,198,'Goblin_Pathfinder',300,0,1126,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1720,198,'Goblins_Bat',0,128,0,0,0,24,26,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,1665,198,'Goblin_Furrier',300,0,1067,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1715,198,'Goblin_Smithy',300,0,1165,0,0,31,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1710,198,'Goblin_Shaman',300,0,1151,0,0,30,34,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,228,198,'Argus',0,128,165,3700,0,36,37,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,2386,198,'Leech_King',0,128,1505,1960,0,35,36,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,4386,198,'Wyrmfly',0,128,0,0,0,30,30,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,5533,198,'Dark_Elemental',0,128,568,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,4675,198,'Lost_Soul_NM',0,128,0,3500,0,50,50,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,5161,198,'Ogbunabali',0,128,0,0,0,94,95,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,250,198,'Aroma_Crawler',0,128,0,0,0,44,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,6570,198,'Wight_blm',300,0,2654,0,0,32,35,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Garlaige_Citadel (Zone 200)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,512,200,'Borer_Beetle',300,0,340,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,3619,200,'Siege_Bat',300,0,2246,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,6439,200,'Wingrats',300,0,2662,0,0,0,NULL);
@@ -13586,6 +17904,56 @@ INSERT INTO `mob_groups` VALUES (45,6544,200,'Fallen_Evacuee_war',300,0,809,0,0,
 INSERT INTO `mob_groups` VALUES (46,6547,200,'Fallen_Officer_war',300,0,814,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (47,6548,200,'Fallen_Soldier_war',300,0,815,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (48,6891,200,'Mephitas',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,512,200,'Borer_Beetle',300,0,340,0,0,41,44,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,3619,200,'Siege_Bat',300,0,2246,0,0,40,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,6439,200,'Wingrats',300,0,2662,0,0,40,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,1283,200,'Fallen_Evacuee_blm',300,0,809,0,0,42,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,6589,200,'Puroboros',300,0,569,0,0,43,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,2958,200,'Oil_Spill',300,0,1845,0,0,43,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,6596,200,'Clockwork_Pod',300,0,485,0,0,44,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,6511,200,'Revenant',300,0,2093,0,0,44,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,731,200,'Citadel_Bats',300,0,473,0,0,46,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,980,200,'Demonic_Weapon',300,0,0,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1291,200,'Fallen_Soldier_blm',300,0,815,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,407,200,'Bhuta',300,0,264,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,2968,200,'Old_Two-Wings',0,128,1851,0,0,52,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,3648,200,'Skewer_Sam',0,128,2266,0,0,54,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,6425,200,'Fortalice_Bats',300,0,82,0,0,92,96,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (16,1328,200,'Fetid_Flesh',300,0,826,0,0,54,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,5767,200,'Hazmat',0,32,3051,0,0,57,58,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (18,1275,200,'Explosure',300,0,802,0,0,52,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1160,200,'Earth_Elemental',300,4,733,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,6597,200,'Droma',300,0,708,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,3912,200,'Thunder_Elemental',300,4,2413,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1290,200,'Fallen_Officer_blm',300,0,814,0,0,52,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,692,200,'Chandelier',0,128,451,3500,0,63,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,38,200,'Acid_Grease',300,0,16,0,0,52,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,4379,200,'Wraith',300,0,2675,0,0,60,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,689,200,'Chamber_Beetle',300,0,448,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,6484,200,'Tainted_Flesh',300,0,2372,0,0,63,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1922,200,'Hellmine',300,0,1295,0,0,59,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,6588,200,'Kaboom',300,0,1296,0,0,91,96,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (30,3078,200,'Over_Weapon',300,0,1968,0,0,59,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,4207,200,'Vault_Weapon',300,0,1968,0,0,59,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1289,200,'Fallen_Major',300,0,813,0,0,59,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1288,200,'Fallen_Mage',300,0,812,0,0,59,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,5841,200,'Hovering_Hotpot',0,32,3010,7000,9999,58,60,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (35,6072,200,'Warden_Beetle',300,0,670,0,0,92,96,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (36,6424,200,'Funnel_Bats',300,0,919,0,0,51,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,1831,200,'Guardian_Statue',0,128,1245,0,0,61,61,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,2478,200,'Magic_Jug',300,0,1566,0,0,62,64,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,5888,200,'Frogamander',7200,0,3087,7000,0,71,73,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (40,6463,200,'Donjon_Bat',300,0,461,0,0,91,96,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (41,3549,200,'Serket',0,128,2203,50000,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,2664,200,'Mimic',0,128,1690,0,0,60,60,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,5531,200,'Light_Elemental',0,128,1521,0,0,75,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,5147,200,'Roly-Poly',0,128,0,0,9999,91,93,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,6544,200,'Fallen_Evacuee_war',300,0,809,0,0,42,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,6547,200,'Fallen_Officer_war',300,0,814,0,0,52,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (47,6548,200,'Fallen_Soldier_war',300,0,815,0,0,47,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (48,6891,200,'Mephitas',0,128,0,0,0,99,99,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Cloister_of_Gales (Zone 201)
@@ -13631,6 +17999,7 @@ INSERT INTO `mob_groups` VALUES (7,4642,203,'Shiva_Prime_HTBF',0,128,0,0,0,0,NUL
 -- FeiYin (Zone 204)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,4092,204,'Undead_Bats',300,0,80,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,3358,204,'Revenant',300,0,2093,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1122,204,'Drone',300,0,192,0,0,0,NULL);
@@ -13676,6 +18045,53 @@ INSERT INTO `mob_groups` VALUES (42,6894,204,'Australis_Shadow',0,128,0,0,0,0,NU
 INSERT INTO `mob_groups` VALUES (43,6895,204,'Occidentalis_Shadow',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (44,6896,204,'Carousing_Celine',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (45,6889,204,'Arcus_Blades',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,4092,204,'Undead_Bats',960,0,80,0,0,38,40,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,3358,204,'Revenant',960,0,2093,0,0,40,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1122,204,'Drone',960,0,192,0,0,41,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,5132,204,'Vampire_Bat',960,0,386,0,0,40,42,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,5323,204,'Sluagh',7200,0,3363,10000,0,77,80,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (6,99,204,'Altedour_I_Tavnazia',0,128,54,20000,20000,65,65,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,5324,204,'Jenglot',7200,0,3362,0,0,73,73,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (8,744,204,'Clockwork_Pod',960,0,486,0,0,41,43,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2678,204,'Miser_Murphy',0,128,1700,7500,0,62,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,3051,204,'Ore_Golem',960,0,1956,0,0,43,45,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,5765,204,'Mind_Hoarder',0,32,3049,7100,0,61,62,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (12,3561,204,'Shadow_war',960,0,2211,0,0,44,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,5319,204,'Shadow_rng',960,0,2211,0,0,44,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,5317,204,'Shadow_blm',960,0,2211,0,0,44,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,5318,204,'Shadow_thf',960,0,2211,0,0,44,46,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,6513,204,'Wekufe',300,0,2530,0,0,97,99,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (17,6598,204,'Sentient_Carafe',300,0,3191,0,0,95,99,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (18,6474,204,'Balayang',300,0,3190,0,0,95,99,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (19,4098,204,'Underworld_Bats',960,0,2520,0,0,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,3841,204,'Talos',960,0,192,0,0,53,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,1120,204,'Droma',960,0,709,0,0,54,56,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,6453,204,'Camazotz',960,0,380,0,0,51,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,6512,204,'Utukku',960,0,2880,0,0,55,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,3723,204,'Specter_war',300,0,2302,0,0,55,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,5320,204,'Specter_blm',300,0,2302,0,0,55,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,5321,204,'Specter_thf',300,0,2302,0,0,55,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,5322,204,'Specter_rng',300,0,2302,0,0,55,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,770,204,'Colossus',960,0,505,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,2043,204,'Ice_Elemental',960,4,1347,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,913,204,'Dark_Elemental',960,4,568,0,0,56,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,2231,204,'Killing_Weapon',960,0,0,0,0,59,61,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,1921,204,'Hellish_Weapon',960,0,1294,0,0,61,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,1754,204,'Goliath',0,32,1195,3500,0,62,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,4323,204,'Western_Shadow',0,32,2645,3750,0,63,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,2907,204,'Northern_Shadow',0,32,1823,3500,0,63,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1164,204,'Eastern_Shadow',0,32,738,3400,0,63,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,3709,204,'Southern_Shadow',0,32,2296,3550,0,63,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,888,204,'Dabotzs_Ghost',0,128,0,0,0,53,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,630,204,'Capricious_Cassie',0,128,411,43000,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,6892,204,'Orientalis_Shadow',0,128,0,0,0,128,128,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,6893,204,'Borealis_Shadow',0,128,0,0,0,128,128,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,6894,204,'Australis_Shadow',0,128,0,0,0,128,128,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,6895,204,'Occidentalis_Shadow',0,128,0,0,0,128,128,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,6896,204,'Carousing_Celine',0,128,0,0,0,128,128,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,6889,204,'Arcus_Blades',0,128,0,0,0,125,125,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Ifrits_Cauldron (Zone 205)
@@ -13895,6 +18311,7 @@ INSERT INTO `mob_groups` VALUES (6,4646,211,'Leviathan_Prime_HTBF',0,128,0,0,0,0
 -- Gustav_Tunnel (Zone 212)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,1804,212,'Greater_Gaylas',300,0,234,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,1701,212,'Goblin_Poacher',300,0,1139,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1709,212,'Goblin_Robber',300,0,1147,0,0,0,NULL);
@@ -13939,11 +18356,58 @@ INSERT INTO `mob_groups` VALUES (41,6905,212,'Bompupu',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (42,6906,212,'Wyvernhunter_Bambrox',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (43,7303,212,'Goblin_Mine',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (44,7179,212,'Goblin_Mine',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,1804,212,'Greater_Gaylas',300,0,234,0,0,46,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,1701,212,'Goblin_Poacher',300,0,1139,0,0,46,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1709,212,'Goblin_Robber',300,0,1147,0,0,46,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,2311,212,'Labyrinth_Lizard',300,0,221,0,0,46,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,2310,212,'Labyrinth_Leech',300,0,174,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,584,212,'Bune',0,128,389,13300,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1924,212,'Hell_Bat',300,0,234,0,0,44,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1705,212,'Goblin_Reaper',300,0,1141,0,0,46,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,1901,212,'Hawker',300,0,571,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1632,212,'Goblinsavior_Heronox',0,32,1012,8000,0,51,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,2491,212,'Makara',300,0,279,0,0,46,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,3375,212,'Robber_Crab',300,0,2111,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,1687,212,'Goblin_Mercenary',300,0,1115,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1634,212,'Goblin_Alchemist',300,0,1014,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1711,212,'Goblin_Shepherd',300,0,1156,0,0,65,68,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,1728,212,'Goblins_Leech',0,128,0,0,0,53,55,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,4390,212,'Wyvernpoacher_Drachlox',0,32,2680,7500,0,70,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,1085,212,'Doom_Soldier',300,0,686,0,0,65,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,1083,212,'Doom_Mage',300,0,676,0,0,65,67,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,4580,212,'Boulder_Eater',300,0,2816,0,0,100,105,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (21,4579,212,'Pygmytoise',300,0,2815,0,0,100,103,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (22,1160,212,'Earth_Elemental',300,4,733,0,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,1082,212,'Doom_Guard',300,0,675,0,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,1087,212,'Doom_Warlock',300,0,688,0,0,76,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,1341,212,'Fire_Elemental',300,4,831,0,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,4065,212,'Typhoon_Wyvern',300,0,42,0,0,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,976,212,'Demonic_Pugil',300,0,463,0,0,73,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1255,212,'Erlik',1200,0,790,0,0,75,78,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,339,212,'Baobhan_Sith',0,32,225,7000,0,79,81,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,6334,212,'Antares',960,0,629,0,0,77,79,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,3856,212,'Taxim',0,32,2385,6500,6500,78,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,4100,212,'Ungur',0,32,2521,16000,0,81,83,0,NULL);
+INSERT INTO `mob_groups` VALUES (33,109,212,'Amikiri',0,32,72,27000,0,80,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,1550,212,'Gigaplasm',0,128,0,4500,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,2469,212,'Macroplasm',0,128,0,3000,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,2648,212,'Microplasm',0,128,0,1050,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (37,2806,212,'Nanoplasm',0,128,0,850,0,70,70,0,NULL);
+INSERT INTO `mob_groups` VALUES (38,348,212,'Baronial_Bat',0,128,0,10500,0,82,82,0,NULL);
+INSERT INTO `mob_groups` VALUES (39,6903,212,'Renfred',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,6904,212,'Gorattz',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,6905,212,'Bompupu',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (42,6906,212,'Wyvernhunter_Bambrox',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (43,1688,212,'Goblin_Mine',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,7179,212,'Goblin_Mine',0,128,0,0,0,0,0,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Labyrinth_of_Onzozo (Zone 213)
 -- ------------------------------------------------------------
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (1,1701,213,'Goblin_Poacher',300,0,1139,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,1709,213,'Goblin_Robber',300,0,1147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (3,1705,213,'Goblin_Reaper',300,0,1141,0,0,0,NULL);
@@ -13980,6 +18444,44 @@ INSERT INTO `mob_groups` VALUES (33,4074,213,'Ubume',0,128,0,5600,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (34,2612,213,'Megapod_Megalops',0,128,0,9800,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (35,6907,213,'Voso',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (36,1728,213,'Goblins_Leech_HI',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (1,1701,213,'Goblin_Poacher',300,0,1139,0,0,46,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (2,1709,213,'Goblin_Robber',300,0,1147,0,0,46,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,1705,213,'Goblin_Reaper',300,0,1141,0,0,46,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (4,2310,213,'Labyrinth_Leech',300,0,1472,0,0,45,48,0,NULL);
+INSERT INTO `mob_groups` VALUES (5,71,213,'Air_Elemental',960,4,38,0,0,60,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (6,758,213,'Cockatrice',300,0,495,0,0,50,53,0,NULL);
+INSERT INTO `mob_groups` VALUES (7,1741,213,'Goblin_Trader',300,0,1180,0,0,46,49,0,NULL);
+INSERT INTO `mob_groups` VALUES (8,1728,213,'Goblins_Leech',0,128,0,0,0,33,35,0,NULL);
+INSERT INTO `mob_groups` VALUES (9,2775,213,'Mushussu',300,0,1757,0,0,51,57,0,NULL);
+INSERT INTO `mob_groups` VALUES (10,1689,213,'Goblin_Miner',300,0,1116,0,0,51,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (11,1641,213,'Goblin_Bouncer',300,0,1029,0,0,51,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (12,1677,213,'Goblin_Hunter',300,0,1094,0,0,51,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (13,2790,213,'Mysticmaker_Profblix',0,128,1763,4500,4500,50,52,0,NULL);
+INSERT INTO `mob_groups` VALUES (14,1654,213,'Goblin_Enchanter',300,0,1049,0,0,51,58,0,NULL);
+INSERT INTO `mob_groups` VALUES (15,1373,213,'Flying_Manta',300,0,851,0,0,55,59,0,NULL);
+INSERT INTO `mob_groups` VALUES (16,2439,213,'Lord_of_Onzozo',0,32,1536,13500,13500,74,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (17,3113,213,'Peg_Powler',0,32,1985,10500,0,61,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (18,4309,213,'Water_Elemental',960,4,2629,0,0,60,62,0,NULL);
+INSERT INTO `mob_groups` VALUES (19,3976,213,'Torama',300,0,2455,0,0,70,73,0,NULL);
+INSERT INTO `mob_groups` VALUES (20,2312,213,'Labyrinth_Manticore',300,0,1475,0,0,71,74,0,NULL);
+INSERT INTO `mob_groups` VALUES (21,2809,213,'Narasimha',0,32,1776,21000,0,75,77,0,NULL);
+INSERT INTO `mob_groups` VALUES (22,1920,213,'Hellion',0,32,1293,15600,0,66,66,0,NULL);
+INSERT INTO `mob_groups` VALUES (23,3835,213,'Tainted_Flesh',300,0,2373,0,0,60,63,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,3706,213,'Soulstealer_Skullnix',0,32,2294,8000,0,69,72,0,NULL);
+INSERT INTO `mob_groups` VALUES (25,3063,213,'Ose',0,32,1960,9400,0,74,76,0,NULL);
+INSERT INTO `mob_groups` VALUES (26,1634,213,'Goblin_Alchemist',300,0,1014,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (27,1637,213,'Goblin_Bandit',300,0,1022,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,1711,213,'Goblin_Shepherd',300,0,1156,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (29,1687,213,'Goblin_Mercenary',900,0,1115,0,0,66,69,0,NULL);
+INSERT INTO `mob_groups` VALUES (30,4389,213,'Wyvern',300,0,2677,0,0,72,75,0,NULL);
+INSERT INTO `mob_groups` VALUES (31,6542,213,'Babaulas',300,0,3194,0,0,95,98,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (32,6538,213,'Boribaba',300,0,3194,0,0,95,98,0,'ABYSSEA');
+INSERT INTO `mob_groups` VALUES (33,4074,213,'Ubume',0,128,0,5600,0,54,54,0,NULL);
+INSERT INTO `mob_groups` VALUES (34,2612,213,'Megapod_Megalops',0,128,0,9800,0,80,80,0,NULL);
+INSERT INTO `mob_groups` VALUES (35,6907,213,'Voso',0,128,0,0,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (36,1728,213,'Goblins_Leech_HI',0,128,0,0,0,49,50,0,NULL);
+>>>>>>> 6b2ffc69b6 ([sql] Mob content tag audits)
 
 -- ------------------------------------------------------------
 -- Abyssea-Attohwa (Zone 215)

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -8305,6 +8305,7 @@ INSERT INTO `mob_groups` VALUES (3,1991,110,'Horrid_Fluke',0,128,895,0,0,0,NULL)
 INSERT INTO `mob_groups` VALUES (4,5868,110,'Greater_Pugil_fished',0,128,147,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,418,110,'Big_Leech',0,128,79,0,0,0,NULL);
 
+<<<<<<< HEAD
 INSERT INTO `mob_groups` VALUES (6,3625,110,'Silk_Caterpillar',0,128,2248,700,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (7,941,110,'Death_Wasp',300,0,584,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (8,2735,110,'Moon_Bat',300,2,461,0,0,0,NULL);
@@ -8344,6 +8345,47 @@ INSERT INTO `mob_groups` VALUES (41,3630,110,'Simurgh',0,128,2255,51000,0,0,NULL
 INSERT INTO `mob_groups` VALUES (42,3745,110,'Sprite',0,128,2001,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (43,4107,110,'Urayuli',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (44,726,110,'Chuglix_Berrypaws',0,128,0,0,0,0,NULL);
+=======
+INSERT INTO `mob_groups` VALUES (6,3625,110,'Silk_Caterpillar',0,128,2248,700,0,28,30,0);
+INSERT INTO `mob_groups` VALUES (7,941,110,'Death_Wasp',300,0,584,0,0,22,26,0);
+INSERT INTO `mob_groups` VALUES (8,2735,110,'Moon_Bat',300,2,461,0,0,23,26,0);
+INSERT INTO `mob_groups` VALUES (9,1757,110,'Goobbue_Farmer',300,0,1200,0,0,28,32,0);
+INSERT INTO `mob_groups` VALUES (10,394,110,'Berry_Grub',300,0,256,0,0,25,28,0);
+INSERT INTO `mob_groups` VALUES (11,2965,110,'Old_Quadav',300,0,1848,0,0,26,30,0);
+INSERT INTO `mob_groups` VALUES (12,791,110,'Copper_Quadav',300,0,361,0,0,26,30,0);
+INSERT INTO `mob_groups` VALUES (13,538,110,'Bronze_Quadav',300,0,361,0,0,30,36,0);
+INSERT INTO `mob_groups` VALUES (14,525,110,'Brass_Quadav',300,0,351,0,0,26,30,0);
+INSERT INTO `mob_groups` VALUES (15,3628,110,'Silver_Quadav',300,0,361,0,0,30,36,0);
+INSERT INTO `mob_groups` VALUES (16,4506,110,'Zircon_Quadav',300,0,361,0,0,30,36,0);
+INSERT INTO `mob_groups` VALUES (17,1472,110,'Garnet_Quadav',300,0,935,0,0,30,36,0);
+INSERT INTO `mob_groups` VALUES (18,4337,110,'Wight_war',300,1,2651,0,0,26,36,0);
+INSERT INTO `mob_groups` VALUES (19,1341,110,'Fire_Elemental',300,4,831,0,0,38,40,0);
+INSERT INTO `mob_groups` VALUES (20,2940,110,'Ochu',300,0,1837,0,0,34,37,0);
+INSERT INTO `mob_groups` VALUES (21,2649,110,'Midnight_Wings',300,2,82,0,0,20,23,0);
+INSERT INTO `mob_groups` VALUES (22,1690,110,'Goblin_Mugger',300,0,1117,0,0,26,30,0);
+INSERT INTO `mob_groups` VALUES (23,1694,110,'Goblin_Pathfinder',300,0,1123,0,0,30,36,0);
+INSERT INTO `mob_groups` VALUES (24,1722,110,'Goblins_Bee',0,128,0,0,0,23,25,0);
+INSERT INTO `mob_groups` VALUES (25,1683,110,'Goblin_Leecher',300,0,1098,0,0,26,30,0);
+INSERT INTO `mob_groups` VALUES (26,1665,110,'Goblin_Furrier',300,0,1064,0,0,30,36,0);
+INSERT INTO `mob_groups` VALUES (27,1666,110,'Goblin_Gambler',300,0,1081,0,0,26,30,0);
+INSERT INTO `mob_groups` VALUES (28,1715,110,'Goblin_Smithy',300,0,1162,0,0,30,36,0);
+INSERT INTO `mob_groups` VALUES (29,1710,110,'Goblin_Shaman',300,0,1148,0,0,30,36,0);
+INSERT INTO `mob_groups` VALUES (30,2054,110,'Ignis_Fatuus',300,8,569,0,0,34,36,0);
+INSERT INTO `mob_groups` VALUES (31,440,110,'Black_Triple_Stars',0,32,286,0,0,26,27,0);
+INSERT INTO `mob_groups` VALUES (32,3165,110,'Poison_Leech',300,0,18,0,0,24,26,0);
+INSERT INTO `mob_groups` VALUES (33,743,110,'Clipper',300,0,482,0,0,23,25,0);
+INSERT INTO `mob_groups` VALUES (34,4309,110,'Water_Elemental',300,4,2629,0,0,38,40,0);
+INSERT INTO `mob_groups` VALUES (35,1267,110,'Evil_Weapon',300,0,0,0,0,36,38,0);
+INSERT INTO `mob_groups` VALUES (36,6025,110,'Ravenous_Crawler',7200,0,3097,3500,0,42,42,0);
+INSERT INTO `mob_groups` VALUES (37,1266,110,'Evil_Spirit',300,1,264,0,0,35,38,0);
+INSERT INTO `mob_groups` VALUES (38,5729,110,'Eldritch_Edge',0,32,2993,5096,0,55,55,0);
+INSERT INTO `mob_groups` VALUES (39,1124,110,'Drooling_Daisy',0,32,712,1400,0,39,40,0);
+INSERT INTO `mob_groups` VALUES (40,6658,110,'Goblin_Digger',300,0,1040,0,0,28,32,0);
+INSERT INTO `mob_groups` VALUES (41,3630,110,'Simurgh',0,128,2255,51000,0,58,58,0);
+INSERT INTO `mob_groups` VALUES (42,3745,110,'Sprite',0,128,2001,0,0,61,63,0);
+INSERT INTO `mob_groups` VALUES (43,4107,110,'Urayuli',0,128,0,0,0,1,1,0);
+INSERT INTO `mob_groups` VALUES (44,726,110,'Chuglix_Berrypaws',0,128,0,0,0,1,1,0);
+>>>>>>> 1d0dac08ff (Rolanberry Fields NM Audits)
 
 -- Voidwalker
 INSERT INTO `mob_groups` VALUES (45,6999,110,'Yilbegan',86400,0,3185,90000,5000,0,'WOTG');

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -814,7 +814,11 @@ enum class Mod
     ENSPELL_DMG       = 343,  // stores the base damage of the enspell before reductions
     ENSPELL_DMG_BONUS = 432,  // adds X to the base damage of the enspell before bonuses and reductions
     ENSPELL_CHANCE    = 856,  // Chance of enspell activating (0 = 100%, 10 = 10%, 30 = 30%, ...)
+<<<<<<< HEAD
     ENSPELL_DMG_PCT   = 1195, // adds X% to the multiplier applied to enspell damage after base damage is calculated, before day and weather bonuses and reductions
+=======
+    ENSPELL_DMG_PCT   = 1195,  // adds X% to the multiplier applied to enspell damage after base damage is calculated, before day and weather bonuses and reductions
+>>>>>>> b026ff17dd (Update modifier.h to include enspell_dmg_pct)
     SPIKES            = 342,  // store the type of spike spell active (0 if nothing)
     SPIKES_DMG        = 344,  // stores the base damage of the spikes before reductions
     SPIKES_DMG_BONUS  = 1079, // Increases Blaze/Ice/Shock spikes damage by percentage (e.g. mod value 50 = +50% spikes damage)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Refactors the Monk Impetus job ability to follow LSB's design goal of self-contained, effect-owned state.

Before: 

Mods (ATT, Crit Rate, ACC, Crit DMG) were applied directly to the player entity. onEffectLose was responsible for manually reversing each mod at the time of expiration. Additionally, removeListener was called with the event type string ('MELEE_SWING_MISS') instead of the listener identifier, making the unregister a silent no-op and leaking listeners past effect expiry.

After:

Mods are owned by the CStatusEffect object via effect:addMod. The engine automatically reverses all effect-owned mods via delModifiers when the effect expires, so onEffectLose no longer needs any mod math.
power and subpower now represent stack counts only. Mod values are derived as stacks × per-stack constant
Scaling constants are centralized in a single IMPETUS table (exported as xi.job_utils.monk.IMPETUS) for easy reference and future extension.
onEffectLose is simplified to only remove the two named listeners ('IMPETUS_MISS', 'IMPETUS_HIT'), which are the correct identifiers as registered in onEffectGain.

## Steps to test these changes

1. Log in as a Monk (or MNK sub job) and confirm Impetus can be activated.
2. Use /checkparam <me> to record your baseline ATT and critical hit rate values.
3. Activate Impetus and begin landing melee hits on an enemy.
4. After each hit, use /checkparam <me> and confirm ATT increases by 2 and critical hit rate increases by 1 per hit landed, up to a cap of 50 stacks (ATT +100, Crit Rate +50).
5. Miss a melee attack and confirm ATT and critical hit rate reset to baseline values.
6. Let Impetus expire naturally (180 second duration) while stacks are accumulated. Confirm ATT and critical hit rate return to baseline.
7. (Augmented Impetus only) With a piece of gear granting AUGMENTS_IMPETUS, repeat steps 3–6 and confirm ACC and Crit DMG increase and reset alongside the main stacks.
