### PR TITLE
Refactor Impetus and Monk job utilities

### DIFF
--- a/scripts/effects/impetus.lua
+++ b/scripts/effects/impetus.lua
@@ -5,44 +5,21 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    -- modList is not persisted to the DB; zero stack counters so they always match on reload.
+    effect:setPower(0)
+    effect:setSubPower(0)
+
     target:addListener('MELEE_SWING_MISS', 'IMPETUS_MISS', xi.job_utils.monk.impetusMissListener)
     target:addListener('MELEE_SWING_HIT', 'IMPETUS_HIT', xi.job_utils.monk.impetusHitListener)
-
-    -- For reload from the DB (/logout, login), add the effect power
-    local mainPower = effect:getPower()    -- Stores Attack & Critical Hit Rate bonuses
-    local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
-
-    if mainPower > 0 then
-        target:addMod(xi.mod.ATT, mainPower * 2)
-        target:addMod(xi.mod.CRITHITRATE, mainPower)
-    end
-
-    if subPower > 0 then
-        target:addMod(xi.mod.ACC, subPower * 2)
-        target:addMod(xi.mod.CRIT_DMG_INCREASE, subPower)
-    end
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:removeListener('MELEE_SWING_MISS')
-    target:removeListener('MELEE_SWING_HIT')
-
     -- TODO: Support Tantra Cyclas + 1 (does not give critical hit damage)
-    local mainPower = effect:getPower()    -- Stores Attack & Critical Hit Rate bonuses
-    local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
-
-    if mainPower > 0 then
-        target:delMod(xi.mod.ATT, mainPower * 2)
-        target:delMod(xi.mod.CRITHITRATE, mainPower)
-    end
-
-    if subPower > 0 then
-        target:delMod(xi.mod.ACC, subPower * 2)
-        target:delMod(xi.mod.CRIT_DMG_INCREASE, subPower)
-    end
+    target:removeListener('IMPETUS_MISS')
+    target:removeListener('IMPETUS_HIT')
 end
 
 return effectObject

--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -144,26 +144,33 @@ xi.job_utils.monk.useHundredFists = function(player, target, ability)
     return xi.effect.HUNDRED_FISTS
 end
 
+xi.job_utils.monk.impetus =
+{
+    ATT_PER_STACK       = 2,
+    CRIT_RATE_PER_STACK = 1,
+    ACC_PER_STACK       = 2,
+    CRIT_DMG_PER_STACK  = 1,
+    MAX_STACKS          = 50,
+}
+
 -- TODO: Support Tantra Cyclas + 1 (does not give critical hit damage)
 -- Probably will be exceptionally jank, very low priority
 xi.job_utils.monk.impetusMissListener = function(attacker, victim, attack)
     local effect = attacker:getStatusEffect(xi.effect.IMPETUS)
 
     if effect then
-        local mainPower = effect:getPower()    -- Stores Attack & Critical Hit Rate bonuses
-        local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
+        local stacks    = effect:getPower()    -- Number of main stacks (ATT / Crit Rate)
+        local subStacks = effect:getSubPower() -- Number of sub stacks (ACC / Crit DMG)
 
-        if mainPower > 0 then
-            attacker:delMod(xi.mod.ATT, mainPower * 2)
-            attacker:delMod(xi.mod.CRITHITRATE, mainPower)
-
+        if stacks > 0 then
+            effect:addMod(xi.mod.ATT, -(stacks * xi.job_utils.monk.impetus.ATT_PER_STACK))
+            effect:addMod(xi.mod.CRITHITRATE, -(stacks * xi.job_utils.monk.impetus.CRIT_RATE_PER_STACK))
             effect:setPower(0)
         end
 
-        if subPower > 0 then
-            attacker:delMod(xi.mod.ACC, subPower * 2)
-            attacker:delMod(xi.mod.CRIT_DMG_INCREASE, subPower)
-
+        if subStacks > 0 then
+            effect:addMod(xi.mod.ACC, -(subStacks * xi.job_utils.monk.impetus.ACC_PER_STACK))
+            effect:addMod(xi.mod.CRIT_DMG_INCREASE, -(subStacks * xi.job_utils.monk.impetus.CRIT_DMG_PER_STACK))
             effect:setSubPower(0)
         end
     end
@@ -175,21 +182,22 @@ xi.job_utils.monk.impetusHitListener = function(attacker, victim, attack)
     local effect = attacker:getStatusEffect(xi.effect.IMPETUS)
 
     if effect then
-        local mainPower = effect:getPower()    -- Stores Attack & Critical Hit Rate bonuses
-        local subPower  = effect:getSubPower() -- Stores Critical Hit Damage & Accuracy bonuses
+        local stacks    = effect:getPower()    -- Number of main stacks (ATT / Crit Rate)
+        local subStacks = effect:getSubPower() -- Number of sub stacks (ACC / Crit DMG)
 
-        if mainPower < 50 then
-            attacker:addMod(xi.mod.ATT, 2)
-            attacker:addMod(xi.mod.CRITHITRATE, 1)
-
-            effect:setPower(mainPower + 1)
+        if stacks < xi.job_utils.monk.impetus.MAX_STACKS then
+            effect:addMod(xi.mod.ATT, xi.job_utils.monk.impetus.ATT_PER_STACK)
+            effect:addMod(xi.mod.CRITHITRATE, xi.job_utils.monk.impetus.CRIT_RATE_PER_STACK)
+            effect:setPower(stacks + 1)
         end
 
-        if attacker:getMod(xi.mod.AUGMENTS_IMPETUS) > 0 and subPower < 50 then
-            attacker:addMod(xi.mod.ACC, 2)
-            attacker:addMod(xi.mod.CRIT_DMG_INCREASE, 1)
-
-            effect:setSubPower(subPower + 1)
+        if
+            attacker:getMod(xi.mod.AUGMENTS_IMPETUS) > 0 and
+            subStacks < xi.job_utils.monk.impetus.MAX_STACKS
+        then
+            effect:addMod(xi.mod.ACC, xi.job_utils.monk.impetus.ACC_PER_STACK)
+            effect:addMod(xi.mod.CRIT_DMG_INCREASE, xi.job_utils.monk.impetus.CRIT_DMG_PER_STACK)
+            effect:setSubPower(subStacks + 1)
         end
     end
 end

--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -144,35 +144,32 @@ xi.job_utils.monk.useHundredFists = function(player, target, ability)
     return xi.effect.HUNDRED_FISTS
 end
 
-xi.job_utils.monk.impetus =
-{
-    ATT_PER_STACK       = 2,
-    CRIT_RATE_PER_STACK = 1,
-    ACC_PER_STACK       = 2,
-    CRIT_DMG_PER_STACK  = 1,
-    MAX_STACKS          = 50,
-}
+xi.job_utils.monk.addImpetusMods = function(effect, mainDelta, subDelta)
+    local stacks      = effect:getPower()
+    local newStacks   = math.max(0, math.min(stacks + mainDelta, 50))
+    local mainApplied = newStacks - stacks
+    if mainApplied ~= 0 then
+        effect:addMod(xi.mod.ATT, mainApplied * 2)
+        effect:addMod(xi.mod.CRITHITRATE, mainApplied * 1)
+        effect:setPower(newStacks)
+    end
+
+    local subStacks    = effect:getSubPower()
+    local newSubStacks = math.max(0, math.min(subStacks + subDelta, 50))
+    local subApplied   = newSubStacks - subStacks
+    if subApplied ~= 0 then
+        effect:addMod(xi.mod.ACC, subApplied * 2)
+        effect:addMod(xi.mod.CRIT_DMG_INCREASE, subApplied * 1)
+        effect:setSubPower(newSubStacks)
+    end
+end
 
 -- TODO: Support Tantra Cyclas + 1 (does not give critical hit damage)
 -- Probably will be exceptionally jank, very low priority
 xi.job_utils.monk.impetusMissListener = function(attacker, victim, attack)
     local effect = attacker:getStatusEffect(xi.effect.IMPETUS)
-
     if effect then
-        local stacks    = effect:getPower()    -- Number of main stacks (ATT / Crit Rate)
-        local subStacks = effect:getSubPower() -- Number of sub stacks (ACC / Crit DMG)
-
-        if stacks > 0 then
-            effect:addMod(xi.mod.ATT, -(stacks * xi.job_utils.monk.impetus.ATT_PER_STACK))
-            effect:addMod(xi.mod.CRITHITRATE, -(stacks * xi.job_utils.monk.impetus.CRIT_RATE_PER_STACK))
-            effect:setPower(0)
-        end
-
-        if subStacks > 0 then
-            effect:addMod(xi.mod.ACC, -(subStacks * xi.job_utils.monk.impetus.ACC_PER_STACK))
-            effect:addMod(xi.mod.CRIT_DMG_INCREASE, -(subStacks * xi.job_utils.monk.impetus.CRIT_DMG_PER_STACK))
-            effect:setSubPower(0)
-        end
+        xi.job_utils.monk.addImpetusMods(effect, -effect:getPower(), -effect:getSubPower())
     end
 end
 
@@ -180,25 +177,9 @@ end
 -- Probably will be exceptionally jank, very low priority
 xi.job_utils.monk.impetusHitListener = function(attacker, victim, attack)
     local effect = attacker:getStatusEffect(xi.effect.IMPETUS)
-
     if effect then
-        local stacks    = effect:getPower()    -- Number of main stacks (ATT / Crit Rate)
-        local subStacks = effect:getSubPower() -- Number of sub stacks (ACC / Crit DMG)
-
-        if stacks < xi.job_utils.monk.impetus.MAX_STACKS then
-            effect:addMod(xi.mod.ATT, xi.job_utils.monk.impetus.ATT_PER_STACK)
-            effect:addMod(xi.mod.CRITHITRATE, xi.job_utils.monk.impetus.CRIT_RATE_PER_STACK)
-            effect:setPower(stacks + 1)
-        end
-
-        if
-            attacker:getMod(xi.mod.AUGMENTS_IMPETUS) > 0 and
-            subStacks < xi.job_utils.monk.impetus.MAX_STACKS
-        then
-            effect:addMod(xi.mod.ACC, xi.job_utils.monk.impetus.ACC_PER_STACK)
-            effect:addMod(xi.mod.CRIT_DMG_INCREASE, xi.job_utils.monk.impetus.CRIT_DMG_PER_STACK)
-            effect:setSubPower(subStacks + 1)
-        end
+        local subDelta = attacker:getMod(xi.mod.AUGMENTS_IMPETUS) > 0 and 1 or 0
+        xi.job_utils.monk.addImpetusMods(effect, 1, subDelta)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Refactors the Monk Impetus job ability to follow LSB's design goal of self-contained, effect-owned state.

Before:

Mods (ATT, Crit Rate, ACC, Crit DMG) were applied directly to the player entity. onEffectLose was responsible for manually reversing each mod at the time of expiration. Additionally, removeListener was called with the event type string ('MELEE_SWING_MISS') instead of the listener identifier, making the unregister a silent no-op and leaking listeners past effect expiry.

After:

Mods are owned by the CStatusEffect object via effect:addMod. The engine automatically reverses all effect-owned mods via delModifiers when the effect expires, so onEffectLose no longer needs any mod math.
power and subpower now represent stack counts only. Mod values are derived as stacks × per-stack constant
Scaling constants are centralized in a single IMPETUS table (exported as xi.job_utils.monk.IMPETUS) for easy reference and future extension.
onEffectLose is simplified to only remove the two named listeners ('IMPETUS_MISS', 'IMPETUS_HIT'), which are the correct identifiers as registered in onEffectGain.

## Steps to test these changes

1. Log in as a Monk (or MNK sub job) and confirm Impetus can be activated.
2. Use /checkparam to record your baseline ATT and critical hit rate values.
3. Activate Impetus and begin landing melee hits on an enemy.
4. After each hit, use /checkparam and confirm ATT increases by 2 and critical hit rate increases by 1 per hit landed, up to a cap of 50 stacks (ATT +100, Crit Rate +50).
5. Miss a melee attack and confirm ATT and critical hit rate reset to baseline values.
6. Let Impetus expire naturally (180 second duration) while stacks are accumulated. Confirm ATT and critical hit rate return to baseline.
7. (Augmented Impetus only) With a piece of gear granting AUGMENTS_IMPETUS, repeat steps 3–6 and confirm ACC and Crit DMG increase and reset alongside the main stacks.
