### PR TITLE
WyvernFixStackingLevels

### DIFF
--- a/modules/zenith-public/lua/2-base/dragoon_adjustments.lua
+++ b/modules/zenith-public/lua/2-base/dragoon_adjustments.lua
@@ -6,7 +6,7 @@
 
 require('modules/module_utils')
 
-local m = Module:new('dragoon_adjustments')
+local m = Module:new('b_dragoon_adjustments')
 
 local wyvernMods = {
     { xi.mod.ACC, 1 },
@@ -41,16 +41,22 @@ m:addOverride('xi.job_utils.dragoon.addWyvernExp', function(player, ability)
     return numLevelUps
 end)
 
-m:addOverride('xi.pets.wyvern.onMobDeath', function(mob, player)
-    local numLevelUps = mob:getLocalVar('level_Ups')
+m:addOverride('xi.pets.wyvern.removeWyvernLevels', function(mob)
+    local master  = mob:getMaster()
+    local numLvls = mob:getLocalVar('level_Ups')
 
-    -- Add player buffs back before call to super
-    -- Call to super will remove the original mod calculations
-    for _, mod in ipairs(playerMods) do
-        player:addMod(mod[1], mod[2] * numLevelUps)
+    -- The player only ever received the trimmed buffs (see the addWyvernExp override),
+    -- but base removeWyvernLevels deletes the full base amounts. Re-add the trimmed delta
+    -- first so the net removal matches what the player actually has.
+    -- NOTE: the wyvern's onMobDeath is invoked with a nil killer arg, so the player must
+    -- be resolved via mob:getMaster() rather than a function parameter.
+    if master and numLvls > 0 then
+        for _, mod in ipairs(playerMods) do
+            master:addMod(mod[1], mod[2] * numLvls)
+        end
     end
 
-    super(mob, player)
+    super(mob)
 end)
 
 return m


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a bug where wyvern levels were stacking when dismissed or killed and resummoned.
## Steps to test these changes

Summon Wyvern and gain levels then dismiss and resummon those levels should no longer be present.
In depth testing write up added to Plane for player testing.
