### PR TITLE
Merge Fixes from latest LSB changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,8 +6,8 @@
     url = https://github.com/InoUno/ximeshes.git
 [submodule "mod-lqs"]
     path = modules/LQS
-    url = https://github.com/LoxleyX/LQS.git
-    branch = main
+    url = https://github.com/Zenith-XI/LQS.git
+    branch = Prod
     ignore = dirty
 [submodule "mod-priv"]
     path = modules/zenith-private

--- a/modules/zenith-public/git-patches/103-SpelllAndRangeAttackQueuing.patch
+++ b/modules/zenith-public/git-patches/103-SpelllAndRangeAttackQueuing.patch
@@ -1,8 +1,8 @@
 diff --git a/src/map/ai/ai_container.cpp b/src/map/ai/ai_container.cpp
-index ff9c8ed6bc..a1d0574463 100644
+index 555f6c0bc0..f98dbaf4f3 100644
 --- a/src/map/ai/ai_container.cpp
 +++ b/src/map/ai/ai_container.cpp
-@@ -461,6 +461,29 @@ void CAIContainer::Tick(timer::time_point _tick)
+@@ -462,6 +462,29 @@ auto CAIContainer::Tick(timer::time_point tick) -> Task<void>
              break;
          }
      }
@@ -16,7 +16,7 @@ index ff9c8ed6bc..a1d0574463 100644
 +    {
 +        if (
 +            m_queuedRangedAttack &&
-+            _tick - PChar->m_LastRangedAttackTime > std::chrono::milliseconds(1100)
++            tick - PChar->m_LastRangedAttackTime > std::chrono::milliseconds(1100)
 +        )
 +        {
 +            RangedAttack(m_queuedRangedAttack);
@@ -31,12 +31,12 @@ index ff9c8ed6bc..a1d0574463 100644
 +    }
  
      PEntity->PostTick();
- }
+ 
 diff --git a/src/map/ai/ai_container.h b/src/map/ai/ai_container.h
-index ef3f629986..a5f00c6faa 100644
+index ba04b962c5..bf96d142e9 100644
 --- a/src/map/ai/ai_container.h
 +++ b/src/map/ai/ai_container.h
-@@ -133,6 +133,10 @@ public:
+@@ -132,6 +132,10 @@ public:
      // pathfinder, not guaranteed to be implemented
      std::unique_ptr<CPathFind> PathFind;
  
@@ -48,7 +48,7 @@ index ef3f629986..a5f00c6faa 100644
      // input controller
      std::unique_ptr<CController> Controller;
 diff --git a/src/map/ai/controllers/player_controller.cpp b/src/map/ai/controllers/player_controller.cpp
-index f78f912183..53f1df355c 100644
+index 3ddd7b433d..6d45afd7e6 100644
 --- a/src/map/ai/controllers/player_controller.cpp
 +++ b/src/map/ai/controllers/player_controller.cpp
 @@ -25,6 +25,8 @@
@@ -60,7 +60,7 @@ index f78f912183..53f1df355c 100644
  #include "entities/charentity.h"
  #include "items/item_weapon.h"
  #include "latent_effect_container.h"
-@@ -49,6 +51,26 @@ void CPlayerController::Tick(timer::time_point /*tick*/)
+@@ -50,6 +52,26 @@ auto CPlayerController::Tick(timer::time_point /*tick*/) -> Task<void>
  bool CPlayerController::Cast(uint16 targid, SpellID spellid)
  {
      auto* PChar = static_cast<CCharEntity*>(POwner);
@@ -87,7 +87,7 @@ index f78f912183..53f1df355c 100644
      if (canAct() && !PChar->PRecastContainer->HasRecast(RECAST_MAGIC, static_cast<Recast>(spellid), 0s))
      {
          if (auto target = PChar->GetEntity(targid); target && target->PAI->IsUntargetable())
-@@ -155,7 +177,26 @@ bool CPlayerController::Ability(uint16 targid, uint16 abilityid)
+@@ -156,7 +178,26 @@ bool CPlayerController::Ability(uint16 targid, uint16 abilityid)
  bool CPlayerController::RangedAttack(uint16 targid)
  {
      auto* PChar = static_cast<CCharEntity*>(POwner);

--- a/modules/zenith-public/git-patches/109-TrueShotTraitEffect.patch
+++ b/modules/zenith-public/git-patches/109-TrueShotTraitEffect.patch
@@ -1,0 +1,17 @@
+diff --git a/scripts/globals/combat/physical_utilities.lua b/scripts/globals/combat/physical_utilities.lua
+index ec5b8b1231..438cb20044 100644
+--- a/scripts/globals/combat/physical_utilities.lua
++++ b/scripts/globals/combat/physical_utilities.lua
+@@ -907,7 +907,11 @@ xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsA
+         pDif = pDif * 1.25
+     end
+ 
+-    -- Step 5: TODO: True Shot.
++    -- Step 5: True Shot.
++    local trueShotBonus = actor:getMod(xi.mod.TRUE_SHOT_EFFECT)
++    if trueShotBonus > 0 then
++        pDif = pDif * (1 + trueShotBonus / 100)
++    end
+ 
+     -- Crit damage bonus is a final modifier
+     if isCritical then

--- a/modules/zenith-public/git-patches/110-lua-getGroupId-binding.patch
+++ b/modules/zenith-public/git-patches/110-lua-getGroupId-binding.patch
@@ -1,0 +1,106 @@
+diff --git a/src/map/entities/mobentity.cpp b/src/map/entities/mobentity.cpp
+index 26c219fcb4..fcb17ce165 100644
+--- a/src/map/entities/mobentity.cpp
++++ b/src/map/entities/mobentity.cpp
+@@ -204,6 +204,11 @@ uint32 CMobEntity::getEntityFlags() const
+     return m_flags;
+ }
+ 
++uint32 CMobEntity::getGroupID() const
++{
++    return m_GroupID;
++}
++
+ void CMobEntity::setEntityFlags(uint32 EntityFlags)
+ {
+     m_flags = EntityFlags;
+diff --git a/src/map/entities/mobentity.h b/src/map/entities/mobentity.h
+index 3d48aafe78..d5109656b7 100644
+--- a/src/map/entities/mobentity.h
++++ b/src/map/entities/mobentity.h
+@@ -121,6 +121,7 @@ public:
+ 
+     uint32 getEntityFlags() const;             // Returns the current value in m_flags
+     void   setEntityFlags(uint32 EntityFlags); // Change the current value in m_flags
++    uint32 getGroupID() const;                 // Returns the mob's group ID from mob_groups
+ 
+     bool IsFarFromHome();      // check if mob is too far from spawn
+     bool CanBeNeutral() const; // check if mob can have killing pause
+@@ -262,6 +263,7 @@ public:
+ 
+     uint32 m_flags;       // includes the CFH flag and whether the HP bar should be shown or not (e.g. Yilgeban doesnt)
+     uint8  m_name_prefix; // The ding bats VS Ding bats
++    uint32 m_GroupID;     // mobgroup ID within zone
+ 
+     uint8 m_unk0; // possibly campaign related (entity 0x24)
+     uint8 m_unk1; // (entity_update 0x25)
+diff --git a/src/map/lua/lua_baseentity.cpp b/src/map/lua/lua_baseentity.cpp
+index f8017d119f..f78f43ce29 100644
+--- a/src/map/lua/lua_baseentity.cpp
++++ b/src/map/lua/lua_baseentity.cpp
+@@ -19306,6 +19306,24 @@ uint32 CLuaBaseEntity::getPool()
+     return 0;
+ }
+ 
++/************************************************************************
++ *  Function: getGroupId()
++ *  Purpose : Returns a Mob's Group ID from mob_groups table - ClaimShield
++ *  Example : local groupId = mob:getGroupId()
++ *  Notes   : Returns 0 if entity is not a mob
++ ************************************************************************/
++
++uint32 CLuaBaseEntity::getGroupId()
++{
++    if (m_PBaseEntity->objtype == TYPE_MOB || m_PBaseEntity->objtype == TYPE_TRUST)
++    {
++        CMobEntity* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
++        return PMob->getGroupID();
++    }
++
++    return 0;
++}
++
+ /************************************************************************
+  *  Function: getDropID()
+  *  Purpose : Returns the integer Drop ID assigned to a Mob
+@@ -20991,6 +21009,7 @@ void CLuaBaseEntity::Register()
+     SOL_REGISTER("tryHitInterrupt", CLuaBaseEntity::tryHitInterrupt);
+ 
+     SOL_REGISTER("getPool", CLuaBaseEntity::getPool);
++    SOL_REGISTER("getGroupId", CLuaBaseEntity::getGroupId);
+     SOL_REGISTER("getDropID", CLuaBaseEntity::getDropID);
+     SOL_REGISTER("setDropID", CLuaBaseEntity::setDropID);
+     SOL_REGISTER("addTreasure", CLuaBaseEntity::addTreasure);
+diff --git a/src/map/lua/lua_baseentity.h b/src/map/lua/lua_baseentity.h
+index b698fc5527..4e36a34687 100644
+--- a/src/map/lua/lua_baseentity.h
++++ b/src/map/lua/lua_baseentity.h
+@@ -940,6 +940,7 @@ public:
+     void tryHitInterrupt(CLuaBaseEntity* attacker);
+ 
+     uint32 getPool(); // Returns a mobs pool ID. If entity is not a mob, returns nil.
++    uint32 getGroupId(); // Returns a mobs group ID from mob_groups. Returns 0 if not available.
+     uint32 getDropID();
+     void   setDropID(uint32 dropID);
+     void   addTreasure(uint16 itemID, const sol::object& arg1, const sol::object& arg2);
+diff --git a/src/map/utils/zoneutils.cpp b/src/map/utils/zoneutils.cpp
+index 62631d3640..4952922dc0 100644
+--- a/src/map/utils/zoneutils.cpp
++++ b/src/map/utils/zoneutils.cpp
+@@ -424,7 +424,7 @@ auto LoadMOBList(Scheduler& scheduler, const std::vector<uint16>& zoneIds) -> Ta
+                                            "fire_res_rank, ice_res_rank, wind_res_rank, earth_res_rank, lightning_res_rank, water_res_rank, light_res_rank, dark_res_rank, "
+                                            "paralyze_res_rank, bind_res_rank, silence_res_rank, slow_res_rank, poison_res_rank, light_sleep_res_rank, dark_sleep_res_rank, blind_res_rank, "
+                                            "Element, mob_pools.speciesid, mob_species_system.familyID, name_prefix, entityFlags, animationsub, "
+-                                           "(mob_species_system.HP / 100), (mob_species_system.MP / 100), spellList, mob_groups.poolid, "
++                                           "(mob_species_system.HP / 100), (mob_species_system.MP / 100), spellList, mob_groups.poolid, mob_groups.groupid AS mobgroupid, "
+                                            "allegiance, namevis, aggro, roamflag, mob_pools.skill_list_id, mob_pools.true_detection, mob_species_system.detects, "
+                                            "mob_species_system.charmable, mob_groups.content_tag, "
+                                            "mob_pools.modelSize, mob_pools.modelHitboxSize, "
+@@ -472,6 +472,7 @@ auto LoadMOBList(Scheduler& scheduler, const std::vector<uint16>& zoneIds) -> Ta
+                                     PMob->m_RespawnTime = std::chrono::seconds(rset->get<uint32>("respawntime"));
+                                     PMob->m_SpawnType   = rset->get<SPAWNTYPE>("spawntype");
+                                     PMob->m_DropID      = rset->get<uint32>("dropid");
++                                    PMob->m_GroupID     = rset->get<uint32>("mobgroupid");
+ 
+                                     // Check if the drop list is valid
+                                     if (PMob->m_DropID != 0 && itemutils::GetDropList(PMob->m_DropID) == nullptr)

--- a/modules/zenith-public/lua/1-enum/xi/item.lua
+++ b/modules/zenith-public/lua/1-enum/xi/item.lua
@@ -7,6 +7,8 @@
 require('modules/module_utils')
 
 local m = Module:new('e_x-item')
+m:addOverride('xi.dummyFunc', function()
+end)
 
 -- Vendor overrides
 xi.item.HANDFUL_OF_STEEL_SCALES  = 676

--- a/modules/zenith-public/lua/1-enum/zxi/zones.lua
+++ b/modules/zenith-public/lua/1-enum/zxi/zones.lua
@@ -2,6 +2,8 @@
 -- Converts zone names to IDs
 -----------------------------------
 local m = Module:new('e_z-zones')
+m:addOverride('xi.dummyFunc', function()
+end)
 
 zxi = zxi or {}
 zxi.zone =

--- a/modules/zenith-public/lua/2-base/gm_command_permissions.lua
+++ b/modules/zenith-public/lua/2-base/gm_command_permissions.lua
@@ -24,6 +24,8 @@
 -----------------------------------
 
 local m = Module:new('c_gmCmdPerms')
+m:addOverride('xi.dummyFunc', function()
+end)
 
 -----------------------------------
 -- Command Permission Definitions

--- a/modules/zenith-public/lua/4-additive/npc/jeuno/[LQS]jeunoTeleportNpc.lua
+++ b/modules/zenith-public/lua/4-additive/npc/jeuno/[LQS]jeunoTeleportNpc.lua
@@ -9,18 +9,34 @@
 --   - Standard retail outpost costs
 -----------------------------------
 
-return LQS.outpostTeleporter({
-    name = 'Outpost Warper',
-    zone = 'Lower_Jeuno',
-    pos  = { 24.1552, -1.0, 45.9046, 149 },
-    look = 1415, -- Hume Uncle model
+-- LQS v2.x: LQS.outpostTeleporter() now returns an onTrigger handler instead
+-- of registering the NPC itself, so the NPC is declared via LQS.npc.
+local m = Module:new('a-n_jeuno_outpost_warper')
 
-    -- Apply Signet before teleport (uses rank-based duration)
-    preTeleportEffects = { LQS.signetEffect() },
+LQS.npc(m, {
+    ['Lower_Jeuno'] =
+    {
+        {
+            name      = 'Outpost Warper',
+            look      = 1415, -- Hume Uncle model
+            pos       = { 24.1552, -1.0, 45.9046, 149 },
+            onTrigger = LQS.outpostTeleporter({
+                -- Apply Signet before teleport (uses rank-based duration)
+                preTeleportEffects = { LQS.signetEffect() },
 
-    -- Other defaults:
-    -- greeting       = "Welcome to the Outpost Warp Service!"
-    -- itemsPerPage   = 5
-    -- teleportDelay  = 1250
-    -- animation      = { actionID = 6, animID = 600 }
+                -- Other defaults:
+                -- greeting       = "Welcome to the Outpost Warp Service!"
+                -- itemsPerPage   = 5
+                -- teleportDelay  = 1250
+                -- animation      = { actionID = 6, animID = 600 }
+                -- outpostOverrides = {
+                -- [xi.region.RONFAURE]    = { gil = 500, cp = 50 },  -- pricier
+                -- [xi.region.QUFIMISLAND] = { gil = 0,   cp = 0  },  -- free
+                -- [xi.region.VOLLBOW]     = { gil = 250, level = 40 }, -- cheaper + lower level req
+                --},
+            }),
+        },
+    },
 })
+
+return m


### PR DESCRIPTION
Update to public repo git patch files and LQS module.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Brings the server up to date with the latest LandSandBoat (LSB) upstream and updates the LQS quest module so everything builds and loads cleanly.

- **Git patches:** Updates our patch files so they apply against the latest LSB code — fixes `103-SpelllAndRangeAttackQueuing` and adds `109-TrueShotTraitEffect` and `110-lua-getGroupId-binding`.
- **LQS module:** Points the LQS submodule at our own `Zenith-XI/LQS` fork (branch `Prod`). That branch includes a C++ build fix (LSB renamed the item-lookup API, which previously broke compilation) and a fix so the new LQS helper modules load without the "no overrides found" error.
- **Jeuno outpost warper:** Updates the Lower Jeuno outpost teleporter NPC to use the new LQS teleporter API so it keeps working after the LQS update.

## Steps to test these changes

rebuild server
