### PR TITLE
Adjust abilities and traits round 2

### DIFF
--- a/modules/zenith-public/lua/2-base/abilities.lua
+++ b/modules/zenith-public/lua/2-base/abilities.lua
@@ -36,8 +36,8 @@ local effectAdjustments =
         effectId = xi.effect.CONSPIRATOR,
         multiply =
         {
-            power = 0.75, -- 25% reduction
-            subpower = 0.75, -- 25% reduction
+            power = 0.50, -- 50% reduction
+            subpower = 0.50, -- 50% reduction
         },
     },
     dodge =
@@ -70,8 +70,8 @@ local effectAdjustments =
         effectId = xi.effect.HAGAKURE,
         multiply =
         {
-            power = 0.5, -- 50% reduction
-            subpower = 0.5, -- 50% reduction
+            power = 0.25, -- 75% reduction
+            subpower = 0.25, --75% reduction
         },
     },
     hamanoha =
@@ -122,7 +122,7 @@ local effectAdjustments =
         effectId = xi.effect.MARCATO,
         add =
         {
-            power = -25, -- Changed from 1.5x to 1.25x
+            power = -30, -- Changed from 1.5x to 1.20x
         },
     },
 }

--- a/modules/zenith-public/lua/2-base/abilities.lua
+++ b/modules/zenith-public/lua/2-base/abilities.lua
@@ -125,6 +125,24 @@ local effectAdjustments =
             power = -30, -- Changed from 1.5x to 1.20x
         },
     },
+    -- Blue Mage
+    azure_lore =
+    {
+        effectId = xi.effect.AZURE_LORE,
+        add =
+        {
+            duration = 15000, -- Changed from 30s to 45s
+        },
+    },
+    -- Puppetmaster
+    overdrive =
+    {
+        effectId = xi.effect.OVERDRIVE,
+        add =
+        {
+            duration = -120000, -- Reverted from 180s to original 60s
+        },
+    },
 }
 
 -- Helper function to check if an effect is being restored

--- a/modules/zenith-public/sql/TraitsAndJAs.sql
+++ b/modules/zenith-public/sql/TraitsAndJAs.sql
@@ -129,8 +129,8 @@ UPDATE `abilities` SET `level` = 75 WHERE `name` = 'perpetuance'; -- Abyssea
 UPDATE `abilities` SET `level` = 75 WHERE `name` = 'immanence'; -- Abyssea
 
 -- Strategems
-UPDATE `abilities_charges` SET `level` = 65 AND `chargeTime` = 70 WHERE `recastId` = 231 AND `maxCharges` = 4; -- 4 stratagem limit at level 65. Recharges every 70 seconds instead of 60 (3 charges limit is 80 seconds)
-UPDATE `abilities_charges` SET `level` = 75 AND `chargeTime` = 60 WHERE `recastId` = 231 AND `maxCharges` = 5; -- 5 stratagem limit at level 75. Recharges every 60 seconds instead of 48
+UPDATE `abilities_charges` SET `level` = 65, `chargeTime` = 70 WHERE `recastId` = 231 AND `maxCharges` = 4; -- 4 stratagem limit at level 65. Recharges every 70 seconds instead of 60 (3 charges limit is 80 seconds)
+UPDATE `abilities_charges` SET `level` = 75, `chargeTime` = 60 WHERE `recastId` = 231 AND `maxCharges` = 5; -- 5 stratagem limit at level 75. Recharges every 60 seconds instead of 48
 
 -- RUN
 UPDATE `abilities` SET `level` = 71 WHERE `name` = 'liement'; -- SOA

--- a/modules/zenith-public/sql/TraitsAndJAs.sql
+++ b/modules/zenith-public/sql/TraitsAndJAs.sql
@@ -2,142 +2,143 @@
 -- Job Ability and Trait Changes
 -- Public Module for ZenithXI
 --------------------------------
--- Content tags are set NULL to ensure they aren't disabled before we enable the corresponding `content_tag` expansion.
-
+-- Content tags set NULL ensure they aren't disabled before we enable the corresponding `content_tag` expansion.
+-- Any ability is subject to rebalance or removal before an expansion release but many from 2010+ have already been reduced in potency.
 -------------------
 -- Job Abilities --
 -------------------
 
 -- WAR
-UPDATE `abilities` SET `level` = 71, `content_tag`= NULL WHERE `name` = 'restraint';
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'blood_rage';
+-- (Lvl 60) Retaliation - WOTG
+UPDATE `abilities` SET `level` = 71, `content_tag`= 'TOAU' WHERE `name` = 'restraint';
+UPDATE `abilities` SET `level` = 75 WHERE `name` = 'blood_rage'; -- Abyssea
 
 -- MNK
-UPDATE `abilities` SET `level` = 71, `recastTime`= 90, `content_tag`= NULL WHERE `name` = 'perfect_counter'; -- Recast changed from 60 to 90
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'impetus';
+-- (Lvl 65) Footwork - WOTG - Modern implementation but reduced power
+UPDATE `abilities` SET `level` = 71, `recastTime`= 90, `content_tag`= 'TOAU' WHERE `name` = 'perfect_counter'; -- Recast changed from 60 to 90
+-- UPDATE `abilities` SET `level` = 75 WHERE `name` = 'impetus'; -- Abyssea
 UPDATE `abilities` SET `recastTime` = 300 WHERE `name` = 'focus' AND `abilityId` = 36; -- Focus: Update recast from 120 seconds (2 minutes) to 300 seconds (5 minutes)
 UPDATE `abilities` SET `recastTime` = 300 WHERE `name` = 'dodge' AND `abilityId` = 37; -- Dodge: Update recast from 120 seconds (2 minutes) to 300 seconds (5 minutes)
 
 -- WHM
-UPDATE `abilities` SET `level` = 60, `content_tag`= NULL WHERE `name` = 'divine_caress'; -- TODO: Ability needs to be corrected
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'sacrosanctity';
+UPDATE `abilities` SET `content_tag`= 'TOAU' WHERE `name` = 'afflatus_solace'; -- Set TOAU rather than WOTG due to retail merit category
+UPDATE `abilities` SET `content_tag`= 'TOAU' WHERE `name` = 'afflatus_misery'; -- Set TOAU rather than WOTG due to retail merit category
+-- UPDATE `abilities` SET `level` = 60, `content_tag`= 'COP' WHERE `name` = 'divine_caress'; -- TODO: Not implemented
+UPDATE `abilities` SET `level` = 75 WHERE `name` = 'sacrosanctity'; -- Abyssea
 
 -- BLM
-UPDATE `abilities` SET `level` = 45, `recastTime`= 90, `content_tag`= NULL WHERE `name` = 'cascade'; -- Recast changed from 60 to 90
-UPDATE `abilities` SET `level` = 60, `content_tag`= NULL WHERE `name` = 'manawell';
-UPDATE `abilities` SET `level` = 70, `content_tag`= NULL WHERE `name` = 'enmity_douse';
--- UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'mana_wall'; -- TODO: Not fully implemented.
+UPDATE `abilities` SET `level` = 40, `recastTime`= 90, `content_tag`= NULL WHERE `name` = 'cascade'; -- Recast changed from 60 to 90
+UPDATE `abilities` SET `level` = 60, `content_tag`= 'TOAU' WHERE `name` = 'manawell';
+UPDATE `abilities` SET `level` = 70, `content_tag`= 'COP' WHERE `name` = 'enmity_douse';
+-- UPDATE `abilities` SET `level` = 75 WHERE `name` = 'mana_wall'; -- TODO: Not implemented -- Abyssea
 
 -- RDM
-UPDATE `abilities` SET `level` = 60, `content_tag`= NULL WHERE `name` = 'spontaneity';
-UPDATE `abilities` SET `level` = 75, `recastTime`= 300, `content_tag`= NULL WHERE `name` = 'saboteur'; -- Recast changed from 180 to 300
+-- (Lvl 50) Composure - WOTG - Era implementation
+UPDATE `abilities` SET `level` = 60, `content_tag`= 'COP' WHERE `name` = 'spontaneity';
+UPDATE `abilities` SET `level` = 75, `recastTime`= 600 WHERE `name` = 'saboteur'; -- Recast changed from 180 to 600 - Abyssea
 
 -- THF
 UPDATE `abilities` SET `level` = 40, `content_tag`= NULL WHERE `name` = 'accomplice' ;
-UPDATE `abilities` SET `level` = 40, `content_tag`= NULL WHERE `name` = 'collaborator';
-UPDATE `abilities` SET `level` = 60, `content_tag`= NULL WHERE `name` = 'despoil';
-UPDATE `abilities` SET `level` = 65, `content_tag`= NULL WHERE `name` = 'conspirator';
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'bully';
+UPDATE `abilities` SET `level` = 40, `content_tag`= 'ROTZ' WHERE `name` = 'collaborator';
+UPDATE `abilities` SET `level` = 60, `content_tag`= 'COP' WHERE `name` = 'despoil';
+UPDATE `abilities` SET `level` = 65, `content_tag`= 'TOAU' WHERE `name` = 'conspirator';
+UPDATE `abilities` SET `level` = 75 WHERE `name` = 'bully'; -- Abyssea
 
 -- PLD
-UPDATE `abilities` SET `level` = 65, `content_tag`= NULL WHERE `name` = 'divine_emblem';
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'sepulcher';
+-- (Lvl 62) Rampart - ROTZ
+UPDATE `abilities` SET `level` = 65, `content_tag`= 'WOTG' WHERE `name` = 'divine_emblem';
+UPDATE `abilities` SET `level` = 75, `content_tag`= 'ROTZ' WHERE `name` = 'sepulcher';
 
 -- DRK
-UPDATE `abilities` SET `level` = 65, `content_tag`= NULL WHERE `name` = 'nether_void';
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'arcane_crest'; -- TODO: Duration changed from 180 to 120.
--- UPDATE `abilities` SET `level` = 75, `recastTime`= 180, `content_tag`= NULL WHERE `name` = 'scarlet_delirium'; -- Recast changed from 90 to 180. TODO: Not fully implemented.
+UPDATE `abilities` SET `content_tag`= 'COP' WHERE `name` = 'consume_mana';
+UPDATE `abilities` SET `level` = 65, `content_tag`= 'WOTG' WHERE `name` = 'nether_void';
+UPDATE `abilities` SET `level` = 75, `content_tag`= 'ROTZ' WHERE `name` = 'arcane_crest'; -- Duration changed from 180 to 120.
+-- UPDATE `abilities` SET `level` = 75, `recastTime`= 180 WHERE `name` = 'scarlet_delirium'; -- Recast changed from 90 to 180 - Abyssea TODO: Not fully implemented
 
 -- BST
--- UPDATE `abilities` SET `level` = 65, `content_tag`= NULL WHERE `name` = 'spur'; -- TODO: Not yet implemented
--- UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'run_wild'; -- TODO: Not yet implemented
+-- (Lvl 45) Snarl - WOTG
+UPDATE `abilities` SET `level` = 65 WHERE `name` = 'spur';
+-- UPDATE `abilities` SET `level` = 75 WHERE `name` = 'run_wild'; -- Abyssea
 
 -- BRD
+UPDATE `abilities` SET `content_tag`= NULL WHERE `name` = 'pianissimo'; -- (Lvl 1)
 -- UPDATE `abilities` SET `level` = 40, `content_tag`= NULL WHERE `name` = 'tenuto'; -- TODO: Not yet implemented
 UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'marcato';
 
 -- RNG
-UPDATE `abilities` SET `level` = 60, `content_tag`= NULL WHERE `name` = 'bounty_shot';
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'double_shot';
+-- (Lvl 45) Velocity Shot - TOAU
+-- (Lvl 51) Unlimited Shot - ROTZ
+UPDATE `abilities` SET `level` = 60, `content_tag`= 'COP' WHERE `name` = 'bounty_shot';
+UPDATE `abilities` SET `level` = 75 WHERE `name` = 'double_shot'; -- Abyssea
 
 -- SAM
-UPDATE `abilities` SET `level` = 55, `content_tag`= NULL WHERE `name` = 'hagakure';
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'sengikori';
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'hamanoha';
+-- (Lvl 25) Hasso - TOAU
+-- (Lvl 35) Seigan - TOAU
+-- (Lvl 40) Sekkanoki - WOTG
+-- UPDATE `abilities` SET `level` = 71 WHERE `name` = 'hagakure'; -- Abyssea - JA unavailable due to SAM over-efficiency
+-- UPDATE `abilities` SET `level` = 65, `recastTime`= 300, `content_tag`= 'COP' WHERE `name` = 'konzen-ittai'; -- Recast changed from 180s to 300s - JA unavailable due to SAM over efficiency
+UPDATE `abilities` SET `level` = 75 WHERE `name` = 'sengikori'; -- Abyssea
+UPDATE `abilities` SET `level` = 75, `content_tag`= 'ROTZ' WHERE `name` = 'hamanoha';
 
 -- NIN
-UPDATE `abilities` SET `level` = 50, `content_tag`= NULL WHERE `name` = 'futae';
-UPDATE `abilities` SET `level` = 71, `content_tag`= NULL WHERE `name` = 'issekigan';
+UPDATE `abilities` SET `content_tag`= 'TOAU' WHERE `name` = 'yonin'; -- Set TOAU rather than WOTG due to retail merit category
+UPDATE `abilities` SET `content_tag`= 'TOAU' WHERE `name` = 'innin'; -- Set TOAU rather than WOTG due to retail merit category
+UPDATE `abilities` SET `level` = 50, `content_tag`= 'ROTZ' WHERE `name` = 'futae';
+UPDATE `abilities` SET `level` = 71, `content_tag`= 'COP' WHERE `name` = 'issekigan';
 UPDATE `abilities` SET `recastTime`= 300 WHERE `name` = 'sange'; -- Reverts recast reduction from October 2014 update
 
 -- DRG
-UPDATE `abilities` SET `level` = 40, `content_tag`= NULL WHERE `name` = 'smiting_breath';
-UPDATE `abilities` SET `level` = 60, `content_tag`= NULL WHERE `name` = 'steady_wing';
-UPDATE `abilities` SET `level` = 71, `recastTime`= 90, `content_tag`= NULL WHERE `name` = 'restoring_breath'; -- Recast changed from 60 to 90
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'dragon_breaker';
+UPDATE `abilities` SET `content_tag`= 'ROTZ' WHERE `name` = 'spirit_surge'; -- (Lvl 1)
+UPDATE `abilities` SET `level` = 40, `content_tag`= 'ROTZ' WHERE `name` = 'smiting_breath';
+UPDATE `abilities` SET `level` = 60, `content_tag`= 'COP' WHERE `name` = 'steady_wing';
+-- UPDATE `abilities` SET `level` = 65, `content_tag`= 'TOAU' WHERE `name` = 'spirit_bond'; -- TODO: 50% damage split needs to be coded
+UPDATE `abilities` SET `level` = 70, `recastTime`= 90, `content_tag`= 'ROTZ' WHERE `name` = 'restoring_breath'; -- Recast changed from 60 to 90
+UPDATE `abilities` SET `level` = 75, `content_tag`= 'ROTZ' WHERE `name` = 'dragon_breaker';
 
 -- SMN
-UPDATE `abilities` SET `level` = 75, `recastTime`= 300, `content_tag`= NULL WHERE `name` = 'avatars_favor'; -- Recast changed from 30 to 300
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'mana_cede';
+-- (Lvl 50) Elemental Siphon - WOTG
+-- UPDATE `abilities` SET `level` = 75, `recastTime`= 300, `content_tag`= 'ROTZ' WHERE `name` = 'avatars_favor'; -- Recast reverted from 30 to 300 - TODO Perpetuation cost must first be added
+UPDATE `abilities` SET `recastTime`= 300, `content_tag`= 'TOAU' WHERE `name` = 'apogee'; -- (Lvl 70) - Recast changed from 180 to 300
+UPDATE `abilities` SET `level` = 75 WHERE `name` = 'mana_cede'; -- Abyssea
 
 -- BLU
-UPDATE `abilities` SET `level` = 65, `content_tag`= NULL WHERE `name` = 'efflux';
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'unbridled_learning';
+UPDATE `abilities` SET `level` = 65 WHERE `name` = 'efflux'; -- Abyssea
+UPDATE `abilities` SET `level` = 75, `content_tag`= 'WOTG' WHERE `name` = 'unbridled_learning';
 
 -- COR
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'triple_shot';
+UPDATE `abilities` SET `level` = 75 WHERE `name` = 'triple_shot'; -- Abyssea
 
 -- PUP
-UPDATE `abilities` SET `level` = 60, `content_tag`= NULL WHERE `name` = 'cooldown';
--- UPDATE `abilities` SET `level` = 71, `content_tag`= NULL WHERE `name` = 'tactical_switch'; -- TODO: Not yet implemented
-UPDATE `abilities` SET `recastTime`= 90, `content_tag`= NULL WHERE `name` = 'deus_ex_automata'; -- Recast changed from 60 to 90
+UPDATE `abilities` SET `recastTime`= 180, `content_tag`= 'TOAU' WHERE `name` = 'maintenance'; -- (Lvl 30) Recast changed from 60 to 180
+UPDATE `abilities` SET `level` = 60, `content_tag`= 'TOAU' WHERE `name` = 'cooldown';
+-- UPDATE `abilities` SET `level` = 71 WHERE `name` = 'tactical_switch'; -- Abyssea TODO: Not yet implemented
+UPDATE `abilities` SET `recastTime`= 90, `content_tag`= 'WOTG' WHERE `name` = 'deus_ex_automata'; -- (Lvl 5) Recast changed from 60 to 90
 
 -- DNC
-UPDATE `abilities` SET `level` = 71, `recastTime`= 30, `content_tag`= NULL WHERE `name` = 'presto'; -- TODO: Potency changed from 5 steps to original 3. Daze increase from 5 to original 2. Step Accuracy from +50 to +20.
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'feather_step';
--- UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'climactic_flourish'; -- TODO: Not yet implemented. TODO: Flourish III Category does not display in the menu when making them available at an earlier level.
--- UPDATE `abilities` SET `level` = 71, `recastTime`= 45, `content_tag`= NULL WHERE `name` = 'striking_flourish'; -- TODO: Not yet implemented
--- UPDATE `abilities` SET `level` = 75, `recastTime`= 60, `content_tag`= NULL WHERE `name` = 'ternary_flourish'; -- TODO: Not yet implemented
+UPDATE `abilities` SET `content_tag`= 'WOTG' WHERE `name` = 'contradance'; -- (Lvl 50)
+UPDATE `abilities` SET `content_tag`= 'WOTG' WHERE `name` = 'chocobo_jig_ii'; -- (Lvl 70)
+-- UPDATE `abilities` SET `level` = 71, `recastTime`= 30, `content_tag`= 'WOTG' WHERE `name` = 'presto'; -- TODO: Revert to original potency. Grants 5 steps to 3. Daze increase from 5 to 2. Step Accuracy from +50 to +20.
+UPDATE `abilities` SET `level` = 75 WHERE `name` = 'feather_step'; -- Abyssea
+-- UPDATE `abilities` SET `level` = 75 WHERE `name` = 'climactic_flourish'; -- Abyssea TODO: Not yet implemented. TODO: Flourish III Category does not display in the menu when making them available at an earlier level.
+-- UPDATE `abilities` SET `level` = 71, `recastTime`= 45, `content_tag`= 'WOTG' WHERE `name` = 'striking_flourish'; -- TODO: Not yet implemented
+-- UPDATE `abilities` SET `level` = 75, `recastTime`= 60 WHERE `name` = 'ternary_flourish'; -- Abyssea TODO: Not yet implemented
 
 -- SCH
--- UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'libra'; -- TODO: Not yet implemented.
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'perpetuance';
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'immanence';
+-- UPDATE `abilities` SET `level` = 75, `content_tag`= 'WOTG' WHERE `name` = 'libra'; -- TODO: Not yet implemented.
+UPDATE `abilities` SET `level` = 75 WHERE `name` = 'perpetuance'; -- Abyssea
+UPDATE `abilities` SET `level` = 75 WHERE `name` = 'immanence'; -- Abyssea
 
 -- Strategems
-UPDATE `abilities_charges` SET `level` = 65 WHERE `recastId` = 231 AND `maxCharges` = 4; -- 4 stratagem limit at level 65. Recharges every 60 seconds
-UPDATE `abilities_charges` SET `level` = 75 WHERE `recastId` = 231 AND `maxCharges` = 5; -- 5 stratagem limit at level 75. Recharges every 48 seconds
+UPDATE `abilities_charges` SET `level` = 65 AND `chargeTime` = 70 WHERE `recastId` = 231 AND `maxCharges` = 4; -- 4 stratagem limit at level 65. Recharges every 70 seconds instead of 60 (3 charges limit is 80 seconds)
+UPDATE `abilities_charges` SET `level` = 75 AND `chargeTime` = 60 WHERE `recastId` = 231 AND `maxCharges` = 5; -- 5 stratagem limit at level 75. Recharges every 60 seconds instead of 48
 
 -- RUN
-UPDATE `abilities` SET `level` = 71, `content_tag`= NULL WHERE `name` = 'liement';
-UPDATE `abilities` SET `level` = 75, `content_tag`= NULL WHERE `name` = 'one_for_all';
+UPDATE `abilities` SET `level` = 71 WHERE `name` = 'liement'; -- SOA
+UPDATE `abilities` SET `level` = 75 WHERE `name` = 'one_for_all'; -- SOA
 
 -- GEO
-UPDATE `abilities` SET `level` = 65, `content_tag`= NULL WHERE `name` = 'concentric_pulse';
-UPDATE `abilities` SET `level` = 71, `content_tag`= NULL WHERE `name` = 'theurgic_focus'; -- TODO: Not yet implemented. TODO: Potency changed from +50MAB to +25MAB
-
--------------------------
--- Content Tag Updates --
--------------------------
-UPDATE `abilities` SET `content_tag`= NULL WHERE `name` IN (
-    'footwork',
-    'afflatus_solace',
-    'afflatus_misery',
-    'composure',
-    'snarl',
-    'bestial_loyalty',
-    'pianissimo',
-    'yonin',
-    'innin',
-    'hasso',
-    'seigan',
-    'sekkanoki',
-    'spirit_surge',
-    'elemental_siphon',
-    'maintenance',
-    'chocobo_jig_ii',
-    'contradance'
-);
+UPDATE `abilities` SET `level` = 65 WHERE `name` = 'concentric_pulse'; -- SOA
+-- UPDATE `abilities` SET `level` = 71 WHERE `name` = 'theurgic_focus'; -- SOA TODO: Not yet implemented. TODO: Potency changed from +50MAB to +20MAB
 
 ------------------------
 -- Disabled Abilities --
@@ -145,7 +146,8 @@ UPDATE `abilities` SET `content_tag`= NULL WHERE `name` IN (
 UPDATE `abilities`
 SET `level` = 76
 WHERE `name` IN (
-    'majesty'
+    'majesty',
+    'konzen-ittai'
 );
 
 ------------
@@ -167,42 +169,51 @@ UPDATE `traits` SET `value` = 5 WHERE `name` = 'damage limit+' AND `rank` = 2; -
 UPDATE `traits` SET `value` = 6 WHERE `name` = 'damage limit+' AND `rank` = 3; -- Damage Limit+ III, 6%
 UPDATE `traits` SET `value` = 7 WHERE `name` = 'damage limit+' AND `rank` = 4; -- Damage Limit+ IV, 7%
 
-UPDATE `traits` SET `value` = 8 WHERE `name` = 'smite' AND `rank` = 1;  -- Smite I, 3.12%
-UPDATE `traits` SET `value` = 10 WHERE `name` = 'smite' AND `rank` = 2; -- Smite II, 3.9%
-UPDATE `traits` SET `value` = 12 WHERE `name` = 'smite' AND `rank` = 3; -- Smite III, 4.68%
-UPDATE `traits` SET `value` = 14 WHERE `name` = 'smite' AND `rank` = 4; -- Smite IV, 5.46%
+UPDATE `traits` SET `value` = 7 WHERE `name` = 'smite' AND `rank` = 1;  -- Smite I, 2.73%
+UPDATE `traits` SET `value` = 9 WHERE `name` = 'smite' AND `rank` = 2;  -- Smite II, 3.52%
+UPDATE `traits` SET `value` = 11 WHERE `name` = 'smite' AND `rank` = 3; -- Smite III, 4.3%
+UPDATE `traits` SET `value` = 13 WHERE `name` = 'smite' AND `rank` = 4; -- Smite IV, 5.08%
+
+UPDATE `traits` SET `value` = 10 WHERE `name` = 'stalwart soul' AND `rank` = 1; -- Stalwart Soul I, -1% (Souleater 9%)
+UPDATE `traits` SET `value` = 15 WHERE `name` = 'stalwart soul' AND `rank` = 2; -- Stalwart Soul II, -1.5%  (Souleater 8.5%)
+UPDATE `traits` SET `value` = 20 WHERE `name` = 'stalwart soul' AND `rank` = 3; -- Stalwart Soul III, -2%  (Souleater 8%)
 
 UPDATE `traits` SET `value` = 3 WHERE `name` = 'skillchain bonus' AND `rank` = 1; -- Skillchain Bonus I, 3%
 UPDATE `traits` SET `value` = 5 WHERE `name` = 'skillchain bonus' AND `rank` = 2; -- Skillchain Bonus II, 5%
 UPDATE `traits` SET `value` = 7 WHERE `name` = 'skillchain bonus' AND `rank` = 3; -- Skillchain Bonus III, 7%
 
-UPDATE `traits` SET `value` = 3 WHERE `name` = 'mag. burst bonus' AND `rank` = 1; -- Mag. Burst Bonus II, 3%
+UPDATE `traits` SET `value` = 3 WHERE `name` = 'mag. burst bonus' AND `rank` = 1; -- Mag. Burst Bonus I, 3%
 UPDATE `traits` SET `value` = 5 WHERE `name` = 'mag. burst bonus' AND `rank` = 2; -- Mag. Burst Bonus II, 5%
 UPDATE `traits` SET `value` = 7 WHERE `name` = 'mag. burst bonus' AND `rank` = 3; -- Mag. Burst Bonus III, 7%
 
+-- Shield Def. Bonus I, -2 damage
+-- Shield Def. Bonus II, -4 damage
 UPDATE `traits` SET `value` = 5 WHERE `name` = 'shield def. bonus' AND `rank` = 3; -- Shield Def. Bonus III, -5 damage
 
--- UPDATE `traits` SET `value` = 3 WHERE `name` = 'true shot' AND `rank` = 1; -- True Shot I, +3% damage -- TODO: Not yet implemented
--- UPDATE `traits` SET `value` = 4 WHERE `name` = 'true shot' AND `rank` = 2; -- True Shot II, +4% damage -- TODO: Not yet implemented
+-- Shield Mastery I, 10 TP
+UPDATE `traits` SET `value` = 15 WHERE `name` = 'shield mastery' AND `rank` = 2; -- Shield Mastery II, 15 TP
+UPDATE `traits` SET `value` = 20 WHERE `name` = 'shield mastery' AND `rank` = 3; -- Shield Mastery III, 20 TP
 
--- UPDATE `traits` SET `value` = 3 WHERE `name` = 'dead aim' AND `rank` = 1; -- Dead Aim I, +5% critical hit damage -- TODO: Not yet implemented
--- UPDATE `traits` SET `value` = 7 WHERE `name` = 'dead aim' AND `rank` = 2; -- Dead Aim II, +7% critical hit damage -- TODO: Not yet implemented
--- UPDATE `traits` SET `value` = 9 WHERE `name` = 'dead aim' AND `rank` = 3; -- Dead Aim II, +9% critical hit damage -- TODO: Not yet implemented
+-- UPDATE `traits` SET `value` = 2 WHERE `name` = 'true shot' AND `rank` = 1; -- True Shot I, +2% damage -- TODO: Not yet implemented
+-- UPDATE `traits` SET `value` = 3 WHERE `name` = 'true shot' AND `rank` = 2; -- True Shot II, +3% damage -- TODO: Not yet implemented
+
+-- UPDATE `traits` SET `value` = 3 WHERE `name` = 'dead aim' AND `rank` = 1; -- Dead Aim I, +3% critical hit damage -- TODO: Not yet implemented
+-- UPDATE `traits` SET `value` = 5 WHERE `name` = 'dead aim' AND `rank` = 2; -- Dead Aim II, +5% critical hit damage -- TODO: Not yet implemented
+-- UPDATE `traits` SET `value` = 7 WHERE `name` = 'dead aim' AND `rank` = 3; -- Dead Aim II, +7% critical hit damage -- TODO: Not yet implemented
 
 UPDATE `traits` SET `value` = 5 WHERE `name` = 'tandem strike' AND `rank` = 1;    -- Tandem Strike I, +5 Acc/Macc
 UPDATE `traits` SET `value` = 10 WHERE `name` = 'tandem strike' AND `rank` = 2;   -- Tandem Strike II, +10 Acc/Macc
 UPDATE `traits` SET `value` = 15 WHERE `name` = 'tandem strike' AND `rank` = 3;   -- Tandem Strike III, +15 Acc/Macc
 UPDATE `traits` SET `value` = 20 WHERE `name` = 'tandem strike' AND `rank` = 4;   -- Tandem Strike IV, +20 Acc/Macc
 
-UPDATE `traits` SET `value` = 10 WHERE `name` = 'daken' AND `rank` = 1; -- Daken I, 10%
-UPDATE `traits` SET `value` = 12 WHERE `name` = 'daken' AND `rank` = 2; -- Daken II, 12%
-UPDATE `traits` SET `value` = 14 WHERE `name` = 'daken' AND `rank` = 3; -- Daken III, 14%
-UPDATE `traits` SET `value` = 16 WHERE `name` = 'daken' AND `rank` = 4; -- Daken IV, 16%
+UPDATE `traits` SET `value` = 6 WHERE `name` = 'daken' AND `rank` = 1; -- Daken I, 6%
+UPDATE `traits` SET `value` = 8 WHERE `name` = 'daken' AND `rank` = 2; -- Daken II, 8%
+UPDATE `traits` SET `value` = 10 WHERE `name` = 'daken' AND `rank` = 3; -- Daken III, 10%
+UPDATE `traits` SET `value` = 12 WHERE `name` = 'daken' AND `rank` = 4; -- Daken IV, 12%
 
 UPDATE `traits` SET `value` = 1 WHERE `name` = 'ws damage boost' AND `rank` = 1; -- WS Damage Boost I, 1%
 UPDATE `traits` SET `value` = 2 WHERE `name` = 'ws damage boost' AND `rank` = 2; -- WS Damage Boost II, 2%
 UPDATE `traits` SET `value` = 3 WHERE `name` = 'ws damage boost' AND `rank` = 3; -- WS Damage Boost III, 3%
--- UPDATE `traits` SET `value` = 4 WHERE `name` = 'ws damage boost' AND `rank` = 4; -- WS Damage Boost IV, 4% -- Tier 4 is intentionally disabled below
 
 UPDATE `traits` SET `value` = 8 WHERE `name` = 'conserve tp' AND `rank` = 1;  -- Conserve TP I, 8%
 UPDATE `traits` SET `value` = 10 WHERE `name` = 'conserve tp' AND `rank` = 2; -- Conserve TP II, 10%
@@ -210,8 +221,8 @@ UPDATE `traits` SET `value` = 12 WHERE `name` = 'conserve tp' AND `rank` = 3; --
 
 UPDATE `traits` SET `value` = 10 WHERE `name` = 'tactical parry' AND `rank` = 1; -- Tactical Parry I, 10TP
 UPDATE `traits` SET `value` = 20 WHERE `name` = 'tactical parry' AND `rank` = 2; -- Tactical Parry II, 20TP
-UPDATE `traits` SET `value` = 30 WHERE `name` = 'tactical parry' AND `rank` = 3; -- Tactical Parry III, 30TP
-UPDATE `traits` SET `value` = 40 WHERE `name` = 'tactical parry' AND `rank` = 4; -- Tactical Parry IV, 40TP
+UPDATE `traits` SET `value` = 25 WHERE `name` = 'tactical parry' AND `rank` = 3; -- Tactical Parry III, 25TP
+UPDATE `traits` SET `value` = 30 WHERE `name` = 'tactical parry' AND `rank` = 4; -- Tactical Parry IV, 30TP
 
 UPDATE `traits` SET `value` = 15 WHERE `name` = 'tactical guard' AND `rank` = 1; -- Tactical Guard I, 15TP
 UPDATE `traits` SET `value` = 30 WHERE `name` = 'tactical guard' AND `rank` = 2; -- Tactical Guard II, 30TP
@@ -238,10 +249,10 @@ UPDATE `traits` SET `level` = 75 WHERE `name` = 'skillchain bonus' AND `job` = 2
 -- WHM
 UPDATE `traits` SET `level` = 50 WHERE `name` = 'shield def. bonus' AND `job` = 3 AND `rank` = 1; -- Shield Def. Bonus I
 UPDATE `traits` SET `level` = 75 WHERE `name` = 'shield def. bonus' AND `job` = 3 AND `rank` = 2; -- Shield Def. Bonus II
-UPDATE `traits` SET `level` = 75 WHERE `name` = 'auto regen' AND `job` = 3 AND `rank` = 2;        -- Auto Regen II
+UPDATE `traits` SET `level` = 75 WHERE `name` = 'auto regen' AND `job` = 3 AND `rank` = 2;        -- Auto Regen II - Abyssea
 
 -- BLM
-UPDATE `traits` SET `level` = 65 WHERE `name` = 'occult acumen' AND `job` = 4 AND `rank` = 1; -- Occult Acumen I
+UPDATE `traits` SET `level` = 55 WHERE `name` = 'occult acumen' AND `job` = 4 AND `rank` = 1; -- Occult Acumen I
 UPDATE `traits` SET `level` = 75 WHERE `name` = 'conserve mp' AND `job` = 4 AND `rank` = 2;   -- Conserve MP II
 
 -- RDM
@@ -251,10 +262,10 @@ UPDATE `traits` SET `level` = 70 WHERE `name` = 'shield def. bonus' AND `job` = 
 
 -- THF
 UPDATE `traits` SET `level` = 45 WHERE `name` = 'crit. atk. bonus' AND `job` = 6 AND `rank` = 1; -- Crit. Atk. Bonus I
-UPDATE `traits` SET `level` = 50 WHERE `name` = 'assassin' AND `job` = 6 AND `rank` = 1;         -- Assassin
+UPDATE `traits` SET `level` = 50 WHERE `name` = 'assassin' AND `job` = 6 AND `rank` = 1;         -- Assassin - Level lowered
 UPDATE `traits` SET `level` = 60 WHERE `name` = 'crit. atk. bonus' AND `job` = 6 AND `rank` = 2; -- Crit. Atk. Bonus II
 UPDATE `traits` SET `level` = 71 WHERE `name` = 'crit. atk. bonus' AND `job` = 6 AND `rank` = 3; -- Crit. Atk. Bonus III
-UPDATE `traits` SET `level` = 75 WHERE `name` = 'dual wield' AND `job` = 6 AND `rank` = 1;       -- Dual Wield I
+UPDATE `traits` SET `level` = 71 WHERE `name` = 'dual wield' AND `job` = 6 AND `rank` = 1;       -- Dual Wield I
 
 -- PLD
 UPDATE `traits` SET `level` = 35 WHERE `name` = 'crit. def. bonus' AND `job` = 7 AND `rank` = 1;  -- Crit. Def. Bonus I
@@ -271,9 +282,9 @@ UPDATE `traits` SET `level` = 65 WHERE `name` = 'occult acumen' AND `job` = 8 AN
 UPDATE `traits` SET `level` = 70 WHERE `name` = 'tactical parry' AND `job` = 8 AND `rank` = 1; -- Tactical Parry I
 
 -- BST
-UPDATE `traits` SET `level` = 55 WHERE `name` = 'fencer' AND `job` = 9 AND `rank` = 1;          -- Fencer I
+UPDATE `traits` SET `level` = 50 WHERE `name` = 'fencer' AND `job` = 9 AND `rank` = 1;          -- Fencer I
 UPDATE `traits` SET `level` = 71 WHERE `name` = 'fencer' AND `job` = 9 AND `rank` = 2;          -- Fencer II
-UPDATE `traits` SET `level` = 75 WHERE `name` = 'stout servant' AND `job` = 9 AND `rank` = 1;   -- Stout Servant I
+UPDATE `traits` SET `level` = 75 WHERE `name` = 'stout servant' AND `job` = 9 AND `rank` = 1;   -- Stout Servant I - Abyssea
 UPDATE `traits` SET `level` = 75 WHERE `name` = 'aquan killer' AND `job` = 9 AND `rank` = 2;    -- Aquan Killer II
 UPDATE `traits` SET `level` = 75 WHERE `name` = 'amorph killer' AND `job` = 9 AND `rank` = 2;   -- Amorph Killer II
 UPDATE `traits` SET `level` = 75 WHERE `name` = 'beast killer' AND `job` = 9 AND `rank` = 2;    -- Beast Killer II
@@ -283,7 +294,7 @@ UPDATE `traits` SET `level` = 75 WHERE `name` = 'plantoid killer' AND `job` = 9 
 UPDATE `traits` SET `level` = 75 WHERE `name` = 'vermin killer' AND `job` = 9 AND `rank` = 2;   -- Vermin Killer II
 
 -- BRD
-UPDATE `traits` SET `level` = 55 WHERE `name` = 'fencer' AND `job` = 10 AND `rank` = 1;           -- Fencer I
+UPDATE `traits` SET `level` = 58 WHERE `name` = 'fencer' AND `job` = 10 AND `rank` = 1;           -- Fencer I
 UPDATE `traits` SET `level` = 70 WHERE `name` = 'crit. def. bonus' AND `job` = 10 AND `rank` = 1; -- Crit. Def. Bonus I
 
 -- RNG
@@ -303,15 +314,15 @@ UPDATE `traits` SET `level` = 75 WHERE `name` = 'max hp boost' AND `job` = 13 AN
 UPDATE `traits` SET `level` = 75 WHERE `name` = 'tactical parry' AND `job` = 13 AND `rank` = 2;   -- Tactical Parry II
 
 -- DRG
+UPDATE `traits` SET `level` = 35 WHERE `name` = 'conserve tp' AND `job` = 14 AND `rank` = 1;      -- Conserve TP I
 UPDATE `traits` SET `level` = 50 WHERE `name` = 'crit. def. bonus' AND `job` = 14 AND `rank` = 1; -- Crit. Def. Bonus I
 UPDATE `traits` SET `level` = 75 WHERE `name` = 'crit. def. bonus' AND `job` = 14 AND `rank` = 2; -- Crit. Def. Bonus II
 
 -- SMN
 UPDATE `traits` SET `level` = 20 WHERE `name` = 'max mp boost' AND `job` = 15 AND `rank` = 2; -- Max MP Boost II
-UPDATE `traits` SET `level` = 35 WHERE `name` = 'max mp boost' AND `job` = 15 AND `rank` = 3; -- Max MP Boost III
+UPDATE `traits` SET `level` = 40 WHERE `name` = 'max mp boost' AND `job` = 15 AND `rank` = 3; -- Max MP Boost III
 UPDATE `traits` SET `level` = 50 WHERE `name` = 'max mp boost' AND `job` = 15 AND `rank` = 4; -- Max MP Boost IV
-UPDATE `traits` SET `level` = 65 WHERE `name` = 'max mp boost' AND `job` = 15 AND `rank` = 5; -- Max MP Boost V
-UPDATE `traits` SET `level` = 75 WHERE `name` = 'max mp boost' AND `job` = 15 AND `rank` = 6; -- Max MP Boost VI
+UPDATE `traits` SET `level` = 70 WHERE `name` = 'max mp boost' AND `job` = 15 AND `rank` = 5; -- Max MP Boost V
 
 -- COR
 -- UPDATE `traits` SET `level` = 60 WHERE `name` = 'dead aim' AND `job` = 17 AND `rank` = 1;  -- Dead Aim I -- TODO: Not yet implemented
@@ -320,7 +331,7 @@ UPDATE `traits` SET `level` = 75 WHERE `name` = 'max mp boost' AND `job` = 15 AN
 -- PUP
 UPDATE `traits` SET `level` = 55 WHERE `name` = 'tactical guard' AND `job` = 18 AND `rank` = 1;   -- Tactical Guard I
 UPDATE `traits` SET `level` = 70 WHERE `name` = 'crit. def. bonus' AND `job` = 18 AND `rank` = 1; -- Crit. Def. Bonus I
-UPDATE `traits` SET `level` = 75 WHERE `name` = 'stout servant' AND `job` = 18 AND `rank` = 1;    -- Stout Servant I
+UPDATE `traits` SET `level` = 75 WHERE `name` = 'stout servant' AND `job` = 18 AND `rank` = 1;    -- Stout Servant I - Abyssea
 UPDATE `traits` SET `level` = 75 WHERE `name` = 'tactical guard' AND `job` = 18 AND `rank` = 2;   -- Tactical Guard II
 
 -- DNC
@@ -334,9 +345,9 @@ UPDATE `traits` SET `level` = 75 WHERE `name` = 'crit. atk. bonus' AND `job` = 1
 UPDATE `traits` SET `level` = 75 WHERE `name` = 'tactical parry' AND `job` = 19 AND `rank` = 4;   -- Tactical Parry IV
 
 -- SCH
-UPDATE `traits` SET `level` = 60 WHERE `name` = 'occult acumen' AND `job` = 20 AND `rank` = 1;    -- Occult Acumen I
-UPDATE `traits` SET `level` = 65 WHERE `name` = 'mag. burst bonus' AND `job` = 20 AND `rank` = 1; -- Mag. Burst Bonus I
-UPDATE `traits` SET `level` = 75 WHERE `name` = 'occult acumen' AND `job` = 20 AND `rank` = 2;    -- Occult Acumen II
+UPDATE `traits` SET `level` = 50 WHERE `name` = 'occult acumen' AND `job` = 20 AND `rank` = 1;    -- Occult Acumen I
+UPDATE `traits` SET `level` = 60 WHERE `name` = 'mag. burst bonus' AND `job` = 20 AND `rank` = 1; -- Mag. Burst Bonus I
+UPDATE `traits` SET `level` = 70 WHERE `name` = 'occult acumen' AND `job` = 20 AND `rank` = 2;    -- Occult Acumen II
 UPDATE `traits` SET `level` = 75 WHERE `name` = 'max mp boost' AND `job` = 20 AND `rank` = 2;     -- Max MP Boost II
 
 -- GEO
@@ -345,57 +356,62 @@ UPDATE `traits` SET `level` = 75 WHERE `name` = 'max mp boost' AND `job` = 21 AN
 
 -- RUN
 UPDATE `traits` SET `level` = 35 WHERE `name` = 'tactical parry' AND `job` = 22 AND `rank` = 1;   -- Tactical Parry I
-UPDATE `traits` SET `level` = 71 WHERE `name` = 'tactical parry' AND `job` = 22 AND `rank` = 3;   -- Tactical Parry III
+UPDATE `traits` SET `level` = 70 WHERE `name` = 'tactical parry' AND `job` = 22 AND `rank` = 3;   -- Tactical Parry III
 UPDATE `traits` SET `level` = 75 WHERE `name` = 'magic def. bonus' AND `job` = 22 AND `rank` = 5; -- Magic Def. Bonus V
 UPDATE `traits` SET `level` = 75 WHERE `name` = 'max hp boost' AND `job` = 22 AND `rank` = 4;     -- Max HP Boost IV
 
 ---------------------
 -- Disabled Traits --
 ---------------------
-DELETE FROM `traits` WHERE `name`='ws damage boost' AND `rank` = 4; -- WS Damage Boost IV disabled
+DELETE FROM `traits` WHERE `name`='double attack' AND `rank` = 2;   -- Double Attack II
+DELETE FROM `traits` WHERE `name`='double attack' AND `rank` = 3;   -- Double Attack III
+DELETE FROM `traits` WHERE `name`='dual wield' AND `rank` = 2 AND `job` = 19; -- Dual Wield II - DNC - Job is receiving a lot of OOE traits/JAs. We need to observe how it handles these without a free /WAR boost too.
+DELETE FROM `traits` WHERE `name`='dual wield' AND `rank` = 3 AND `job` = 19; -- Dual Wield III - DNC - DW III on DNC could be the tipping point on balance.
+DELETE FROM `traits` WHERE `name`='max hp boost II' AND `rank` = 1; -- Max HP Boost II I
+DELETE FROM `traits` WHERE `name`='ws damage boost' AND `rank` = 4; -- WS Damage Boost IV
 
 -------------------------
 -- Content Tag Updates --
 -------------------------
 UPDATE `traits` SET `content_tag`= NULL WHERE `name` IN (
-    'shield mastery',
-    'shield def. bonus',
-    'smite',
-    'damage limit+',
-    'fencer',
-    'crit. atk. bonus',
-    'tactical guard',
-    'skillchain bonus',
-    'auto regen',
-    'tranquil heart',
-    'occult acumen',
-    'conserve mp',
-    'elemental celerity',
-    'mag. burst bonus',
-    'shield barrier',
-    'dual wield',
-    'attack bonus',
-    'tactical parry',
-    'stout servant',
-    'aquan killer',
     'amorph killer',
+    'aquan killer',
+    'attack bonus',
     'beast killer',
     'bird killer',
-    'lizard killer',
-    'plantoid killer',
-    'vermin killer',
-    'tandem strike',
-    'tandem blow',
-    'crit. def. bonus',
-    'dead aim',
-    'daken',
-    'conserve tp',
-    'ws damage boost',
     'blood boon',
-    'max mp boost',
-    'max hp boost',
     'clear mind',
+    'conserve mp',
+    'conserve tp',
+    'crit. atk. bonus',
+    'crit. def. bonus',
+    'daken',
+    'damage limit+',
+    'dead aim',
+    'defense bonus',
+    'divine benison',
+    'dual wield',
+    'elemental celerity',
+    'fencer',
     'inquartata',
+    'lizard killer',
+    'mag. burst bonus',
+    'max hp boost',
+    'max mp boost',
+    'occult acumen',
+    'plantoid killer',
+    'shield barrier',
+    'shield def. bonus',
+    'shield mastery',
+    'skillchain bonus',
+    'smite',
+    'stalwart soul',
+    'tactical guard',
+    'tactical parry',
+    'tandem blow',
+    'tandem strike',
     'tenacity',
-    'magic def. bonus'
+    'tranquil heart',
+    'vermin killer',
+    'ws damage boost'
 );


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Abilities.lua
- Further reduces the power of Conspirator, Marcato and Hagakure.
- Increases the duration of Azure Lore by 15 seconds
- Reverts the duration of Overdrive to Era.

TraitsAndJAs.sql
- Scaled back the power of certain traits.
- Adjusted the content tags with more entries being restored to their original content tag. Most OOE traits are available immediately. OOE JAs were assigned more progression focused gates.
- Tweaked access to be more conservative.
- Removed Konzen-ittai. SAM has enough efficiency and identity without it.

## Steps to test these changes


