### PR TITLE
pdifWeaponCaps

### DIFF
--- a/modules/zenith-public/lua/2-base/pdif_weapon_caps.lua
+++ b/modules/zenith-public/lua/2-base/pdif_weapon_caps.lua
@@ -1,0 +1,34 @@
+-----------------------------------
+-- Custom pDIF weapon caps
+-- Overrides xi.combat.physical.pDifWeaponCapTable (PC melee/ranged pDIF caps):
+--   1H melee = 2.0, 2H melee = 2.25, ranged & automaton = 3.0
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('b_pdif_weapon_caps')
+
+-- Data-only module: dummy override so the loader does not report
+-- "No overrides found" (enforced in src/map/utils/moduleutils.cpp).
+m:addOverride('xi.dummyFunc', function()
+end)
+
+xi.combat.physical.pDifWeaponCapTable[xi.skill.HAND_TO_HAND    ] = 2
+xi.combat.physical.pDifWeaponCapTable[xi.skill.DAGGER          ] = 2
+xi.combat.physical.pDifWeaponCapTable[xi.skill.SWORD           ] = 2
+xi.combat.physical.pDifWeaponCapTable[xi.skill.GREAT_SWORD     ] = 2.25
+xi.combat.physical.pDifWeaponCapTable[xi.skill.AXE             ] = 2
+xi.combat.physical.pDifWeaponCapTable[xi.skill.GREAT_AXE       ] = 2.25
+xi.combat.physical.pDifWeaponCapTable[xi.skill.SCYTHE          ] = 2.25
+xi.combat.physical.pDifWeaponCapTable[xi.skill.POLEARM         ] = 2.25
+xi.combat.physical.pDifWeaponCapTable[xi.skill.KATANA          ] = 2
+xi.combat.physical.pDifWeaponCapTable[xi.skill.GREAT_KATANA    ] = 2.25
+xi.combat.physical.pDifWeaponCapTable[xi.skill.CLUB            ] = 2
+xi.combat.physical.pDifWeaponCapTable[xi.skill.STAFF           ] = 2.25
+xi.combat.physical.pDifWeaponCapTable[xi.skill.AUTOMATON_MELEE ] = 3
+xi.combat.physical.pDifWeaponCapTable[xi.skill.AUTOMATON_RANGED] = 3
+xi.combat.physical.pDifWeaponCapTable[xi.skill.AUTOMATON_MAGIC ] = 3
+xi.combat.physical.pDifWeaponCapTable[xi.skill.ARCHERY         ] = 3
+xi.combat.physical.pDifWeaponCapTable[xi.skill.MARKSMANSHIP    ] = 3
+xi.combat.physical.pDifWeaponCapTable[xi.skill.THROWING        ] = 3
+
+return m

--- a/modules/zenith-public/lua/2-base/pdif_weapon_caps.lua
+++ b/modules/zenith-public/lua/2-base/pdif_weapon_caps.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Custom pDIF weapon caps
+-- Post August 2007 pDIF weapon caps
 -- Overrides xi.combat.physical.pDifWeaponCapTable (PC melee/ranged pDIF caps):
---   1H melee = 2.0, 2H melee = 2.25, ranged & automaton = 3.0
+--   1H melee = 2.0, 2H melee = 2.25, ranged 3.0. Automaton are included for completeness, not active behavior.
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds modules/zenith-public/lua/2-base/pdif_weapon_caps.lua, which overrides
xi.combat.physical.pDifWeaponCapTable to set player physical-damage-ratio
(pDIF) caps to: 1H melee = 2.0, 2H melee = 2.25, ranged = 3.0 (automaton
entries left at 3.0). This lowers the max-hit ceiling versus the LSB defaults and
compresses the 1H-vs-2H gap.

## Steps to test these changes

## **Functional: 1H melee cap (Sword → 2.0)**

**Setup**

```
!changejob WAR 99          -- level 99 main job
!capskill SWORD            -- cap sword skill (or: !capallskills)
!additem Xiphos            -- any Sword; equip it via inventory
```

Spawn a weak, low-DEF target and lower its level so the player's cRatio is high\
enough that the **pDIF cap is the binding constraint** (otherwise cRatio caps\
below 2.0 and you won't see the change):

```
!spawnmob <mobID>          -- pick any nearby test mob's ID
!setmoblevel <mobID> 1     -- force very low DEF / high cRatio
```

**Steps**

1. Equip the Sword, engage the low-level target, land several normal (non-crit)\
   hits.

2. Note the **maximum** non-crit hit value over ~15–20 swings.

**Expected**

* Max non-crit hit is bounded by the new 2.0 pDIF cap — visibly lower than on a\
  build without this module (where Sword capped at 3.25). Crits add +1 to the cap\
  (per the `isCritical` term), so ignore crits when reading the ceiling.


More detailed testing added to related plane ticket.
