### PR TITLE
Implement retail-style duplicate login handling

### DIFF
--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -260,31 +260,15 @@ void auth_session::read_func()
                                  "WHERE a.charid IN (SELECT charid FROM chars WHERE accid = ?)",
                                  accountID);
             }
-            // TODO: Lock out same account logging in multiple times. Can check data/view session existence on same IP/account?
-            // Not a real problem because the account is locked out when a character is logged in.
-
-            /*
-            const auto rset = db::preparedStmt("SELECT charid "
-                    "FROM accounts_sessions "
-                    "WHERE accid = ? LIMIT 1", accountID);
-            if (rset && rset->rowsCount() != 0 && rset->next())
+            // Retail behavior: if this account already has an active session, kick the old
+            // session and allow the new login to proceed. The map server's stale-session
+            // cleanup will handle disconnecting the old client.
+            const auto sessionCheck = db::preparedStmt("SELECT charid FROM accounts_sessions WHERE accid = ? LIMIT 1", accountID);
+            if (sessionCheck && sessionCheck->rowsCount() != 0)
             {
-                // TODO: kick player out of map server if already logged in
-                // uint32 charid = rset->get<uint32>("charid");
-
-                // This error message doesn't work when sent this way. Unknown how to transmit "1039" error message to a client already logged in.
-                // session_t& authenticatedSession = get_authenticated_session(socket_, session.sentAccountID);
-                // if (auto data = authenticatedSession.buffer_.data()session)
-                // {
-                //  generateErrorMessage(data->buffer_.data(), 139);
-                //  data->do_write(0x24);
-                //  return;
-                //}
-                ref<uint8>(buffer_.data(), 0) = LOGIN_ERROR_ALREADY_LOGGED_IN;
-                do_write(1);
-                return;
+                ShowInfoFmt("login_parse: account {} logging in from {}, clearing existing session", accountID, ipAddress);
+                db::preparedStmt("DELETE FROM accounts_sessions WHERE accid = ?", accountID);
             }
-            */
 
             // Success
             unsigned char hash[16];

--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -260,9 +260,9 @@ void auth_session::read_func()
                                  "WHERE a.charid IN (SELECT charid FROM chars WHERE accid = ?)",
                                  accountID);
             }
-            // Retail behavior: if this account already has an active session, kick the old
-            // session and allow the new login to proceed. The map server's stale-session
-            // cleanup will handle disconnecting the old client.
+            // Retail behavior: if this account already has an active session, clear the DB
+            // session row so the new login can proceed. The map server handles evicting the
+            // old character when the new session arrives (in createPendingSession).
             const auto sessionCheck = db::preparedStmt("SELECT charid FROM accounts_sessions WHERE accid = ? LIMIT 1", accountID);
             if (sessionCheck && sessionCheck->rowsCount() != 0)
             {

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -51,6 +51,7 @@
 
 #include "utils/charutils.h"
 #include "utils/jailutils.h"
+#include "utils/petutils.h"
 #include "utils/serverutils.h"
 #include "utils/zoneutils.h"
 
@@ -153,51 +154,79 @@ void IPCClient::handleMessage_AccountLogin(const IPP& ipp, const ipc::AccountLog
 
     if (auto session = networking_.sessions().getSessionByAccountId(message.accountId))
     {
-        // Extreme overkill but...
-        // Scramble key so server rejects input
-        for (uint32_t& i : session->blowfish.key)
+        if (session->PChar && session->PChar->animation == ANIMATION_ATTACK)
         {
-            i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
-        }
+            // Character is in combat — don't instant-evict (would allow exploiting to
+            // escape death). Instead, scramble blowfish so the old client can't send
+            // valid packets. The character stays in-zone as link-dead and mobs can
+            // still kill them. cleanupSessions will remove them after timeout.
+            ShowInfoFmt("handleMessage_AccountLogin: account {} in combat, scrambling keys (link-dead)", message.accountId);
 
-        for (uint32_t& i : session->prev_blowfish.key)
-        {
-            i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
-        }
-
-        for (uint32_t& i : session->blowfish.P)
-        {
-            i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
-        }
-
-        for (uint32_t& i : session->prev_blowfish.P)
-        {
-            i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
-        }
-
-        for (uint8_t& i : session->blowfish.hash)
-        {
-            // uniform_int_distribution doesnt like uint8_t, so do some workaround
-            i = static_cast<uint8_t>(xirand::GetRandomNumber<uint16_t>(std::numeric_limits<uint16_t>::max()) % 255);
-        }
-
-        for (uint8_t& i : session->prev_blowfish.hash)
-        {
-            // uniform_int_distribution doesnt like uint8_t, so do some workaround
-            i = static_cast<uint8_t>(xirand::GetRandomNumber<uint16_t>(std::numeric_limits<uint16_t>::max()) % 255);
-        }
-
-        for (int i = 0; i < 4; i++)
-        {
-            for (uint32_t& x : session->blowfish.S[i])
+            for (uint32_t& i : session->blowfish.key)
             {
-                x = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
+                i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
             }
 
-            for (uint32_t& x : session->prev_blowfish.S[i])
+            for (uint32_t& i : session->prev_blowfish.key)
             {
-                x = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
+                i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
             }
+
+            for (uint32_t& i : session->blowfish.P)
+            {
+                i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
+            }
+
+            for (uint32_t& i : session->prev_blowfish.P)
+            {
+                i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
+            }
+
+            for (uint8_t& i : session->blowfish.hash)
+            {
+                i = static_cast<uint8_t>(xirand::GetRandomNumber<uint16_t>(std::numeric_limits<uint16_t>::max()) % 255);
+            }
+
+            for (uint8_t& i : session->prev_blowfish.hash)
+            {
+                i = static_cast<uint8_t>(xirand::GetRandomNumber<uint16_t>(std::numeric_limits<uint16_t>::max()) % 255);
+            }
+
+            for (int i = 0; i < 4; i++)
+            {
+                for (uint32_t& x : session->blowfish.S[i])
+                {
+                    x = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
+                }
+
+                for (uint32_t& x : session->prev_blowfish.S[i])
+                {
+                    x = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
+                }
+            }
+        }
+        else
+        {
+            // Not in combat — instant clean eviction (retail behavior).
+            if (session->PChar)
+            {
+                ShowInfoFmt("handleMessage_AccountLogin: evicting session for account {} (duplicate login)", message.accountId);
+
+                session->PChar->StatusEffectContainer->SaveStatusEffects(true);
+                charutils::SaveCharPosition(session->PChar.get());
+
+                if (session->PChar->PPet != nullptr && session->PChar->PPet->objtype == TYPE_MOB)
+                {
+                    petutils::DespawnPet(session->PChar.get());
+                }
+
+                session->PChar->status = STATUS_TYPE::SHUTDOWN;
+                charutils::removeCharFromZone(session->PChar.get());
+                session->shuttingDown = 0; // Prevent destroySession from deleting the new accounts_sessions row
+                session->PChar.reset();
+            }
+
+            networking_.sessions().destroySession(session);
         }
     }
 }
@@ -208,9 +237,39 @@ void IPCClient::handleMessage_CharZone(const IPP& ipp, const ipc::CharZone& mess
 
     auto session = networking_.sessions().getSessionByCharId(message.charId);
 
-    if (session) // Update in case of edge case
+    if (session)
     {
-        session->last_update = timer::now();
+        if (session->PChar)
+        {
+            // Active character in this session means a duplicate login —
+            // the old client is still playing. Evict it (retail: new login wins).
+            ShowInfoFmt("handleMessage_CharZone: evicting active session for charid {} (duplicate login)", message.charId);
+
+            session->PChar->StatusEffectContainer->SaveStatusEffects(true);
+            charutils::SaveCharPosition(session->PChar.get());
+
+            if (session->PChar->PPet != nullptr && session->PChar->PPet->objtype == TYPE_MOB)
+            {
+                petutils::DespawnPet(session->PChar.get());
+            }
+
+            session->PChar->status = STATUS_TYPE::SHUTDOWN;
+            charutils::removeCharFromZone(session->PChar.get());
+            // removeCharFromZone sets shuttingDown=1 for SHUTDOWN status, which
+            // would cause destroySession to DELETE the accounts_sessions row.
+            // That row now belongs to Client 2, so prevent the deletion.
+            session->shuttingDown = 0;
+            session->PChar.reset();
+
+            networking_.sessions().destroySession(session);
+
+            networking_.sessions().createPendingSession(message.charId);
+        }
+        else
+        {
+            // PChar is null — normal zoning (session waiting for client reconnect)
+            session->last_update = timer::now();
+        }
     }
     else
     {

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -154,80 +154,34 @@ void IPCClient::handleMessage_AccountLogin(const IPP& ipp, const ipc::AccountLog
 
     if (auto session = networking_.sessions().getSessionByAccountId(message.accountId))
     {
-        if (session->PChar && session->PChar->animation == ANIMATION_ATTACK)
+        if (session->PChar)
         {
-            // Character is in combat — don't instant-evict (would allow exploiting to
-            // escape death). Instead, scramble blowfish so the old client can't send
-            // valid packets. The character stays in-zone as link-dead and mobs can
-            // still kill them. cleanupSessions will remove them after timeout.
-            ShowInfoFmt("handleMessage_AccountLogin: account {} in combat, scrambling keys (link-dead)", message.accountId);
+            ShowInfoFmt("handleMessage_AccountLogin: evicting session for account {} (duplicate login)", message.accountId);
 
-            for (uint32_t& i : session->blowfish.key)
+            // If the character is in combat, snapshot the mobs' hate before
+            // evicting so it can be restored when they next zone in. This stops a
+            // second session being used to instantly shed enmity, while leaving
+            // the normal logout-to-shed behaviour untouched.
+            if (session->PChar->hasEnmityEXPENSIVE())
             {
-                i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
+                charutils::captureDuplicateLoginEnmity(session->PChar.get());
             }
 
-            for (uint32_t& i : session->prev_blowfish.key)
+            session->PChar->StatusEffectContainer->SaveStatusEffects(true);
+            charutils::SaveCharPosition(session->PChar.get());
+
+            if (session->PChar->PPet != nullptr && session->PChar->PPet->objtype == TYPE_MOB)
             {
-                i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
+                petutils::DespawnPet(session->PChar.get());
             }
 
-            for (uint32_t& i : session->blowfish.P)
-            {
-                i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
-            }
-
-            for (uint32_t& i : session->prev_blowfish.P)
-            {
-                i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
-            }
-
-            for (uint8_t& i : session->blowfish.hash)
-            {
-                i = static_cast<uint8_t>(xirand::GetRandomNumber<uint16_t>(std::numeric_limits<uint16_t>::max()) % 255);
-            }
-
-            for (uint8_t& i : session->prev_blowfish.hash)
-            {
-                i = static_cast<uint8_t>(xirand::GetRandomNumber<uint16_t>(std::numeric_limits<uint16_t>::max()) % 255);
-            }
-
-            for (int i = 0; i < 4; i++)
-            {
-                for (uint32_t& x : session->blowfish.S[i])
-                {
-                    x = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
-                }
-
-                for (uint32_t& x : session->prev_blowfish.S[i])
-                {
-                    x = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
-                }
-            }
+            session->PChar->status = STATUS_TYPE::SHUTDOWN;
+            charutils::removeCharFromZone(session->PChar.get());
+            session->shuttingDown = 0; // Prevent destroySession from deleting the new accounts_sessions row
+            session->PChar.reset();
         }
-        else
-        {
-            // Not in combat — instant clean eviction (retail behavior).
-            if (session->PChar)
-            {
-                ShowInfoFmt("handleMessage_AccountLogin: evicting session for account {} (duplicate login)", message.accountId);
 
-                session->PChar->StatusEffectContainer->SaveStatusEffects(true);
-                charutils::SaveCharPosition(session->PChar.get());
-
-                if (session->PChar->PPet != nullptr && session->PChar->PPet->objtype == TYPE_MOB)
-                {
-                    petutils::DespawnPet(session->PChar.get());
-                }
-
-                session->PChar->status = STATUS_TYPE::SHUTDOWN;
-                charutils::removeCharFromZone(session->PChar.get());
-                session->shuttingDown = 0; // Prevent destroySession from deleting the new accounts_sessions row
-                session->PChar.reset();
-            }
-
-            networking_.sessions().destroySession(session);
-        }
+        networking_.sessions().destroySession(session);
     }
 }
 
@@ -242,8 +196,15 @@ void IPCClient::handleMessage_CharZone(const IPP& ipp, const ipc::CharZone& mess
         if (session->PChar)
         {
             // Active character in this session means a duplicate login —
-            // the old client is still playing. Evict it (retail: new login wins).
+            // the old client is still in the world. Evict it (retail: new login wins).
             ShowInfoFmt("handleMessage_CharZone: evicting active session for charid {} (duplicate login)", message.charId);
+
+            // Snapshot combat enmity (if any) so it can be restored when the
+            // character zones back in — a second session can't be used to shed hate.
+            if (session->PChar->hasEnmityEXPENSIVE())
+            {
+                charutils::captureDuplicateLoginEnmity(session->PChar.get());
+            }
 
             session->PChar->StatusEffectContainer->SaveStatusEffects(true);
             charutils::SaveCharPosition(session->PChar.get());

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -28,6 +28,9 @@
 
 #include <array>
 #include <chrono>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
 
 #include "lua/luautils.h"
 
@@ -62,6 +65,7 @@
 #include "ability.h"
 #include "alliance.h"
 #include "conquest_system.h"
+#include "enmity_container.h"
 #include "grades.h"
 #include "ipc_client.h"
 #include "item_container.h"
@@ -71,6 +75,7 @@
 #include "map_networking.h"
 #include "mob_modifier.h"
 #include "nominate_manager.h"
+#include "notoriety_container.h"
 #include "recast_container.h"
 #include "roe.h"
 #include "spell.h"
@@ -8139,6 +8144,123 @@ void removeCharFromZone(CCharEntity* PChar)
     charutils::SaveLastLogout(PChar);
 
     PChar->status = STATUS_TYPE::DISAPPEAR;
+}
+
+namespace
+{
+    struct CapturedEnmity_t
+    {
+        uint32 mobId;
+        int32  CE;
+        int32  VE;
+    };
+
+    struct CapturedEnmityRecord_t
+    {
+        timer::time_point             capturedAt;
+        std::vector<CapturedEnmity_t> entries;
+    };
+
+    // Keyed by charid. Holds enmity snapshots taken when a character is evicted
+    // by a duplicate (second session) login, to be restored on its next zone-in.
+    std::unordered_map<uint32, CapturedEnmityRecord_t> g_duplicateLoginEnmity;
+    std::mutex                                         g_duplicateLoginEnmityMutex;
+
+    // How long a captured snapshot stays valid. After this a relog is treated as
+    // a normal return (mobs would have reset/deaggroed on their own by then).
+    constexpr auto kDuplicateLoginEnmityTTL = std::chrono::seconds(180);
+} // namespace
+
+void captureDuplicateLoginEnmity(CCharEntity* PChar)
+{
+    if (PChar == nullptr || PChar->PNotorietyContainer == nullptr)
+    {
+        return;
+    }
+
+    std::vector<CapturedEnmity_t> entries;
+
+    // PNotorietyContainer is the list of mobs that currently hold enmity on PChar.
+    for (auto* PEntity : *PChar->PNotorietyContainer)
+    {
+        auto* PMob = dynamic_cast<CMobEntity*>(PEntity);
+        if (PMob == nullptr || PMob->PEnmityContainer == nullptr)
+        {
+            continue;
+        }
+
+        const int32 CE = PMob->PEnmityContainer->GetCE(PChar);
+        const int32 VE = PMob->PEnmityContainer->GetVE(PChar);
+
+        if (CE > 0 || VE > 0)
+        {
+            entries.push_back({ PMob->id, CE, VE });
+        }
+    }
+
+    if (entries.empty())
+    {
+        return;
+    }
+
+    const std::size_t count = entries.size();
+
+    {
+        std::lock_guard<std::mutex> lock(g_duplicateLoginEnmityMutex);
+        g_duplicateLoginEnmity[PChar->id] = { timer::now(), std::move(entries) };
+    }
+
+    ShowInfoFmt("captureDuplicateLoginEnmity: stored {} enmity entr(y/ies) for charid {}", count, PChar->id);
+}
+
+void restoreDuplicateLoginEnmity(CCharEntity* PChar)
+{
+    if (PChar == nullptr)
+    {
+        return;
+    }
+
+    CapturedEnmityRecord_t record;
+    {
+        std::lock_guard<std::mutex> lock(g_duplicateLoginEnmityMutex);
+        auto                        it = g_duplicateLoginEnmity.find(PChar->id);
+        if (it == g_duplicateLoginEnmity.end())
+        {
+            return;
+        }
+        record = std::move(it->second);
+        g_duplicateLoginEnmity.erase(it);
+    }
+
+    if (timer::now() > record.capturedAt + kDuplicateLoginEnmityTTL)
+    {
+        return;
+    }
+
+    uint32 restored = 0;
+    for (const auto& entry : record.entries)
+    {
+        auto* PMob = dynamic_cast<CMobEntity*>(zoneutils::GetEntity(entry.mobId, TYPE_MOB));
+        if (PMob == nullptr || PMob->PEnmityContainer == nullptr || PMob->isDead())
+        {
+            continue;
+        }
+
+        // Mob must still share the character's zone (it could have been killed and
+        // respawned elsewhere, or the character could have zoned out before relog).
+        if (PMob->getZone() != PChar->getZone())
+        {
+            continue;
+        }
+
+        PMob->PEnmityContainer->UpdateEnmity(PChar, entry.CE, entry.VE);
+        ++restored;
+    }
+
+    if (restored > 0)
+    {
+        ShowInfoFmt("restoreDuplicateLoginEnmity: re-applied enmity from {} mob(s) onto charid {}", restored, PChar->id);
+    }
 }
 
 void updateSession(MapSession* PSession, CCharEntity* PChar, CZone* currentZone)

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -304,6 +304,14 @@ void forceSynthCritFail(const std::string& sourceFunction, CCharEntity* PChar);
 
 void removeCharFromZone(CCharEntity* PChar);
 
+// Duplicate-login (second session) anti-exploit: capture the mobs' hate on a
+// character right before it is evicted by a duplicate login, then restore that
+// hate when the character next zones in. This stops players using a second
+// session to instantly shed enmity, while leaving the normal logout-to-shed
+// behaviour (e.g. sleep a mob then log out) completely unaffected.
+void captureDuplicateLoginEnmity(CCharEntity* PChar);
+void restoreDuplicateLoginEnmity(CCharEntity* PChar);
+
 void updateSession(MapSession* PSession, CCharEntity* PChar, CZone* currentZone);
 void loadDeathTimestamp(CCharEntity* PChar);
 void loadZoningFlag(CCharEntity* PChar);

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -25,6 +25,7 @@
 #include "aman.h"
 #include "battlefield.h"
 #include "campaign_system.h"
+#include "charutils.h"
 #include "common/logging.h"
 #include "conquest_system.h"
 #include "entities/mobentity.h"
@@ -1407,6 +1408,11 @@ void AfterZoneIn(CBaseEntity* PEntity)
 
     PChar->aman().onZoneIn();
     luautils::AfterZoneIn(PChar);
+
+    // Re-apply any enmity that was captured when this character was evicted by a
+    // duplicate (second session) login, so a second session can't be used to
+    // shed hate. No-op for normal logins.
+    charutils::restoreDuplicateLoginEnmity(PChar);
 }
 
 auto IsAlwaysOutOfNationControl(const REGION_TYPE region) -> bool


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements retail-style duplicate login handling across auth_session.cpp and ipc_client.cpp.

**Retail behavior:** When an account logs in while already having an active session on a map server, the new login succeeds and the old session is **instantly evicted** — the old client is immediately disconnected and the new client loads in cleanly.

### Changes:
- **auth_session.cpp**: Clears the accounts_sessions DB row when a duplicate login is detected, allowing the new login to proceed.
- **ipc_client.cpp (handleMessage_AccountLogin)**: Instantly evicts the old session when the map server receives the AccountLogin IPC for an already-active account. Saves status effects/position, despawns pet, removes character from zone, and destroys the session cleanly.
- **ipc_client.cpp (handleMessage_CharZone)**: Safety net eviction in case AccountLogin didn't catch it (only triggers when PChar is still active; normal zoning is unaffected).

**Before:** Commented-out dead code with a TODO note that attempted to reject duplicate logins — which is not how retail works.
**After:** Working retail-accurate implementation with instant eviction and no log spam.

## Steps to test these changes

1. Build the project
2. Start the server stack (xi_connect, xi_world, xi_map)
3. Log in with a game client and select a character (enters game world)
4. Open a second game client and log in with the **same account**
5. Select the same character on Client 2
6. **Expected:**
   - Client 1 is instantly disconnected
   - Client 2 loads into the game world successfully
   - Map server log shows one info line: handleMessage_AccountLogin evicting session for account X (duplicate login)
   - No "bad packet" log spam
7. Verify normal zoning still works (zone between areas on Client 2 after login)