### PR TITLE
[ci] Export source_changes from check-changes step

### DIFF
--- a/.github/workflows/runner_build.yml
+++ b/.github/workflows/runner_build.yml
@@ -89,6 +89,7 @@ jobs:
             fi
           done
           echo "SKIP_BUILD=$([[ $source_changes == false && ${{ inputs.optional_build }} == true ]] && echo 'true' || echo 'false')" >> $GITHUB_ENV
+          echo "source_changes=$source_changes" >> $GITHUB_OUTPUT
 
       - name: Checkout
         if: ${{ env.SKIP_BUILD != 'true' }}


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- The `check-changes` step in `runner_build.yml` set `SKIP_BUILD` via `$GITHUB_ENV` but never wrote `source_changes` to `$GITHUB_OUTPUT`.
- As a result, `steps.check-changes.outputs.source_changes` was always empty, and the gate `${{ !inputs.optional_build || steps.check-changes.outputs.source_changes == 'true' }}` evaluated to `false` whenever `optional_build: true` (e.g. the `Clang_Tidy` job in `pr_checks.yml`).
- That silently skipped the **Include only public modules** and **Apply git Patches** steps, so the `LQS` submodule was never initialized and private modules were never stripped from `modules/init.txt`.
- CMake then read `LQS/cpp` and `zenith-private/cpp` from `init.txt`, found the directories did not exist, fell through the `IS_DIRECTORY` check, hit the `MATCHES "\.cpp"` elseif (because `/cpp` matches the regex `.cpp`), and added the bare directory paths as source files — producing `Cannot find source file: .../modules/LQS/cpp`.
Add `echo "source_changes=\$source_changes" >> \$GITHUB_OUTPUT` to the `check-changes` step so the gate actually sees the right value.

## Steps to test these changes

## Test plan
- [ ] Open any PR and confirm the `Clang Tidy` job's runner log shows `Include only public modules` and `Apply git Patches` steps **executing** rather than being skipped.
- [ ] Confirm `git submodule update --init --remote --force modules/LQS` runs and `modules/LQS/cpp/lqs_util.cpp` is picked up by CMake.
- [ ] Confirm `modules/init.txt` has `zenith-private` lines stripped before CMake reads it (no more orphaned `Adding module files to build: .../modules/zenith-private/cpp` line in configure output).
- [ ] Confirm the configure step completes without the `Cannot find source file` error.