### PR TITLE
Implement retail-style duplicate login handling

### DIFF
--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -260,31 +260,15 @@ void auth_session::read_func()
                                  "WHERE a.charid IN (SELECT charid FROM chars WHERE accid = ?)",
                                  accountID);
             }
-            // TODO: Lock out same account logging in multiple times. Can check data/view session existence on same IP/account?
-            // Not a real problem because the account is locked out when a character is logged in.
-
-            /*
-            const auto rset = db::preparedStmt("SELECT charid "
-                    "FROM accounts_sessions "
-                    "WHERE accid = ? LIMIT 1", accountID);
-            if (rset && rset->rowsCount() != 0 && rset->next())
+            // Retail behavior: if this account already has an active session, kick the old
+            // session and allow the new login to proceed. The map server's stale-session
+            // cleanup will handle disconnecting the old client.
+            const auto sessionCheck = db::preparedStmt("SELECT charid FROM accounts_sessions WHERE accid = ? LIMIT 1", accountID);
+            if (sessionCheck && sessionCheck->rowsCount() != 0)
             {
-                // TODO: kick player out of map server if already logged in
-                // uint32 charid = rset->get<uint32>("charid");
-
-                // This error message doesn't work when sent this way. Unknown how to transmit "1039" error message to a client already logged in.
-                // session_t& authenticatedSession = get_authenticated_session(socket_, session.sentAccountID);
-                // if (auto data = authenticatedSession.buffer_.data()session)
-                // {
-                //  generateErrorMessage(data->buffer_.data(), 139);
-                //  data->do_write(0x24);
-                //  return;
-                //}
-                ref<uint8>(buffer_.data(), 0) = LOGIN_ERROR_ALREADY_LOGGED_IN;
-                do_write(1);
-                return;
+                ShowInfoFmt("login_parse: account {} logging in from {}, clearing existing session", accountID, ipAddress);
+                db::preparedStmt("DELETE FROM accounts_sessions WHERE accid = ?", accountID);
             }
-            */
 
             // Success
             unsigned char hash[16];


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements retail-style duplicate login handling in `auth_session.cpp`.

**Retail behavior:** When an account logs in while already having an active session on a map server, the new login succeeds and the old session is cleared. The map server's existing stale-session cleanup (5-second timeout) handles disconnecting the old client.

This replaces the commented-out TODO block (lines 263-287) that attempted to reject duplicate logins — which is not how retail works.

**Before:** Commented-out dead code with a TODO note.
**After:** Working retail-accurate implementation in 8 lines.

## Steps to test these changes

1. Build the project
2. Start the server stack (xi_connect, xi_world, xi_map)
3. Log in with xiloader and select a character (enters game world)
4. Insert a fake session: `INSERT INTO accounts_sessions (accid, charid, server_addr, server_port, client_addr) VALUES (1000, 1, 16777343, 54230, 16777343);`
5. Attempt to log in again with the same account
6. **Expected:** Login succeeds, old session row is deleted
7. Verify connect-server logs: `login_parse: account X logging in from Y, clearing existing session`