### PR TITLE
Correctly implement Cascade (ZENITHDEV-211)

### DIFF
--- a/modules/zenith-public/lua/4-additive/jobAbilities/cascadeMagicDamage.lua
+++ b/modules/zenith-public/lua/4-additive/jobAbilities/cascadeMagicDamage.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- Cascade Magic Damage Equation Override
+-- Custom modifications for ZenithXI
+-- Reduces the Cascade magic damage bonus from floor(TP / 10) to floor(TP / 40).
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+
+local m = Module:new('a-j_blm_cascade')
+
+m:addOverride('xi.job_utils.black_mage.calculateCascadeMagicDamage', function(player, tp)
+    return math.floor(tp / 40)
+end)
+
+return m

--- a/scripts/effects/cascade.lua
+++ b/scripts/effects/cascade.lua
@@ -4,15 +4,16 @@
 ---@type TEffect
 local effectObject = {}
 
+-- The magic damage bonus is stored in the effect's power when Cascade is used, and is applied to
+-- (and consumed by) the next elemental magic spell via xi.job_utils.black_mage.tryConsumeCascade.
+-- See scripts/globals/spells/damage_spell.lua and enfeebling_spell.lua.
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.MATT, 100)
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.MATT, 100)
 end
 
 return effectObject

--- a/scripts/globals/job_utils/black_mage.lua
+++ b/scripts/globals/job_utils/black_mage.lua
@@ -21,8 +21,37 @@ end
 -----------------------------------
 -- Ability Use Functions
 -----------------------------------
+-- Cascade grants a magic damage bonus to the next elemental magic spell, based on the TP consumed
+-- when the ability is used. Retail formula is floor(TP / 10). Kept as its own function so servers
+-- can override the equation via a module.
+xi.job_utils.black_mage.calculateCascadeMagicDamage = function(player, tp)
+    return math.floor(tp / 10)
+end
+
+-- Consumes the Cascade buff for an elemental magic spell, returning the stored magic damage bonus.
+-- Cascade is only consumed by elemental magic (including non-damaging spells such as Burn or Frost),
+-- and never by weapon skills, divine magic, etc.
+xi.job_utils.black_mage.tryConsumeCascade = function(caster, skillType)
+    if
+        skillType ~= xi.skill.ELEMENTAL_MAGIC or
+        not caster:hasStatusEffect(xi.effect.CASCADE)
+    then
+        return 0
+    end
+
+    local bonus = caster:getStatusEffect(xi.effect.CASCADE):getPower()
+    caster:delStatusEffectSilent(xi.effect.CASCADE)
+
+    return bonus
+end
+
 xi.job_utils.black_mage.useCascade = function(player, target, ability)
-    player:addStatusEffect(xi.effect.CASCADE, { power = 1, duration = 60, origin = player })
+    local tp    = player:getTP()
+    local bonus = xi.job_utils.black_mage.calculateCascadeMagicDamage(player, tp)
+
+    -- Spend all current TP and store the resulting magic damage bonus on the buff.
+    player:delTP(tp)
+    player:addStatusEffect(xi.effect.CASCADE, { power = bonus, duration = 60, origin = player })
 
     return xi.effect.CASCADE
 end

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -427,6 +427,9 @@ xi.spells.damage.calculateBaseDamage = function(caster, target, spellId, spellGr
     -- Bonus to spell base damage from gear.
     baseSpellDamageBonus = baseSpellDamageBonus + caster:getMod(xi.mod.MAGIC_DAMAGE)
 
+    -- Cascade (BLM): flat magic damage bonus to the next elemental spell, consumed on use.
+    baseSpellDamageBonus = baseSpellDamageBonus + xi.job_utils.black_mage.tryConsumeCascade(caster, skillType)
+
     -----------------------------------
     -- STEP 4: Spell Damage
     -----------------------------------

--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -388,6 +388,9 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     local spellEffect  = pTable[spellId][column.EFFECT_ID]
     local tier         = pTable[spellId][column.EFFECT_TIER] or 0
 
+    -- Cascade (BLM) is consumed by any elemental magic, including non-damaging spells like Burn/Frost.
+    xi.job_utils.black_mage.tryConsumeCascade(caster, skillType)
+
     ------------------------------
     -- STEP 1: Check spell nullification.
     ------------------------------


### PR DESCRIPTION
Implements **ZENITHDEV-211** — Correctly implement Cascade (BLM).

## Problem
Cascade (BLM job ability) was a stub that simply added a flat **+100 Magic Attack Bonus**, ignoring the caster's TP and applying to *any* magic. Per [BG-Wiki](https://www.bg-wiki.com/ffxi/Cascade) / [FFO wiki](https://wiki.ffo.jp/html/33800.html) it should consume current TP and grant a **Magic Damage** bonus to the **next elemental magic spell only**.

## Part 1 — core (upstream-accurate)
- On use: capture current TP, `delTP(tp)`, store a Magic Damage bonus = `floor(TP / 10)` in the effect power.
- Bonus is applied/consumed in the spell pipeline (mirrors the existing **Manawell**/**Ebullience** next-spell precedent), added alongside `xi.mod.MAGIC_DAMAGE`.
- Only **Elemental Magic** consumes it (not WS, divine, etc.).
- Consumed by **any** elemental spell, including non-damaging ones (Burn, Frost) via the enfeebling path.

### Files
- `scripts/globals/job_utils/black_mage.lua` — `calculateCascadeMagicDamage`, `tryConsumeCascade`, rewritten `useCascade`.
- `scripts/effects/cascade.lua` — dropped flat +100 MATT (no-op, like ebullience).
- `scripts/globals/spells/damage_spell.lua` — consume in `calculateBaseDamage` (nukes).
- `scripts/globals/spells/enfeebling_spell.lua` — consume in `useEnfeeblingSpell` (Burn/Frost).

## Part 2 — ZenithXI module override
- `modules/zenith-public/lua/4-additive/jobAbilities/cascadeMagicDamage.lua` — overrides the equation to `floor(TP / 40)` (¼ retail) for ZenithXI tuning.

## Testing notes
- Draft for test-server validation.
- Requires the map server to reload Lua. The Cascade ability level/recast override lives in `modules/zenith-public/sql/TraitsAndJAs.sql` (BLM Lv45, 90s recast) — import into the test DB if not already present.
- Suggested checks: TP is consumed on use; next Fire/Stone/etc. nuke gets the mDMG bonus; bonus is *not* consumed by WS/divine/cure; Burn/Frost consume the buff; AoE -ga consumes on first target (matches Manawell/Ebullience).
