### PR TITLE
Add blockers for elite training

### DIFF
--- a/modules/zenith-public/lua/2-base/regime_restrictions.lua
+++ b/modules/zenith-public/lua/2-base/regime_restrictions.lua
@@ -14,8 +14,16 @@ local blockedOptions =
 {
     [xi.regime.type.FIELDS] =
     {
+        [36]  = true, -- ELITE_INTRO
+        [52]  = true, -- ELITE_CHAP1
+        [68]  = true, -- ELITE_CHAP2
+        [84]  = true, -- ELITE_CHAP3
+        [100] = true, -- ELITE_CHAP4
+        [116] = true, -- ELITE_CHAP5
         [117] = true, -- DRIED_MEAT
+        [132] = true, -- ELITE_CHAP6
         [133] = true, -- SALTED_FISH
+        [148] = true, -- ELITE_CHAP7
         [149] = true, -- HARD_COOKIE
         [165] = true, -- INSTANT_NOODLES
     },


### PR DESCRIPTION

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Causes the custom blocked message to display when selecting any elite training option from FoV.

## Steps to test these changes

Try to accept any elite training option and observe the system message.
