### PR TITLE
Reject duplicate logins at auth stage

### DIFF
--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -260,31 +260,14 @@ void auth_session::read_func()
                                  "WHERE a.charid IN (SELECT charid FROM chars WHERE accid = ?)",
                                  accountID);
             }
-            // TODO: Lock out same account logging in multiple times. Can check data/view session existence on same IP/account?
-            // Not a real problem because the account is locked out when a character is logged in.
-
-            /*
-            const auto rset = db::preparedStmt("SELECT charid "
-                    "FROM accounts_sessions "
-                    "WHERE accid = ? LIMIT 1", accountID);
-            if (rset && rset->rowsCount() != 0 && rset->next())
+            // Reject login if this account already has an active session on a map server
+            const auto sessionCheck = db::preparedStmt("SELECT charid FROM accounts_sessions WHERE accid = ? LIMIT 1", accountID);
+            if (sessionCheck && sessionCheck->rowsCount() != 0)
             {
-                // TODO: kick player out of map server if already logged in
-                // uint32 charid = rset->get<uint32>("charid");
-
-                // This error message doesn't work when sent this way. Unknown how to transmit "1039" error message to a client already logged in.
-                // session_t& authenticatedSession = get_authenticated_session(socket_, session.sentAccountID);
-                // if (auto data = authenticatedSession.buffer_.data()session)
-                // {
-                //  generateErrorMessage(data->buffer_.data(), 139);
-                //  data->do_write(0x24);
-                //  return;
-                //}
-                ref<uint8>(buffer_.data(), 0) = LOGIN_ERROR_ALREADY_LOGGED_IN;
-                do_write(1);
+                ShowWarningFmt("login_parse: account {} attempted duplicate login from {}", accountID, ipAddress);
+                sendLoginResult(login_result::LOGIN_ERROR_ALREADY_LOGGED_IN);
                 return;
             }
-            */
 
             // Success
             unsigned char hash[16];


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Replaces the commented-out duplicate login TODO in `auth_session.cpp` with a working implementation.

After password/OTP verification succeeds, checks `accounts_sessions` for an existing active session on the account. If one exists, rejects the login with `LOGIN_ERROR_ALREADY_LOGGED_IN` and logs a warning with the source IP.

This hardens the login flow by catching duplicate logins early at the auth layer, rather than relying solely on the map server's downstream lockout.

## Steps to test these changes

1. Build the project (zero errors/warnings)
2. Start the server stack (xi_connect, xi_world, xi_map)
3. Log in with xiloader and create/select a character (enters game world)
4. Launch a second xiloader instance and attempt to log in with the same account
5. Expected: Login is rejected with "Account already logged in" message
6. Verify the connect-server logs: `login_parse: account X attempted duplicate login from Y`
7. Log out the first character, try again — login should succeed