### PR TITLE
Reverts Guild Vendors to legacy system

### DIFF
--- a/modules/zenith-public/lua/3-complete/guildShopSharing.lua
+++ b/modules/zenith-public/lua/3-complete/guildShopSharing.lua
@@ -1,0 +1,329 @@
+-----------------------------------
+-- Shared-Inventory Guild Vendors
+--
+-- Lets several NPCs share one dynamic guild shop (one inventory + price pool).
+-- The base xi.guildShops keys shop config (xi.data.guildShops[name]) and live
+-- state (xi.guildShops.state[name]) by npc:getName(), so differently-named NPCs
+-- cannot share a pool. This module adds an npcName -> shopKey alias (default key
+-- is the npc's own name) and re-implements the public xi.guildShops.* entry
+-- points keyed by that shop key. Because price is derived from the shared stock,
+-- sharing the state shares the prices automatically.
+--
+-- The price/restock math is a faithful copy of scripts/globals/guild_shops.lua;
+-- keep it identical so non-aliased shops behave exactly as before.
+--
+-- Public module for ZenithXI
+-----------------------------------
+local m = Module:new('c_guildShopSharing')
+
+xi              = xi or {}
+xi.guildShops   = xi.guildShops or {}
+xi.guildShops.state = xi.guildShops.state or {}
+
+-- npcName -> canonical shop key. Any NPC not listed uses its own name as the key.
+xi.guildShops.alias = xi.guildShops.alias or
+{
+    ['Vicious_Eye']   = 'Amulya',
+    ['Celestina']     = 'Yabby_Tanmikey',
+    ['Mololo']        = 'Kamilah',
+    ['Chomo_Jinjahl'] = 'Kopopo',
+}
+
+-- Resolve an NPC display name to its shop key (alias or the name itself).
+xi.guildShops.shopKeyFor = function(name)
+    return xi.guildShops.alias[name] or name
+end
+
+local function keyFor(npc)
+    return xi.guildShops.shopKeyFor(npc:getName())
+end
+
+-- One-time warning if an aliased NPC points at a shop key with no config.
+local warnedMissing = {}
+local function warnMissingShop(npc)
+    local name = npc:getName()
+    if xi.guildShops.alias[name] ~= nil and not warnedMissing[name] then
+        warnedMissing[name] = true
+        printf('[guildShopSharing] %s aliased to %s but no shop config found', name, keyFor(npc))
+    end
+end
+
+-----------------------------------
+-- Ported helpers (math identical to scripts/globals/guild_shops.lua)
+-----------------------------------
+
+local priceFloorOf = function(cfg)
+    return cfg.priceFloor or (cfg.maxStock * 3 / 4)
+end
+
+local calcBuyPrice = function(buyMax, priceFloor, maxStock, stock)
+    local kneeRatio = 2 / 3
+    if priceFloor <= 0 then
+        return buyMax
+    end
+
+    local knee = kneeRatio * priceFloor
+    if stock <= knee then
+        return math.floor(buyMax * (125 - math.floor(150 * stock / priceFloor)) / 125)
+    end
+
+    return math.floor(buyMax * (200 - math.floor(100 * (stock - knee) / (maxStock - knee))) / 1000)
+end
+
+local calcSellPrice = function(base, maxStock, stock)
+    if maxStock <= 0 then
+        return math.floor(base * 3 / 2)
+    end
+
+    local index = math.floor(200 * stock / maxStock)
+    return math.floor(base * (600 - index) / 400)
+end
+
+-- State is keyed by shop key, so aliased NPCs share one live state table.
+local getShopState = function(key)
+    local state = xi.guildShops.state[key]
+    if state == nil then
+        state =
+        {
+            lastRoll = -1,
+            items    = {},
+        }
+
+        xi.guildShops.state[key] = state
+    end
+
+    return state
+end
+
+local shopConfig = function(shop, itemId)
+    for _, cfg in ipairs(shop.stock) do
+        if cfg.id == itemId then
+            return cfg
+        end
+    end
+end
+
+local shopFor = function(npc)
+    return xi.data.guildShops[keyFor(npc)]
+end
+
+local rejected = function(trade)
+    return { itemNo = 0, count = 0, trade = trade }
+end
+
+local rollShopDay = function(key, shop)
+    local state = getShopState(key)
+    local today = VanadielUniqueDay()
+    if state.lastRoll == today then
+        return state
+    end
+
+    local firstRoll = state.lastRoll < 0
+    local days      = firstRoll and 0 or (today - state.lastRoll)
+
+    for _, cfg in ipairs(shop.stock) do
+        local prev  = state.items[cfg.id]
+        local stock = prev and prev.stock or cfg.initial
+
+        if not firstRoll and cfg.restockRate > 0 and stock < cfg.targetStock then
+            stock = math.min(cfg.targetStock, stock + cfg.restockRate * days)
+        end
+
+        stock = math.min(stock, cfg.targetStock)
+
+        state.items[cfg.id] =
+        {
+            stock     = stock,
+            buyPrice  = calcBuyPrice(cfg.buyMax, priceFloorOf(cfg), cfg.maxStock, stock),
+            sellPrice = cfg.sellPrice or calcSellPrice(GetReadOnlyItem(cfg.id):getBasePrice(), cfg.maxStock, stock),
+            offered   = stock > 0,
+        }
+    end
+
+    state.lastRoll = today
+
+    return state
+end
+
+local guildShopIsOpen = function(npc)
+    local shop = shopFor(npc)
+    if shop == nil then
+        return false
+    end
+
+    local hour = VanadielHour()
+    return hour >= shop.hours[1] and hour < shop.hours[2]
+end
+
+-----------------------------------
+-- Overridden public entry points (shop-key aware)
+-----------------------------------
+
+m:addOverride('xi.guildShops.onTrigger', function(player, npc)
+    local shop = shopFor(npc)
+    if shop == nil then
+        warnMissingShop(npc)
+        return false
+    end
+
+    npc:facePlayer(player)
+    rollShopDay(keyFor(npc), shop)
+
+    return player:openGuildShop(npc, shop.hours[1], shop.hours[2])
+end)
+
+m:addOverride('xi.guildShops.onPlayerBuy', function(player, npc, itemId, quantity)
+    local shop = shopFor(npc)
+
+    if shop == nil or not guildShopIsOpen(npc) then
+        return rejected(-1)
+    end
+
+    local cfg = shopConfig(shop, itemId)
+    if cfg == nil then
+        return rejected(-1)
+    end
+
+    local state = rollShopDay(keyFor(npc), shop)
+    local item  = state.items[itemId]
+
+    if not item.offered then
+        return rejected(-1)
+    end
+
+    quantity = math.min(quantity, item.stock)
+    if quantity <= 0 then
+        return rejected(-1)
+    end
+
+    local cost = item.buyPrice * quantity
+    if player:getGil() < cost then
+        return rejected(-1)
+    end
+
+    if not player:addItem(itemId, quantity) then
+        return rejected(-1)
+    end
+
+    player:delGil(cost)
+    item.stock = item.stock - quantity
+
+    return { itemNo = itemId, count = item.stock, trade = quantity }
+end)
+
+m:addOverride('xi.guildShops.onBuyList', function(player, npc)
+    local shop = shopFor(npc)
+    if shop == nil then
+        return {}
+    end
+
+    local state = rollShopDay(keyFor(npc), shop)
+
+    local items = {}
+    for _, cfg in ipairs(shop.stock) do
+        local item = state.items[cfg.id]
+        if item.offered then
+            items[#items + 1] =
+            {
+                id    = cfg.id,
+                count = item.stock,
+                price = item.buyPrice,
+                max   = cfg.maxStock,
+            }
+        end
+    end
+
+    return items
+end)
+
+m:addOverride('xi.guildShops.onPlayerSell', function(player, npc, itemId, quantity)
+    local shop = shopFor(npc)
+
+    if shop == nil or not guildShopIsOpen(npc) then
+        return rejected(-4)
+    end
+
+    local cfg = shopConfig(shop, itemId)
+    if cfg == nil or cfg.noSell then
+        return rejected(-4)
+    end
+
+    local state = rollShopDay(keyFor(npc), shop)
+    local item  = state.items[itemId]
+
+    local want   = math.min(quantity, cfg.maxStock - item.stock)
+    local stacks = player:findItems(itemId, xi.inventoryLocation.INVENTORY)
+    local sold   = 0
+    for _ = 1, #stacks do
+        local front = player:findItems(itemId, xi.inventoryLocation.INVENTORY)[1]
+        local take  = front and math.min(want - sold, front:getQuantity() - front:getReservedValue()) or 0
+        if take <= 0 then
+            break
+        end
+
+        player:delItem(itemId, take)
+        sold = sold + take
+    end
+
+    if sold <= 0 then
+        return rejected(-4)
+    end
+
+    player:addGil(item.sellPrice * sold)
+    item.stock = item.stock + sold
+
+    local trade = (sold < quantity) and -1 or sold
+    return { itemNo = itemId, count = item.stock, trade = trade, sold = sold, price = item.sellPrice }
+end)
+
+m:addOverride('xi.guildShops.onSellList', function(player, npc)
+    local shop = shopFor(npc)
+    if shop == nil then
+        return {}
+    end
+
+    local state = rollShopDay(keyFor(npc), shop)
+
+    local items = {}
+    for _, cfg in ipairs(shop.stock) do
+        if not cfg.noSell then
+            local item  = state.items[cfg.id]
+            local price = item.sellPrice
+            if cfg.hidden then
+                price = bit.bor(price, 0x80000000)
+            end
+
+            items[#items + 1] =
+            {
+                id    = cfg.id,
+                count = item.stock,
+                price = price,
+                max   = cfg.maxStock,
+            }
+        end
+    end
+
+    return items
+end)
+
+m:addOverride('xi.guildShops.onGameHour', function(player, npc)
+    local shop = shopFor(npc)
+    if shop == nil then
+        return
+    end
+
+    if VanadielHour() == shop.hours[2] then
+        xi.guildShops.onShopClose(player, npc)
+    end
+end)
+
+m:addOverride('xi.guildShops.onShopClose', function(player, npc)
+    local shop = shopFor(npc)
+    if shop ~= nil then
+        player:sendGuildClose(shop.hours[1], shop.hours[2])
+    end
+
+    player:clearGuildShop()
+end)
+
+return m

--- a/modules/zenith-public/lua/3-complete/guildVendorShops.lua
+++ b/modules/zenith-public/lua/3-complete/guildVendorShops.lua
@@ -1,0 +1,153 @@
+-----------------------------------
+-- Guild Vendor Shop Overrides
+--
+-- Redirects the legacy "General Vendor" guild merchants -- which open the static,
+-- infinite-stock shop built from xi.shop.generalGuildStock in
+-- scripts/globals/shop.lua -- to the real, finite guild shop they share inventory
+-- with. The General Vendor's own shop is replaced; it now opens the partner shop.
+--
+-- Two share mechanisms, both giving true shared stock with the partner merchant:
+--   * sendGuild  -> retail DB-backed guild shop keyed by guildid
+--                   (sql/guild_shops.sql via src/map/utils/guildutils.cpp).
+--                   Both NPCs calling sendGuild(<id>, ...) read the same stock.
+--   * dynamic   -> ZenithXI dynamic vendor (scripts/data/guild_shops.lua). The
+--                  General Vendor is aliased to the partner's shop key by the
+--                  c_guildShopSharing module, so xi.guildShops.onTrigger opens
+--                  and shares the partner's inventory + prices.
+--
+-- Public module for ZenithXI
+-----------------------------------
+local m = Module:new('c_guildVendorShops')
+
+-- Each entry overrides one General Vendor's onTrigger.
+--   zone    : xi.zone the NPC lives in (used to resolve its dialog)
+--   dialog  : original showText key on zones[zone].text, or nil for no dialog
+--   guild   : { guildId, open, close, holiday } -> player:sendGuild(...)  (DB guild shop)
+--   (dynamic entries have no guild field; alias in c_guildShopSharing routes them)
+-- Exactly one of guild / (no guild) is set per entry.
+local sharedGuildVendors =
+{
+    -- sendGuild merchants (DB-backed guild shops, shared by guildid)
+    {
+        path   = 'xi.zones.Bastok_Markets.npcs.Teerth.onTrigger',
+        zone   = xi.zone.BASTOK_MARKETS,
+        dialog = 'TEERTH_SHOP_DIALOG',
+        guild  = { 5272, 8, 23, 4 }, -- Visala (Goldsmithing)
+    },
+    {
+        path   = 'xi.zones.Bastok_Mines.npcs.Odoba.onTrigger',
+        zone   = xi.zone.BASTOK_MINES,
+        dialog = 'ODOBA_SHOP_DIALOG',
+        guild  = { 5262, 8, 23, 6 }, -- Maymunah (Alchemy)
+    },
+    {
+        path   = 'xi.zones.Northern_San_dOria.npcs.Cauzeriste.onTrigger',
+        zone   = xi.zone.NORTHERN_SAN_DORIA,
+        dialog = 'CAUZERISTE_SHOP_DIALOG',
+        guild  = { 5132, 6, 21, 0 }, -- Chaupire (Woodworking)
+    },
+    {
+        path   = 'xi.zones.Northern_San_dOria.npcs.Lucretia.onTrigger',
+        zone   = xi.zone.NORTHERN_SAN_DORIA,
+        dialog = 'LUCRETIA_SHOP_DIALOG',
+        guild  = { 531, 8, 23, 2 }, -- Doggomehr (Smithing)
+    },
+    {
+        path   = 'xi.zones.Selbina.npcs.Gibol.onTrigger',
+        zone   = xi.zone.SELBINA,
+        dialog = 'CLOTHCRAFT_SHOP_DIALOG',
+        guild  = { 5152, 6, 21, 0 }, -- Kuzah Hpirohpon (Clothcraft)
+    },
+    {
+        path   = 'xi.zones.Southern_San_dOria.npcs.Cletae.onTrigger',
+        zone   = xi.zone.SOUTHERN_SAN_DORIA,
+        dialog = 'CLETAE_DIALOG',
+        guild  = { 529, 3, 18, 4 }, -- Kueh Igunahmori (Leathercraft)
+    },
+    {
+        path   = 'xi.zones.Windurst_Woods.npcs.Meriri.onTrigger',
+        zone   = xi.zone.WINDURST_WOODS,
+        dialog = 'MERIRI_DIALOG',
+        guild  = { 5152, 6, 21, 0 }, -- Kuzah Hpirohpon (Clothcraft)
+    },
+    {
+        path   = 'xi.zones.Windurst_Woods.npcs.Retto-Marutto.onTrigger',
+        zone   = xi.zone.WINDURST_WOODS,
+        dialog = 'RETTO_MARUTTO_DIALOG',
+        guild  = { 514, 8, 23, 3 }, -- Shih Tayuun (Bonecraft)
+    },
+
+    -- Dynamic vendors (ZenithXI Lua guild shops, shared by NPC name)
+    {
+        path   = 'xi.zones.Metalworks.npcs.Vicious_Eye.onTrigger',
+        zone   = xi.zone.METALWORKS,
+        dialog = 'VICIOUS_EYE_SHOP_DIALOG',
+    },
+    {
+        path   = 'xi.zones.Mhaura.npcs.Celestina.onTrigger',
+        zone   = xi.zone.MHAURA,
+        dialog = nil, -- Celestina shows no shop dialog
+    },
+    {
+        path   = 'xi.zones.Mhaura.npcs.Mololo.onTrigger',
+        zone   = xi.zone.MHAURA,
+        dialog = 'SMITHING_GUILD',
+    },
+    {
+        path   = 'xi.zones.Windurst_Waters.npcs.Chomo_Jinjahl.onTrigger',
+        zone   = xi.zone.WINDURST_WATERS,
+        dialog = 'CHOMOJINJAHL_SHOP_DIALOG',
+    },
+}
+
+-- Resolve the NPC's kept dialog text id, or nil if it has none.
+-- @param entry table: a sharedGuildVendors row
+-- @return integer or nil: the resolved zones[zone].text value
+local function dialogText(entry)
+    if entry.dialog == nil then
+        return nil
+    end
+
+    return zones[entry.zone].text[entry.dialog]
+end
+
+-- Open the partner's DB-backed guild shop via sendGuild. Stock is shared by guildid.
+-- @param player CBaseEntity
+-- @param npc CBaseEntity: the triggered General Vendor
+-- @param entry table: a sharedGuildVendors row with a guild field
+local function openSharedSendGuild(player, npc, entry)
+    local guild = entry.guild
+    if player:sendGuild(guild[1], guild[2], guild[3], guild[4]) then
+        local dialog = dialogText(entry)
+        if dialog ~= nil then
+            player:showText(npc, dialog)
+        end
+    end
+end
+
+-- Open the shared dynamic vendor shop. The alias registered by c_guildShopSharing
+-- (xi.guildShops.alias) maps this General Vendor's name to the partner's shop key,
+-- so triggering it directly opens and depletes the shared inventory + price pool.
+-- @param player CBaseEntity
+-- @param npc CBaseEntity: the triggered General Vendor
+-- @param entry table: a sharedGuildVendors row without a guild field
+local function openSharedDynamicShop(player, npc, entry)
+    if xi.guildShops.onTrigger(player, npc) then
+        local dialog = dialogText(entry)
+        if dialog ~= nil then
+            player:showText(npc, dialog)
+        end
+    end
+end
+
+for _, entry in ipairs(sharedGuildVendors) do
+    m:addOverride(entry.path, function(player, npc)
+        if entry.guild ~= nil then
+            openSharedSendGuild(player, npc, entry)
+        else
+            openSharedDynamicShop(player, npc, entry)
+        end
+    end)
+end
+
+return m


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Reverts Guild Vendors to legacy system with shared inventory

## Steps to test these changes

## Test: Shared inventory — Mololo ↔ Kamilah (headline)

**Goal**: Buying from the General Vendor (Mololo) depletes the *same* pool the dynamic vendor (Kamilah) sells from, at the same price.

**Commands**:
```
!zone 249           -- Mhaura
!gotoname Mololo
```

**Steps**:
1. Target **Mololo** and interact. The guild shop opens. Note the **Chunk of Tin Ore** stock count and buy price shown.
2. Read the shared state exactly:
   ```
   !exec player:printToPlayer(tostring(xi.guildShops.state.Kamilah and xi.guildShops.state.Kamilah.items[641].stock))
   ```
3. Buy **5x Chunk of Tin Ore** from Mololo's shop window. Close the window.
4. `!gotoname Kamilah` → target **Kamilah** and interact. Note the Chunk of Tin Ore stock count and buy price.
5. Read the shared state again:
   ```
   !exec player:printToPlayer(tostring(xi.guildShops.state.Kamilah and xi.guildShops.state.Kamilah.items[641].stock))
   ```

