### PR TITLE
lastResortRebalance

### DIFF
--- a/modules/zenith-public/lua/4-additive/jobAbilities/lastResortRebalance.lua
+++ b/modules/zenith-public/lua/4-additive/jobAbilities/lastResortRebalance.lua
@@ -1,0 +1,44 @@
+-----------------------------------
+-- Last Resort Rebalance
+-- Reduces Last Resort potency to +15% Attack / -15% Defense (base, before merits)
+-- and shortens its duration to 60 seconds. Merit scaling, DRK job-point flat
+-- attack, and Desperate Blows ability haste are preserved.
+-- Custom modifications for ZenithXI
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('a-j_last_resort_rebal')
+
+-----------------------------------
+-- Shorten duration: 180s -> 60s
+-- (full replacement of the trivial base useLastResort -- smallest targeted change)
+-----------------------------------
+m:addOverride('xi.job_utils.dark_knight.useLastResort', function(player, target, ability)
+    player:addStatusEffect(xi.effect.LAST_RESORT, { duration = 60, origin = player })
+
+    return xi.effect.LAST_RESORT
+end)
+
+-----------------------------------
+-- Reduce potency: ATTP/RATTP 25 -> 15, DEFP -25 -> -15 (merit scaling retained).
+-- Job-point flat attack and Desperate Blows haste are re-applied unchanged, since
+-- a full onEffectGain replacement must re-add every mod it wants to keep.
+-----------------------------------
+m:addOverride('xi.effects.last_resort.onEffectGain', function(target, effect)
+    local targetMerit     = target:getMerit(xi.merit.LAST_RESORT_EFFECT)
+    local targetJobPoints = target:getJobPointLevel(xi.jp.LAST_RESORT_EFFECT)
+
+    -- Job point effect (unchanged)
+    effect:addMod(xi.mod.ATT, 2 * targetJobPoints)
+    effect:addMod(xi.mod.RATT, 2 * targetJobPoints)
+
+    -- Reduced potency (base 15, still +1% per Last Resort Effect merit level)
+    effect:addMod(xi.mod.ATTP, 15 + targetMerit)
+    effect:addMod(xi.mod.RATTP, 15 + targetMerit)
+    effect:addMod(xi.mod.DEFP, -15 - targetMerit)
+
+    -- Desperate Blows ability haste (unchanged)
+    effect:addMod(xi.mod.TWOHAND_HASTE_ABILITY, target:getMod(xi.mod.DESPERATE_BLOWS) + target:getMerit(xi.merit.DESPERATE_BLOWS))
+end)
+
+return m

--- a/modules/zenith-public/lua/4-additive/jobAbilities/lastResortRebalance.lua
+++ b/modules/zenith-public/lua/4-additive/jobAbilities/lastResortRebalance.lua
@@ -11,7 +11,7 @@ local m = Module:new('a-j_last_resort_rebal')
 
 -----------------------------------
 -- Shorten duration: 180s -> 60s
--- (full replacement of the trivial base useLastResort -- smallest targeted change)
+-- (75 Era duration: 30 seconds)
 -----------------------------------
 m:addOverride('xi.job_utils.dark_knight.useLastResort', function(player, target, ability)
     player:addStatusEffect(xi.effect.LAST_RESORT, { duration = 60, origin = player })

--- a/modules/zenith-public/lua/4-additive/jobAbilities/lastResortRebalance.lua
+++ b/modules/zenith-public/lua/4-additive/jobAbilities/lastResortRebalance.lua
@@ -32,7 +32,7 @@ m:addOverride('xi.effects.last_resort.onEffectGain', function(target, effect)
     effect:addMod(xi.mod.ATT, 2 * targetJobPoints)
     effect:addMod(xi.mod.RATT, 2 * targetJobPoints)
 
-    -- Reduced potency (base 15, still +1% per Last Resort Effect merit level)
+    -- Reduced potency (base 15, still +2% Atk -2% Def per Last Resort Effect merit level)
     effect:addMod(xi.mod.ATTP, 15 + targetMerit)
     effect:addMod(xi.mod.RATTP, 15 + targetMerit)
     effect:addMod(xi.mod.DEFP, -15 - targetMerit)

--- a/modules/zenith-public/lua/4-additive/jobAbilities/lastResortRebalance.lua
+++ b/modules/zenith-public/lua/4-additive/jobAbilities/lastResortRebalance.lua
@@ -21,7 +21,7 @@ end)
 
 -----------------------------------
 -- Reduce potency: ATTP/RATTP 25 -> 15, DEFP -25 -> -15 (merit scaling retained).
--- Job-point flat attack and Desperate Blows haste are re-applied unchanged, since
+-- Job-point flat attack and Desperate Blows haste are re-applied unchanged. Job points aren't utilized on Zenith.
 -- a full onEffectGain replacement must re-add every mod it wants to keep.
 -----------------------------------
 m:addOverride('xi.effects.last_resort.onEffectGain', function(target, effect)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- New module `modules/zenith-public/lua/4-additive/jobAbilities/lastResortRebalance.lua` nerfs the Dark Knight ability **Last Resort**.
- **Potency** override (`xi.effects.last_resort.onEffectGain`): Attack%/Ranged-Attack% base **25 → 15**, Defense% base **−25 → −15**. Merit scaling (`+1%`/`−1%` per *Last Resort Effect* merit level) is retained.
- **Duration** override (`xi.job_utils.dark_knight.useLastResort`): **180s → 60s**.
- Preserved unchanged: DRK job-point flat attack (`+2 ATT/RATT` per JP level) and Desperate Blows ability haste (`TWOHAND_HASTE_ABILITY` from the `DESPERATE_BLOWS` mod + merit).
- Affected systems: status-effect potency (`ATTP`/`RATTP`/`DEFP` mods) and status-effect duration for one DRK job ability. All logic is Lua — no C++ change.


## Steps to test these changes

**Steps**"
Test 1:

1. `/ja "Last Resort" <me>` — use the ability on yourself.
2. `!geteffects`

**Expected**: The list contains `LAST_RESORT (64)` with `Time: 60s` (may read `59s` if a moment has passed). It must **not** show `3m 0s` / `180s`. The buff-icon countdown in the client should likewise start at ~1:00.

Test 2
**Goal**: Confirm ATTP/RATTP = +15 and DEFP = −15 at 0 merits (verifies the `onEffectGain` potency override).

**Commands** (baseline, before using the ability):
```
!reset
!deleffect LAST_RESORT   -- clear any lingering Last Resort so baselines read clean
!getmod ATTP     -- baseline Attack% (0 with no ATTP gear/food)
!getmod RATTP    -- baseline Ranged Attack%
!getmod DEFP     -- baseline Defense%
```

**Steps**:
1. `/ja "Last Resort" <me>`
2. Re-read the mods while the effect is active:
```
!getmod ATTP
!getmod RATTP
!getmod DEFP
```