### PR TITLE
Added new commands for GMs and for testing purposes.

### DIFF
--- a/modules/zenith-public/cpp/clear_teleport_binding.cpp
+++ b/modules/zenith-public/cpp/clear_teleport_binding.cpp
@@ -1,0 +1,135 @@
+/************************************************************************
+ * Clear Teleport Binding
+ *************************************************************************
+ * Copyright (c) 2026 ZenithXI Dev Teams
+ *************************************************************************
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ *************************************************************************
+ * Adds a `clearTeleport` method to the CBaseEntity Lua usertype so that
+ * Lua scripts (e.g., the !resetoutpost GM command) can lock previously
+ * unlocked teleport bits without requiring a patch against
+ * src/map/lua/lua_baseentity.{h,cpp}.
+ *
+ * Usage from Lua:
+ *   target:clearTeleport(teleType)            -- zero out an entire field
+ *   target:clearTeleport(teleType, bitval)    -- clear a single bit (1 << bitval)
+ *
+ * Supported types: OUTPOST_*, RUNIC_PORTAL, PAST_MAW, CAMPAIGN_*
+ ************************************************************************/
+#include "common/lua.h"
+#include "map/entities/charentity.h"
+#include "map/lua/lua_baseentity.h"
+#include "map/utils/charutils.h"
+#include "map/utils/moduleutils.h"
+#include "map/zone.h"
+
+class ClearTeleportBindingModule : public CPPModule
+{
+    void OnInit() override
+    {
+        TracyZoneScoped;
+
+        // Lua: target:clearTeleport(teleType, [bitval])
+        lua["CBaseEntity"]["clearTeleport"] = [](CLuaBaseEntity* PLuaEntity, uint8 teleType, sol::object const& bitvalObj) -> void
+        {
+            TracyZoneScoped;
+
+            if (PLuaEntity == nullptr)
+            {
+                return;
+            }
+
+            CBaseEntity* PEntity = PLuaEntity->GetBaseEntity();
+            if (PEntity == nullptr || PEntity->objtype != TYPE_PC)
+            {
+                return;
+            }
+
+            auto* PChar = static_cast<CCharEntity*>(PEntity);
+            auto  type  = static_cast<TELEPORT_TYPE>(teleType);
+
+            if (bitvalObj == sol::lua_nil)
+            {
+                switch (type)
+                {
+                    case TELEPORT_TYPE::OUTPOST_SANDY:
+                        PChar->teleport.outpostSandy = 0;
+                        break;
+                    case TELEPORT_TYPE::OUTPOST_BASTOK:
+                        PChar->teleport.outpostBastok = 0;
+                        break;
+                    case TELEPORT_TYPE::OUTPOST_WINDY:
+                        PChar->teleport.outpostWindy = 0;
+                        break;
+                    case TELEPORT_TYPE::RUNIC_PORTAL:
+                        PChar->teleport.runicPortal = 0;
+                        break;
+                    case TELEPORT_TYPE::PAST_MAW:
+                        PChar->teleport.pastMaw = 0;
+                        break;
+                    case TELEPORT_TYPE::CAMPAIGN_SANDY:
+                        PChar->teleport.campaignSandy = 0;
+                        break;
+                    case TELEPORT_TYPE::CAMPAIGN_BASTOK:
+                        PChar->teleport.campaignBastok = 0;
+                        break;
+                    case TELEPORT_TYPE::CAMPAIGN_WINDY:
+                        PChar->teleport.campaignWindy = 0;
+                        break;
+                    default:
+                        ShowError("CBaseEntity::clearTeleport : Parameter 1 out of bounds.");
+                        return;
+                }
+            }
+            else
+            {
+                uint32 bit = 1u << bitvalObj.as<uint32>();
+                switch (type)
+                {
+                    case TELEPORT_TYPE::OUTPOST_SANDY:
+                        PChar->teleport.outpostSandy &= ~bit;
+                        break;
+                    case TELEPORT_TYPE::OUTPOST_BASTOK:
+                        PChar->teleport.outpostBastok &= ~bit;
+                        break;
+                    case TELEPORT_TYPE::OUTPOST_WINDY:
+                        PChar->teleport.outpostWindy &= ~bit;
+                        break;
+                    case TELEPORT_TYPE::RUNIC_PORTAL:
+                        PChar->teleport.runicPortal &= ~bit;
+                        break;
+                    case TELEPORT_TYPE::PAST_MAW:
+                        PChar->teleport.pastMaw &= ~bit;
+                        break;
+                    case TELEPORT_TYPE::CAMPAIGN_SANDY:
+                        PChar->teleport.campaignSandy &= ~bit;
+                        break;
+                    case TELEPORT_TYPE::CAMPAIGN_BASTOK:
+                        PChar->teleport.campaignBastok &= ~bit;
+                        break;
+                    case TELEPORT_TYPE::CAMPAIGN_WINDY:
+                        PChar->teleport.campaignWindy &= ~bit;
+                        break;
+                    default:
+                        ShowError("CBaseEntity::clearTeleport : Parameter 1 out of bounds.");
+                        return;
+                }
+            }
+
+            charutils::SaveTeleport(PChar, type);
+        };
+    }
+};
+
+REGISTER_CPP_MODULE(ClearTeleportBindingModule);

--- a/modules/zenith-public/lua/4-additive/commands/outpost.lua
+++ b/modules/zenith-public/lua/4-additive/commands/outpost.lua
@@ -1,0 +1,345 @@
+-----------------------------------
+-- func: outpost <action> [player] [outpost_name] [nation]
+-- desc: Manages outpost teleport unlocks for a player.
+--
+--       Actions:
+--         add    -> unlock outpost(s)             (aliases: unlock)
+--         reset  -> lock outpost(s)               (aliases: clear, lock)
+--         check  -> list current unlocks          (aliases: list, verify, show)
+--
+--       Optional tokens after the action can appear in any order:
+--         player       any online player name
+--         outpost_name any of the regions listed by an unknown name
+--         nation       sandoria | bastok | windurst (aliases: sandy, windy)
+--
+--       Defaults:
+--         player  -> cursor target if PC, else self
+--         outpost -> ALL outposts
+--         nation  -> ALL three nations
+--
+--       Examples:
+--         !outpost add                              Unlock all outposts, all nations, cursor/self
+--         !outpost add sandoria                     Unlock all outposts for Sandoria, cursor/self
+--         !outpost add ronfaure sandoria            Unlock ronfaure for Sandoria, cursor/self
+--         !outpost add Bob bastok                   Unlock all outposts for Bastok for Bob
+--         !outpost add Bob ronfaure windy           Unlock ronfaure for Windurst for Bob
+--         !outpost reset Bob sandoria               Lock all Sandoria outposts for Bob
+--         !outpost reset ronfaure                   Lock ronfaure across all nations, cursor/self
+--         !outpost check Bob                        Check Bob across all nations
+-----------------------------------
+---@type TCommand
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 1,
+    parameters = 'ssss',
+}
+
+local outpostRegions =
+{
+    ronfaure          = xi.region.RONFAURE,
+    zulkheim          = xi.region.ZULKHEIM,
+    norvallen         = xi.region.NORVALLEN,
+    gustaberg         = xi.region.GUSTABERG,
+    derfland          = xi.region.DERFLAND,
+    sarutabaruta      = xi.region.SARUTABARUTA,
+    kolshushu         = xi.region.KOLSHUSHU,
+    aragoneu          = xi.region.ARAGONEU,
+    fauregandi        = xi.region.FAUREGANDI,
+    valdeaunia        = xi.region.VALDEAUNIA,
+    qufim             = xi.region.QUFIMISLAND,
+    litelor           = xi.region.LITELOR,
+    kuzotz            = xi.region.KUZOTZ,
+    vollbow           = xi.region.VOLLBOW,
+    elshimo_lowlands  = xi.region.ELSHIMO_LOWLANDS,
+    elshimo_uplands   = xi.region.ELSHIMO_UPLANDS,
+    tulia             = xi.region.TULIA,
+    movalpolos        = xi.region.MOVALPOLOS,
+    tavnazia          = xi.region.TAVNAZIANARCH,
+}
+
+local nationTeleports =
+{
+    { name = 'Sandoria', type = xi.teleport.type.OUTPOST_SANDORIA },
+    { name = 'Bastok',   type = xi.teleport.type.OUTPOST_BASTOK   },
+    { name = 'Windurst', type = xi.teleport.type.OUTPOST_WINDURST },
+}
+
+-- Map common aliases (lowercase) to the index in nationTeleports.
+local nationAliases =
+{
+    sandoria   = 1,
+    sandy      = 1,
+    sandy_oria = 1,
+    sandoria_  = 1,
+    san_doria  = 1,
+    bastok     = 2,
+    bas        = 2,
+    windurst   = 3,
+    windy      = 3,
+    windie     = 3,
+}
+
+local actions =
+{
+    add    = 'add',
+    unlock = 'add',
+    reset  = 'reset',
+    clear  = 'reset',
+    lock   = 'reset',
+    check  = 'check',
+    list   = 'check',
+    verify = 'check',
+    show   = 'check',
+}
+
+local function showUsage(player, msg)
+    if msg then
+        player:printToPlayer(msg, xi.msg.channel.SYSTEM_3)
+    end
+
+    player:printToPlayer('Usage: !outpost <add|reset|check> [player] [outpost_name] [nation]', xi.msg.channel.SYSTEM_3)
+end
+
+local function listOutposts(player)
+    local names = {}
+    for name, _ in pairs(outpostRegions) do
+        table.insert(names, name)
+    end
+
+    table.sort(names)
+    player:printToPlayer('Valid outpost names: ' .. table.concat(names, ', '), xi.msg.channel.SYSTEM_3)
+end
+
+local function listNations(player)
+    player:printToPlayer('Valid nations: sandoria, bastok, windurst', xi.msg.channel.SYSTEM_3)
+end
+
+local function resolveNations(nationFilter)
+    if nationFilter == nil then
+        return nationTeleports
+    end
+
+    return { nationTeleports[nationFilter] }
+end
+
+local function nationLabel(nationFilter)
+    if nationFilter == nil then
+        return 'all nations'
+    end
+
+    return nationTeleports[nationFilter].name
+end
+
+local function reportUnlocks(player, target, nationFilter)
+    local sortedNames = {}
+    for name, _ in pairs(outpostRegions) do
+        table.insert(sortedNames, name)
+    end
+
+    table.sort(sortedNames)
+
+    player:printToPlayer(
+        string.format('Outpost unlocks for %s (%s):', target:getName(), nationLabel(nationFilter)),
+        xi.msg.channel.SYSTEM_3
+    )
+
+    for _, nation in ipairs(resolveNations(nationFilter)) do
+        local unlocked = {}
+        for _, name in ipairs(sortedNames) do
+            local bitOffset = outpostRegions[name] + 5 -- Region bits start at 5th bit
+            if target:hasTeleport(nation.type, bitOffset) then
+                table.insert(unlocked, name)
+            end
+        end
+
+        local list = #unlocked > 0 and table.concat(unlocked, ', ') or '(none)'
+        player:printToPlayer(
+            string.format('  %s: %s', nation.name, list),
+            xi.msg.channel.SYSTEM_3
+        )
+    end
+end
+
+-- Classify a single token as outpost, nation, or player.
+-- Returns one of: 'outpost', 'nation', 'player', or nil with an error string.
+local function classifyToken(token, state)
+    local lowered = string.lower(token)
+
+    if outpostRegions[lowered] then
+        if state.outpostName ~= nil then
+            return nil, string.format('Two outposts given ("%s" and "%s").', state.outpostName, lowered)
+        end
+
+        state.outpostName = lowered
+        return 'outpost'
+    end
+
+    if nationAliases[lowered] then
+        if state.nationFilter ~= nil then
+            return nil, string.format(
+                'Two nations given ("%s" and "%s").',
+                nationTeleports[state.nationFilter].name,
+                nationTeleports[nationAliases[lowered]].name
+            )
+        end
+
+        state.nationFilter = nationAliases[lowered]
+        return 'nation'
+    end
+
+    if state.target ~= nil then
+        return nil, string.format('Unknown token "%s".', token)
+    end
+
+    local found = GetPlayerByName(token)
+    if found == nil then
+        return nil, string.format('Player "%s" not found or not online.', token)
+    end
+
+    state.target = found
+    return 'player'
+end
+
+-- Walk over the optional argument list and classify each non-empty token.
+local function resolveArgs(player, ...)
+    local state = {}
+
+    for _, raw in ipairs({ ... }) do
+        if raw ~= nil and raw ~= '' then
+            local _, err = classifyToken(raw, state)
+            if err then
+                return nil, nil, nil, err
+            end
+        end
+    end
+
+    if state.target == nil then
+        local cursorTarget = player:getCursorTarget()
+        if cursorTarget and cursorTarget:isPC() then
+            state.target = cursorTarget
+        else
+            state.target = player
+        end
+    end
+
+    return state.target, state.outpostName, state.nationFilter, nil
+end
+
+local function doAdd(player, target, outpostName, nationFilter)
+    local nations = resolveNations(nationFilter)
+    local scope   = nationLabel(nationFilter)
+
+    if outpostName then
+        local region    = outpostRegions[outpostName]
+        local bitOffset = region + 5
+
+        for _, nation in ipairs(nations) do
+            target:addTeleport(nation.type, bitOffset)
+        end
+
+        player:printToPlayer(
+            string.format(
+                'Unlocked outpost "%s" (region %d) for %s (%s).',
+                outpostName,
+                region,
+                target:getName(),
+                scope
+            ),
+            xi.msg.channel.SYSTEM_3
+        )
+    else
+        for _, nation in ipairs(nations) do
+            for _, region in pairs(outpostRegions) do
+                target:addTeleport(nation.type, region + 5)
+            end
+        end
+
+        player:printToPlayer(
+            string.format('Unlocked ALL outposts for %s (%s).', target:getName(), scope),
+            xi.msg.channel.SYSTEM_3
+        )
+    end
+end
+
+local function doReset(player, target, outpostName, nationFilter)
+    local nations = resolveNations(nationFilter)
+    local scope   = nationLabel(nationFilter)
+
+    if outpostName then
+        local region    = outpostRegions[outpostName]
+        local bitOffset = region + 5
+
+        for _, nation in ipairs(nations) do
+            target:clearTeleport(nation.type, bitOffset)
+        end
+
+        player:printToPlayer(
+            string.format(
+                'Locked outpost "%s" (region %d) for %s (%s).',
+                outpostName,
+                region,
+                target:getName(),
+                scope
+            ),
+            xi.msg.channel.SYSTEM_3
+        )
+    else
+        for _, nation in ipairs(nations) do
+            target:clearTeleport(nation.type)
+        end
+
+        player:printToPlayer(
+            string.format('Reset ALL outpost unlocks for %s (%s).', target:getName(), scope),
+            xi.msg.channel.SYSTEM_3
+        )
+    end
+end
+
+commandObj.onTrigger = function(player, action, arg1, arg2, arg3)
+    if action == nil or action == '' then
+        showUsage(player, 'No action specified.')
+        return
+    end
+
+    local resolvedAction = actions[string.lower(action)]
+    if not resolvedAction then
+        showUsage(player, string.format('Unknown action "%s".', action))
+        return
+    end
+
+    local target, outpostName, nationFilter, err = resolveArgs(player, arg1, arg2, arg3)
+    if err then
+        showUsage(player, err)
+
+        local lowered = string.lower(err)
+        if string.find(lowered, 'outpost', 1, true) then
+            listOutposts(player)
+        elseif string.find(lowered, 'nation', 1, true) then
+            listNations(player)
+        end
+
+        return
+    end
+
+    if resolvedAction == 'check' then
+        reportUnlocks(player, target, nationFilter)
+        return
+    end
+
+    if resolvedAction == 'add' then
+        doAdd(player, target, outpostName, nationFilter)
+    else
+        doReset(player, target, outpostName, nationFilter)
+    end
+
+    if target:getID() ~= player:getID() then
+        target:printToPlayer(
+            'Your outpost teleport unlocks have been updated by a GM.',
+            xi.msg.channel.SYSTEM_3
+        )
+    end
+end
+
+return commandObj


### PR DESCRIPTION

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Added new outpost reset commands and check commands


## Steps to test these changes
-- func: resetoutpost <player> <outpost_name>
-- desc: Resets outpost teleport unlocks for a player.
--       If no outpost name is given, resets ALL outpost warps for all nations.
--       If an outpost name is given, locks only that outpost across all nations.
--       If no player name is provided, uses cursor target or self.
--
--       Verification mode:
--       !resetoutpost check                  -> list unlocked outposts for cursor/self
--       !resetoutpost check <player>         -> list unlocked outposts for player
--       !resetoutpost <player> check         -> list unlocked outposts for player

